### PR TITLE
fix: improves agent detection and troubleshooting UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,33 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu x86_64 (Intel/AMD)
+          - os: ubuntu-latest
+            name: Ubuntu x86_64
+          # Ubuntu ARM64
+          - os: ubuntu-24.04-arm
+            name: Ubuntu ARM64
+          # macOS ARM64 (Apple Silicon)
+          - os: macos-15
+            name: macOS ARM64
+          # macOS x86_64 (Intel) - macos-13 retired, use macos-15-intel
+          - os: macos-15-intel
+            name: macOS x86_64
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@example.com"
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/src/kagan/__main__.py
+++ b/src/kagan/__main__.py
@@ -87,47 +87,47 @@ def tui(db: str, config: str, skip_preflight: bool, skip_update_check: bool) -> 
 
     # Run pre-flight checks unless skipped
     if not skip_preflight:
-        from kagan.config import KaganConfig
-        from kagan.data.builtin_agents import get_builtin_agent
+        from kagan.data.builtin_agents import (
+            any_agent_available,
+            get_first_available_agent,
+        )
         from kagan.ui.screens.troubleshooting import (
             ISSUE_PRESETS,
             DetectedIssue,
             IssueType,
             TroubleshootingApp,
+            create_no_agents_issues,
             detect_issues,
         )
 
-        # Determine agent to check (read config early if exists)
-        agent_name = "Claude Code"
-        agent_install = "curl -fsSL https://claude.ai/install.sh | bash"
-        agent_config = None
-
-        if config_path.exists():
-            cfg = KaganConfig.load(config_path)
-            agent_key = cfg.general.default_worker_agent
-            agent_config = cfg.get_agent(agent_key)
-            if builtin := get_builtin_agent(agent_key):
-                agent_name = builtin.config.name
-                agent_install = builtin.install_command
-                agent_config = builtin.config
-        else:
-            # Use default Claude agent config for first boot
-            builtin = get_builtin_agent("claude")
-            if builtin:
-                agent_config = builtin.config
-
-        # Run pre-flight checks (except lock - we'll check that separately)
-        result = detect_issues(
-            check_lock=False,
-            agent_config=agent_config,
-            agent_name=agent_name,
-            agent_install_command=agent_install,
-        )
-
-        if result.has_blocking_issues:
-            app = TroubleshootingApp(result.issues)
+        # First check: Are ANY agents available?
+        if not any_agent_available():
+            # No agents available - show installation options for all supported agents
+            issues = create_no_agents_issues()
+            app = TroubleshootingApp(issues)
             app.run()
             sys.exit(1)
+
+        # At least one agent is available - use the first available one for pre-flight
+        # The user can select a different agent in the welcome screen later
+        best_agent = get_first_available_agent()
+        if best_agent:
+            agent_name = best_agent.config.name
+            agent_install = best_agent.install_command
+            agent_config = best_agent.config
+
+            # Run pre-flight checks (except lock - we'll check that separately)
+            result = detect_issues(
+                check_lock=False,
+                agent_config=agent_config,
+                agent_name=agent_name,
+                agent_install_command=agent_install,
+            )
+
+            if result.has_blocking_issues:
+                app = TroubleshootingApp(result.issues)
+                app.run()
+                sys.exit(1)
 
     # Import here to avoid slow startup for --help/--version
     from kagan.lock import InstanceLock, InstanceLockError

--- a/src/kagan/app.py
+++ b/src/kagan/app.py
@@ -98,9 +98,9 @@ class KaganApp(App):
         self.log.debug("Config settings", auto_start=self.config.general.auto_start)
 
         project_root = self.config_path.parent.parent
-        if not has_git_repo(project_root):
+        if not await has_git_repo(project_root):
             base_branch = self.config.general.default_base_branch
-            if init_git_repo(project_root, base_branch):
+            if await init_git_repo(project_root, base_branch):
                 self.log("Initialized git repository", base_branch=base_branch)
             else:
                 self.log.warning("Failed to initialize git repository", path=str(project_root))

--- a/src/kagan/data/builtin_agents.py
+++ b/src/kagan/data/builtin_agents.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import shlex
+import shutil
 from dataclasses import dataclass
 
-from kagan.config import AgentConfig
+from kagan.config import AgentConfig, get_os_value
 
 
 @dataclass
@@ -15,8 +17,33 @@ class BuiltinAgent:
     author: str
     description: str
     install_command: str
+    docs_url: str = ""  # Documentation URL for troubleshooting
     mcp_config_file: str = ".mcp.json"  # Filename for MCP config
     mcp_config_format: str = "claude"  # Format: "claude" | "opencode"
+
+
+@dataclass
+class AgentAvailability:
+    """Availability status for an agent."""
+
+    agent: BuiltinAgent
+    interactive_available: bool = False  # CLI available for PAIR mode
+    acp_available: bool = False  # ACP command available for AUTO mode
+
+    @property
+    def is_available(self) -> bool:
+        """Check if agent is available in any mode."""
+        return self.interactive_available or self.acp_available
+
+    @property
+    def install_hint(self) -> str:
+        """Get one-liner install instruction."""
+        return self.agent.install_command
+
+    @property
+    def docs_url(self) -> str:
+        """Get documentation URL."""
+        return self.agent.docs_url
 
 
 # Built-in agents that ship with Kagan
@@ -27,6 +54,10 @@ class BuiltinAgent:
 # MCP config formats:
 # - claude: Uses .mcp.json with {"mcpServers": {"name": {"command": ..., "args": [...]}}}
 # - opencode: Uses opencode.json with {"mcp": {"name": {"type": "local", "command": [...]}}}
+
+# Agent priority order for auto-selection (first available wins)
+AGENT_PRIORITY = ["claude", "opencode"]
+
 BUILTIN_AGENTS: dict[str, BuiltinAgent] = {
     "claude": BuiltinAgent(
         config=AgentConfig(
@@ -40,6 +71,7 @@ BUILTIN_AGENTS: dict[str, BuiltinAgent] = {
         author="Anthropic",
         description="Agentic AI for coding tasks",
         install_command="curl -fsSL https://claude.ai/install.sh | bash",
+        docs_url="https://docs.anthropic.com/en/docs/claude-code",
         mcp_config_file=".mcp.json",
         mcp_config_format="claude",
     ),
@@ -55,6 +87,7 @@ BUILTIN_AGENTS: dict[str, BuiltinAgent] = {
         author="SST",
         description="Multi-model CLI with TUI",
         install_command="npm i -g opencode-ai",
+        docs_url="https://opencode.ai/docs",
         mcp_config_file="opencode.json",
         mcp_config_format="opencode",
     ),
@@ -80,3 +113,92 @@ def list_builtin_agents() -> list[BuiltinAgent]:
         A list of all BuiltinAgent objects.
     """
     return list(BUILTIN_AGENTS.values())
+
+
+def _check_command_available(command: str | None) -> bool:
+    """Check if a command's executable is available in PATH.
+
+    Handles both simple commands ('claude') and complex commands
+    ('npx claude-code-acp', 'opencode acp').
+
+    For npx commands, checks if either npx or the package binary is available.
+    """
+    if not command:
+        return False
+
+    try:
+        parts = shlex.split(command)
+        executable = parts[0] if parts else command
+    except ValueError:
+        # If parsing fails, treat the whole command as executable
+        return shutil.which(command) is not None
+
+    # Handle npx commands specially
+    # For availability checking, we require the binary to be globally installed
+    # Just having npx is not sufficient - the package must be installed
+    if executable == "npx" and len(parts) > 1:
+        package = parts[1]
+        # Check if package is globally installed (for scoped packages like @org/pkg)
+        binary = package.split("/")[-1] if "/" in package else package
+        # Only consider available if the binary is globally installed
+        # npx can run packages on demand, but we can't verify that without running it
+        return shutil.which(binary) is not None
+
+    return shutil.which(executable) is not None
+
+
+def check_agent_availability(agent: BuiltinAgent) -> AgentAvailability:
+    """Check if an agent's commands are available in PATH.
+
+    Args:
+        agent: The BuiltinAgent to check.
+
+    Returns:
+        AgentAvailability with status for both interactive and ACP modes.
+    """
+    interactive_cmd = get_os_value(agent.config.interactive_command)
+    acp_cmd = get_os_value(agent.config.run_command)
+
+    return AgentAvailability(
+        agent=agent,
+        interactive_available=_check_command_available(interactive_cmd),
+        acp_available=_check_command_available(acp_cmd),
+    )
+
+
+def get_all_agent_availability() -> list[AgentAvailability]:
+    """Get availability status for all built-in agents.
+
+    Returns agents in priority order (claude first, then opencode).
+
+    Returns:
+        List of AgentAvailability for all agents in priority order.
+    """
+    result = []
+    for key in AGENT_PRIORITY:
+        if agent := BUILTIN_AGENTS.get(key):
+            result.append(check_agent_availability(agent))
+    return result
+
+
+def get_first_available_agent() -> BuiltinAgent | None:
+    """Get the first available agent based on priority.
+
+    Priority: claude > opencode
+
+    Returns:
+        The first available BuiltinAgent, or None if none available.
+    """
+    for availability in get_all_agent_availability():
+        if availability.is_available:
+            return availability.agent
+    return None
+
+
+def any_agent_available() -> bool:
+    """Check if any agent is available.
+
+    Returns:
+        True if at least one agent is available.
+    """
+    return any(a.is_available for a in get_all_agent_availability())

--- a/src/kagan/git_utils.py
+++ b/src/kagan/git_utils.py
@@ -6,10 +6,127 @@ All functions are async to avoid blocking the event loop during subprocess calls
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+import re
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 - Used at runtime in _ensure_gitignored
 
-if TYPE_CHECKING:
-    from pathlib import Path
+# Minimum git version required for worktree support
+# git worktree was introduced in Git 2.5 (July 2015)
+MIN_GIT_VERSION = (2, 5, 0)
+
+
+@dataclass
+class GitVersion:
+    """Parsed git version information."""
+
+    major: int
+    minor: int
+    patch: int
+    raw: str
+
+    def __ge__(self, other: tuple[int, int, int]) -> bool:
+        return (self.major, self.minor, self.patch) >= other
+
+    def __lt__(self, other: tuple[int, int, int]) -> bool:
+        return (self.major, self.minor, self.patch) < other
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass
+class GitError:
+    """Describes a git operation failure."""
+
+    error_type: str  # "version_low", "user_not_configured", "init_failed", "commit_failed"
+    message: str
+    details: str | None = None
+
+
+@dataclass
+class GitInitResult:
+    """Result of git repository initialization."""
+
+    success: bool
+    error: GitError | None = None
+    gitignore_created: bool = False
+    gitignore_updated: bool = False
+    committed: bool = False
+
+
+async def get_git_version() -> GitVersion | None:
+    """Get the installed git version.
+
+    Returns None if git is not installed or version cannot be determined.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return None
+
+        # Parse "git version X.Y.Z" or "git version X.Y.Z.windows.N" etc.
+        raw = stdout.decode().strip()
+        match = re.search(r"(\d+)\.(\d+)\.(\d+)", raw)
+        if not match:
+            return None
+
+        return GitVersion(
+            major=int(match.group(1)),
+            minor=int(match.group(2)),
+            patch=int(match.group(3)),
+            raw=raw,
+        )
+    except FileNotFoundError:
+        return None
+
+
+async def check_git_user_configured() -> tuple[bool, str | None]:
+    """Check if git user.name and user.email are configured.
+
+    Returns (True, None) if configured, (False, error_message) otherwise.
+    """
+    try:
+        # Check user.name
+        proc_name = await asyncio.create_subprocess_exec(
+            "git",
+            "config",
+            "--get",
+            "user.name",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_name, _ = await proc_name.communicate()
+
+        # Check user.email
+        proc_email = await asyncio.create_subprocess_exec(
+            "git",
+            "config",
+            "--get",
+            "user.email",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_email, _ = await proc_email.communicate()
+
+        name_set = proc_name.returncode == 0 and stdout_name.decode().strip()
+        email_set = proc_email.returncode == 0 and stdout_email.decode().strip()
+
+        if not name_set and not email_set:
+            return False, "Git user.name and user.email are not configured"
+        if not name_set:
+            return False, "Git user.name is not configured"
+        if not email_set:
+            return False, "Git user.email is not configured"
+
+        return True, None
+    except FileNotFoundError:
+        return False, "Git is not installed"
 
 
 async def has_git_repo(repo_root: Path) -> bool:
@@ -75,15 +192,68 @@ async def get_current_branch(repo_root: Path) -> str:
         return ""
 
 
-async def init_git_repo(repo_root: Path, base_branch: str) -> bool:
+async def has_commits(repo_root: Path) -> bool:
+    """Return True if the git repo has at least one commit."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "rev-parse",
+            "HEAD",
+            cwd=repo_root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        return proc.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def _ensure_gitignored(repo_root: Path) -> tuple[bool, bool]:
+    """Add .kagan/ to .gitignore if not already present.
+
+    Returns (created, updated) tuple:
+    - created: True if .gitignore was created from scratch
+    - updated: True if .gitignore was modified (appended to)
+    """
+    gitignore = repo_root / ".gitignore"
+    kagan_entry = ".kagan/"
+
+    if gitignore.exists():
+        content = gitignore.read_text()
+        lines = content.split("\n")
+        # Check if already ignored (with or without trailing slash)
+        if ".kagan" in lines or ".kagan/" in lines:
+            return False, False
+        # Append to existing file
+        if not content.endswith("\n"):
+            content += "\n"
+        content += "\n# Kagan local state\n.kagan/\n"
+        gitignore.write_text(content)
+        return False, True
+    else:
+        # Create new .gitignore
+        gitignore.write_text(f"# Kagan local state\n{kagan_entry}\n")
+        return True, False
+
+
+async def init_git_repo(repo_root: Path, base_branch: str) -> GitInitResult:
     """Initialize a git repo with the requested base branch and initial commit.
+
+    Handles four scenarios:
+    1. Empty folder, no git repo: Create .gitignore with .kagan/, init repo, commit
+    2. Existing git repo with commits and .gitignore: Append .kagan/ if needed, commit
+    3. Existing git repo with commits but no .gitignore: Create .gitignore, commit
+    4. Existing git repo with NO commits: Add .gitignore, create initial commit
 
     Creates an initial commit so that worktrees can be created from the base branch.
     Without a commit, `git worktree add -b <branch> <path> <base>` fails with
     'fatal: invalid reference: <base>'.
+
+    Returns GitInitResult with success status and any errors.
     """
 
-    async def run_git(*args: str) -> tuple[int, str]:
+    async def run_git(*args: str) -> tuple[int, str, str]:
         try:
             proc = await asyncio.create_subprocess_exec(
                 "git",
@@ -92,32 +262,141 @@ async def init_git_repo(repo_root: Path, base_branch: str) -> bool:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await proc.communicate()
+            stdout, stderr = await proc.communicate()
             returncode = proc.returncode if proc.returncode is not None else 1
-            return returncode, stdout.decode()
+            return returncode, stdout.decode(), stderr.decode()
         except FileNotFoundError:
-            return 1, ""
+            return 1, "", "Git is not installed"
 
-    # Try init with -b flag first
-    code, _ = await run_git("init", "-b", base_branch)
-    if code != 0:
-        # Fallback for older git versions without -b support
-        code, _ = await run_git("init")
+    # Check git version first
+    version = await get_git_version()
+    if version is None:
+        return GitInitResult(
+            success=False,
+            error=GitError(
+                error_type="version_low",
+                message="Git is not installed",
+                details="Please install Git to use Kagan",
+            ),
+        )
+
+    if version < MIN_GIT_VERSION:
+        min_ver = f"{MIN_GIT_VERSION[0]}.{MIN_GIT_VERSION[1]}"
+        return GitInitResult(
+            success=False,
+            error=GitError(
+                error_type="version_low",
+                message=f"Git version {version} is too old",
+                details=f"Kagan requires Git {min_ver}+ for worktree support",
+            ),
+        )
+
+    # Check if git user is configured (needed for commits)
+    user_configured, user_error = await check_git_user_configured()
+    if not user_configured:
+        return GitInitResult(
+            success=False,
+            error=GitError(
+                error_type="user_not_configured",
+                message="Git user not configured",
+                details=user_error,
+            ),
+        )
+
+    # Determine if we have an existing repo and if it has commits
+    has_repo = await has_git_repo(repo_root)
+    repo_has_commits = has_repo and await has_commits(repo_root)
+
+    # Ensure .gitignore has .kagan/ entry
+    gitignore_created, gitignore_updated = _ensure_gitignored(repo_root)
+
+    # If repo exists with commits and .gitignore wasn't modified, nothing to do
+    if repo_has_commits and not gitignore_created and not gitignore_updated:
+        return GitInitResult(
+            success=True,
+            gitignore_created=False,
+            gitignore_updated=False,
+            committed=False,
+        )
+
+    if not has_repo:
+        # Scenario 1 or 3: No git repo exists, initialize one
+        # Try init with -b flag first
+        code, _, stderr = await run_git("init", "-b", base_branch)
         if code != 0:
-            return False
-        code, _ = await run_git("branch", "-M", base_branch)
-        if code != 0:
-            return False
+            # Fallback for older git versions without -b support
+            code, _, stderr = await run_git("init")
+            if code != 0:
+                return GitInitResult(
+                    success=False,
+                    error=GitError(
+                        error_type="init_failed",
+                        message="Failed to initialize git repository",
+                        details=stderr.strip() if stderr else None,
+                    ),
+                    gitignore_created=gitignore_created,
+                    gitignore_updated=gitignore_updated,
+                )
+            code, _, stderr = await run_git("branch", "-M", base_branch)
+            if code != 0:
+                return GitInitResult(
+                    success=False,
+                    error=GitError(
+                        error_type="init_failed",
+                        message="Failed to rename branch",
+                        details=stderr.strip() if stderr else None,
+                    ),
+                    gitignore_created=gitignore_created,
+                    gitignore_updated=gitignore_updated,
+                )
 
-    # Create initial commit so worktrees can be created
-    # Without a commit, the base branch doesn't exist as a valid reference
-    gitkeep = repo_root / ".gitkeep"
-    if not gitkeep.exists():
-        gitkeep.write_text("")
-
-    code, _ = await run_git("add", ".gitkeep")
+    # Stage .gitignore (it always exists at this point)
+    code, _, stderr = await run_git("add", ".gitignore")
     if code != 0:
-        return False
+        return GitInitResult(
+            success=False,
+            error=GitError(
+                error_type="commit_failed",
+                message="Failed to stage .gitignore",
+                details=stderr.strip() if stderr else None,
+            ),
+            gitignore_created=gitignore_created,
+            gitignore_updated=gitignore_updated,
+        )
 
-    code, _ = await run_git("commit", "-m", "Initial commit (kagan)")
-    return code == 0
+    # Commit the changes
+    # Scenario 4: repo exists but has no commits - treat as initial commit
+    if not has_repo or not repo_has_commits:
+        commit_msg = "Initial commit (kagan)"
+    elif gitignore_created:
+        commit_msg = "Add .gitignore with kagan exclusion"
+    else:
+        commit_msg = "Add kagan to .gitignore"
+
+    code, _, stderr = await run_git("commit", "-m", commit_msg)
+    if code != 0:
+        # Check if it's just "nothing to commit" (gitignore already committed)
+        if "nothing to commit" in stderr or "nothing added to commit" in stderr:
+            return GitInitResult(
+                success=True,
+                gitignore_created=gitignore_created,
+                gitignore_updated=gitignore_updated,
+                committed=False,
+            )
+        return GitInitResult(
+            success=False,
+            error=GitError(
+                error_type="commit_failed",
+                message="Failed to commit .gitignore",
+                details=stderr.strip() if stderr else None,
+            ),
+            gitignore_created=gitignore_created,
+            gitignore_updated=gitignore_updated,
+        )
+
+    return GitInitResult(
+        success=True,
+        gitignore_created=gitignore_created,
+        gitignore_updated=gitignore_updated,
+        committed=True,
+    )

--- a/src/kagan/styles/kagan.tcss
+++ b/src/kagan/styles/kagan.tcss
@@ -229,25 +229,9 @@ TicketCard.agent-active:focus {
     border: solid $secondary;
 }
 
-/* Pulse state A - bright/highlighted (toggle ON) */
-TicketCard.agent-pulse {
-    border: solid $warning;
-    background: $panel;
-}
-
-TicketCard.agent-pulse:focus {
-    border: solid $warning;
-    background: $panel;
-}
-
-/* Combined: session + agent active - agent pulse takes precedence */
+/* Combined: session + agent active - agent style takes precedence */
 TicketCard.session-active.agent-active {
     border: solid $secondary;
-}
-
-TicketCard.session-active.agent-pulse {
-    border: solid $warning;
-    background: $panel;
 }
 
 /* ============================================

--- a/src/kagan/styles/kagan.tcss
+++ b/src/kagan/styles/kagan.tcss
@@ -1107,30 +1107,35 @@ WelcomeScreen {
     background: $background;
     margin-bottom: 1;
     padding: 1;
+    height: auto;
 }
 
 .issue-card-title {
     text-style: bold;
     color: $warning;
     width: 100%;
+    height: auto;
 }
 
 .issue-card-message {
-    color: $text;
+    color: $foreground;
     width: 100%;
+    height: auto;
     padding-top: 1;
 }
 
 .issue-card-hint {
-    color: $text-muted;
+    color: $foreground 70%;
     text-style: italic;
     width: 100%;
+    height: auto;
     padding-top: 1;
 }
 
 .issue-card-url {
     color: $primary;
     width: 100%;
+    height: auto;
 }
 
 #troubleshoot-resolve-hint {

--- a/src/kagan/styles/kagan.tcss
+++ b/src/kagan/styles/kagan.tcss
@@ -1492,6 +1492,7 @@ SearchBar Input:focus {
    ============================================================================= */
 
 /* Leader mode hint overlay - layer ensures it appears above footer */
+/* Uses offset-y instead of display toggle to avoid layout recalculation */
 .leader-hint {
     dock: bottom;
     width: 100%;
@@ -1500,13 +1501,13 @@ SearchBar Input:focus {
     color: $background;
     text-align: center;
     text-style: bold;
-    display: none;
     layer: overlay;
     padding: 0 1;
+    offset-y: 100%;
 }
 
 .leader-hint.visible {
-    display: block;
+    offset-y: 0;
 }
 
 /* =============================================================================

--- a/src/kagan/ui/screens/troubleshooting.py
+++ b/src/kagan/ui/screens/troubleshooting.py
@@ -35,6 +35,9 @@ class IssueType(Enum):
     NPX_MISSING = "npx_missing"
     ACP_AGENT_MISSING = "acp_agent_missing"
     NO_AGENTS_AVAILABLE = "no_agents_available"  # No supported agents installed
+    GIT_VERSION_LOW = "git_version_low"  # Git version too old for worktrees
+    GIT_USER_NOT_CONFIGURED = "git_user_not_configured"  # Git user.name/email not set
+    GIT_NOT_INSTALLED = "git_not_installed"  # Git is not installed
 
 
 class IssueSeverity(Enum):
@@ -127,6 +130,44 @@ ISSUE_PRESETS: dict[IssueType, IssuePreset] = {
             "Neither npx nor a global installation is available."
         ),
         hint="Install the agent globally or ensure npx is available",
+    ),
+    IssueType.GIT_NOT_INSTALLED: IssuePreset(
+        type=IssueType.GIT_NOT_INSTALLED,
+        severity=IssueSeverity.BLOCKING,
+        icon="[!]",
+        title="Git Not Installed",
+        message=(
+            "Git is required but was not found on your system.\n"
+            "Kagan uses git worktrees for isolated development environments."
+        ),
+        hint="Install Git: brew install git (macOS) or apt install git (Linux)",
+        url="https://git-scm.com/downloads",
+    ),
+    IssueType.GIT_VERSION_LOW: IssuePreset(
+        type=IssueType.GIT_VERSION_LOW,
+        severity=IssueSeverity.BLOCKING,
+        icon="[!]",
+        title="Git Version Too Old",
+        message=(
+            "Your Git version does not support worktrees.\n"
+            "Kagan requires Git 2.5 or later for worktree functionality."
+        ),
+        hint="Upgrade Git: brew upgrade git (macOS) or apt update && apt upgrade git (Linux)",
+        url="https://git-scm.com/downloads",
+    ),
+    IssueType.GIT_USER_NOT_CONFIGURED: IssuePreset(
+        type=IssueType.GIT_USER_NOT_CONFIGURED,
+        severity=IssueSeverity.BLOCKING,
+        icon="[!]",
+        title="Git User Not Configured",
+        message=(
+            "Git user identity is not configured.\nKagan needs to make commits to track changes."
+        ),
+        hint=(
+            "Run:\n"
+            '  git config --global user.name "Your Name"\n'
+            '  git config --global user.email "your@email.com"'
+        ),
     ),
 }
 
@@ -352,13 +393,66 @@ def _check_agent(
     return None
 
 
-def detect_issues(
+async def _check_git_version() -> DetectedIssue | None:
+    """Check if git is installed and version supports worktrees."""
+    from kagan.git_utils import MIN_GIT_VERSION, get_git_version
+
+    version = await get_git_version()
+    if version is None:
+        return DetectedIssue(preset=ISSUE_PRESETS[IssueType.GIT_NOT_INSTALLED])
+
+    if version < MIN_GIT_VERSION:
+        # Create a customized preset with version details
+        preset = IssuePreset(
+            type=IssueType.GIT_VERSION_LOW,
+            severity=IssueSeverity.BLOCKING,
+            icon="[!]",
+            title="Git Version Too Old",
+            message=(
+                f"Your Git version ({version}) does not support worktrees.\n"
+                f"Kagan requires Git {MIN_GIT_VERSION[0]}.{MIN_GIT_VERSION[1]}+ "
+                "for worktree functionality."
+            ),
+            hint="Upgrade Git: brew upgrade git (macOS) or apt update && apt upgrade git (Linux)",
+            url="https://git-scm.com/downloads",
+        )
+        return DetectedIssue(preset=preset, details=str(version))
+
+    return None
+
+
+async def _check_git_user() -> DetectedIssue | None:
+    """Check if git user.name and user.email are configured."""
+    from kagan.git_utils import check_git_user_configured
+
+    is_configured, error_msg = await check_git_user_configured()
+    if not is_configured:
+        # Create a customized preset with specific error
+        preset = IssuePreset(
+            type=IssueType.GIT_USER_NOT_CONFIGURED,
+            severity=IssueSeverity.BLOCKING,
+            icon="[!]",
+            title="Git User Not Configured",
+            message=(f"{error_msg}\nKagan needs to make commits to track changes."),
+            hint=(
+                "Run:\n"
+                '  git config --global user.name "Your Name"\n'
+                '  git config --global user.email "your@email.com"'
+            ),
+        )
+        return DetectedIssue(preset=preset, details=error_msg)
+
+    return None
+
+
+async def detect_issues(
     *,
     check_lock: bool = False,
     lock_acquired: bool = True,
     agent_config: AgentConfig | None = None,
     agent_name: str = "Claude Code",
     agent_install_command: str | None = None,
+    check_git: bool = True,
 ) -> PreflightResult:
     """Run all pre-flight checks and return detected issues.
 
@@ -368,6 +462,7 @@ def detect_issues(
         agent_config: Optional agent configuration to check.
         agent_name: Display name of the agent to check.
         agent_install_command: Installation command for the agent.
+        check_git: Whether to check git version and configuration.
 
     Returns:
         PreflightResult containing all detected issues.
@@ -383,12 +478,23 @@ def detect_issues(
     if check_lock and not lock_acquired:
         issues.append(DetectedIssue(preset=ISSUE_PRESETS[IssueType.INSTANCE_LOCKED]))
 
-    # 3. tmux check
+    # 3. Git checks (version and user configuration)
+    if check_git:
+        git_version_issue = await _check_git_version()
+        if git_version_issue:
+            issues.append(git_version_issue)
+        else:
+            # Only check user config if git is installed and version is OK
+            git_user_issue = await _check_git_user()
+            if git_user_issue:
+                issues.append(git_user_issue)
+
+    # 4. tmux check
     tmux_issue = _check_tmux()
     if tmux_issue:
         issues.append(tmux_issue)
 
-    # 4. Agent check (interactive command for PAIR mode)
+    # 5. Agent check (interactive command for PAIR mode)
     if agent_config:
         from kagan.config import get_os_value
 
@@ -402,7 +508,7 @@ def detect_issues(
             if agent_issue:
                 issues.append(agent_issue)
 
-        # 5. ACP command check (run_command for AUTO mode)
+        # 6. ACP command check (run_command for AUTO mode)
         # This uses smart detection for npx-based commands
         acp_cmd = get_os_value(agent_config.run_command)
         if acp_cmd:

--- a/src/kagan/ui/screens/welcome.py
+++ b/src/kagan/ui/screens/welcome.py
@@ -221,11 +221,8 @@ class WelcomeScreen(Screen):
         kagan_dir = Path(".kagan")
         kagan_dir.mkdir(exist_ok=True)
 
-        # Ensure .kagan is gitignored in git repos
-        if self._has_git_repo:
-            added = self._ensure_gitignored()
-            if added:
-                self.app.call_later(lambda: self.app.notify("Added .kagan/ to .gitignore"))
+        # Note: .gitignore handling is done in git_utils.init_git_repo()
+        # which is called from app.py after welcome screen completes
 
         # Build agent sections from BUILTIN_AGENTS with correct ACP commands
         agent_sections = []
@@ -253,27 +250,3 @@ default_worker_agent = "{worker}"
 '''
 
         (kagan_dir / "config.toml").write_text(config_content)
-
-    def _ensure_gitignored(self) -> bool:
-        """Add .kagan/ to .gitignore if not already present.
-
-        Returns True if .gitignore was modified, False otherwise.
-        """
-        gitignore = Path(".gitignore")
-
-        if gitignore.exists():
-            content = gitignore.read_text()
-            lines = content.split("\n")
-            # Check if already ignored (with or without trailing slash)
-            if ".kagan" in lines or ".kagan/" in lines:
-                return False
-            # Append to existing file
-            if not content.endswith("\n"):
-                content += "\n"
-            content += "\n# Kagan local state\n.kagan/\n"
-            gitignore.write_text(content)
-        else:
-            # Create new .gitignore
-            gitignore.write_text("# Kagan local state\n.kagan/\n")
-
-        return True

--- a/src/kagan/ui/widgets/card.py
+++ b/src/kagan/ui/widgets/card.py
@@ -23,7 +23,6 @@ from kagan.database.models import Ticket, TicketPriority, TicketStatus, TicketTy
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
-    from textual.timer import Timer
 
 
 class TicketCard(Widget):
@@ -35,7 +34,6 @@ class TicketCard(Widget):
     is_agent_active: var[bool] = var(False, toggle_class="agent-active", always_update=True)
     is_session_active: var[bool] = var(False, toggle_class="session-active")
     iteration_info: reactive[str] = reactive("", recompose=True)
-    _pulse_timer: Timer | None = None
 
     @dataclass
     class Selected(Message):
@@ -208,23 +206,6 @@ class TicketCard(Widget):
             self.post_message(self.Selected(self.ticket))
 
     def watch_is_agent_active(self, active: bool) -> None:
-        """Start/stop pulse animation timer when agent state changes."""
+        """Update card display when agent state changes."""
         # Trigger recompose to update badge
         self.refresh(recompose=True)
-        if active:
-            self._pulse_timer = self.set_interval(0.6, self._toggle_pulse)
-        else:
-            if self._pulse_timer is not None:
-                self._pulse_timer.stop()
-                self._pulse_timer = None
-            self.remove_class("agent-pulse")
-
-    def _toggle_pulse(self) -> None:
-        """Toggle the pulse class for animation effect."""
-        self.toggle_class("agent-pulse")
-
-    def on_unmount(self) -> None:
-        """Clean up timer when card is removed."""
-        if self._pulse_timer is not None:
-            self._pulse_timer.stop()
-            self._pulse_timer = None

--- a/tests/e2e/test_welcome.py
+++ b/tests/e2e/test_welcome.py
@@ -57,33 +57,42 @@ class TestBuildBranchOptions:
 class TestGetDefaultBaseBranch:
     """Tests for _get_default_base_branch method."""
 
-    def test_no_git_repo_returns_main(self):
+    async def test_no_git_repo_returns_main(self):
         screen = _create_welcome_screen(has_git_repo=False)
-        result = screen._get_default_base_branch([])
+        result = await screen._get_default_base_branch([])
         assert result == "main"
 
-    def test_no_git_repo_ignores_branches(self):
+    async def test_no_git_repo_ignores_branches(self):
         screen = _create_welcome_screen(has_git_repo=False)
-        result = screen._get_default_base_branch(["develop", "feature"])
+        result = await screen._get_default_base_branch(["develop", "feature"])
         assert result == "main"
 
-    def test_with_git_repo_prefers_default_candidates(self, tmp_path: Path, monkeypatch):
-        # Mock get_current_branch to return None
-        monkeypatch.setattr("kagan.ui.screens.welcome.get_current_branch", lambda _: None)
+    async def test_with_git_repo_prefers_default_candidates(self, tmp_path: Path, monkeypatch):
+        # Mock get_current_branch to return None (async)
+        async def mock_get_current_branch(_):
+            return None
+
+        monkeypatch.setattr("kagan.ui.screens.welcome.get_current_branch", mock_get_current_branch)
         screen = _create_welcome_screen(has_git_repo=True, repo_root=tmp_path)
-        result = screen._get_default_base_branch(["develop", "feature"])
+        result = await screen._get_default_base_branch(["develop", "feature"])
         assert result == "develop"
 
-    def test_with_git_repo_falls_back_to_first_branch(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setattr("kagan.ui.screens.welcome.get_current_branch", lambda _: None)
+    async def test_with_git_repo_falls_back_to_first_branch(self, tmp_path: Path, monkeypatch):
+        async def mock_get_current_branch(_):
+            return None
+
+        monkeypatch.setattr("kagan.ui.screens.welcome.get_current_branch", mock_get_current_branch)
         screen = _create_welcome_screen(has_git_repo=True, repo_root=tmp_path)
-        result = screen._get_default_base_branch(["custom-branch", "another"])
+        result = await screen._get_default_base_branch(["custom-branch", "another"])
         assert result == "custom-branch"
 
-    def test_with_git_repo_uses_current_branch(self, tmp_path: Path, monkeypatch):
-        monkeypatch.setattr("kagan.ui.screens.welcome.get_current_branch", lambda _: "feature-x")
+    async def test_with_git_repo_uses_current_branch(self, tmp_path: Path, monkeypatch):
+        async def mock_get_current_branch(_):
+            return "feature-x"
+
+        monkeypatch.setattr("kagan.ui.screens.welcome.get_current_branch", mock_get_current_branch)
         screen = _create_welcome_screen(has_git_repo=True, repo_root=tmp_path)
-        result = screen._get_default_base_branch(["main", "develop"])
+        result = await screen._get_default_base_branch(["main", "develop"])
         assert result == "feature-x"
 
 

--- a/tests/integration/test_git_utils.py
+++ b/tests/integration/test_git_utils.py
@@ -123,24 +123,34 @@ class TestInitGitRepo:
         await _run_git(tmp_path, "config", "--global", "user.email", "test@test.com")
         await _run_git(tmp_path, "config", "--global", "user.name", "Test")
         result = await init_git_repo(tmp_path, "develop")
-        assert result is True
+        assert result.success is True
         assert await has_git_repo(tmp_path)
-        assert (tmp_path / ".gitkeep").exists()
+        assert (tmp_path / ".gitignore").exists()
+        # Verify .kagan/ is in .gitignore
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".kagan/" in content or ".kagan" in content.split("\n")
 
-    async def test_returns_false_when_git_not_found(self, tmp_path: Path) -> None:
+    async def test_returns_error_when_git_not_found(self, tmp_path: Path) -> None:
         with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError):
-            assert await init_git_repo(tmp_path, "main") is False
+            result = await init_git_repo(tmp_path, "main")
+            assert result.success is False
+            assert result.error is not None
+            assert result.error.error_type == "version_low"
 
     async def test_fallback_for_old_git_versions(self, tmp_path: Path) -> None:
         """When git init -b fails, falls back to git init + git branch -M."""
+        await configure_git_user(tmp_path)
         call_count = [0]
         original_exec = asyncio.create_subprocess_exec
 
         async def mock_subprocess(*args, **kwargs):
             nonlocal call_count
             call_count[0] += 1
-            if call_count[0] == 1:
-                # First call (init -b) fails
+            # Allow git --version and git config calls through
+            if args[1] == "--version" or args[1] == "config":
+                return await original_exec(*args, **kwargs)
+            if call_count[0] == 3:  # First git init -b call (after version and user checks)
+                # First init -b call fails
                 mock_proc = MagicMock()
                 mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
                 mock_proc.returncode = 1
@@ -150,16 +160,227 @@ class TestInitGitRepo:
 
         with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess):
             result = await init_git_repo(tmp_path, "main")
-            assert result is True
+            assert result.success is True
 
-    async def test_returns_false_if_all_init_attempts_fail(self, tmp_path: Path) -> None:
-        """When all init attempts fail, returns False."""
+    async def test_returns_error_if_all_init_attempts_fail(self, tmp_path: Path) -> None:
+        """When all init attempts fail, returns error result."""
+        original_exec = asyncio.create_subprocess_exec
 
         async def mock_subprocess(*args, **kwargs):
+            # Allow git --version and git config calls through
+            if len(args) > 1 and (args[1] == "--version" or args[1] == "config"):
+                return await original_exec(*args, **kwargs)
+            # All other git commands fail
             mock_proc = MagicMock()
             mock_proc.communicate = AsyncMock(return_value=(b"", b"error"))
             mock_proc.returncode = 1
             return mock_proc
 
         with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess):
-            assert await init_git_repo(tmp_path, "main") is False
+            result = await init_git_repo(tmp_path, "main")
+            assert result.success is False
+            assert result.error is not None
+
+    async def test_includes_gitignore_in_initial_commit(self, tmp_path: Path) -> None:
+        """When .gitignore is created, it should be included in the initial commit."""
+        await _run_git(tmp_path, "config", "--global", "user.email", "test@test.com")
+        await _run_git(tmp_path, "config", "--global", "user.name", "Test")
+
+        result = await init_git_repo(tmp_path, "main")
+        assert result.success is True
+
+        # Verify .gitignore is tracked in the commit
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "ls-files",
+            cwd=tmp_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        tracked_files = stdout.decode().strip().split("\n")
+        assert ".gitignore" in tracked_files
+
+
+class TestInitGitRepoScenarios:
+    """Tests for the three gitignore scenarios in init_git_repo."""
+
+    async def test_scenario1_empty_folder_no_git_repo(self, tmp_path: Path) -> None:
+        """Scenario 1: Empty folder, no git repo.
+
+        Expected: .gitignore is created with kagan exclusion, repo initialized, committed.
+        """
+        await configure_git_user(tmp_path)
+
+        result = await init_git_repo(tmp_path, "main")
+
+        assert result.success is True
+        assert result.gitignore_created is True
+        assert result.gitignore_updated is False
+        assert result.committed is True
+        assert (tmp_path / ".gitignore").exists()
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".kagan/" in content
+
+    async def test_scenario2_existing_repo_with_gitignore(self, tmp_path: Path) -> None:
+        """Scenario 2: Existing git repo with .gitignore.
+
+        Expected: .gitignore updated by appending kagan, commit made.
+        """
+        # Set up existing repo with .gitignore
+        await _run_git(tmp_path, "init", "-b", "main")
+        await configure_git_user(tmp_path)
+        (tmp_path / ".gitignore").write_text("node_modules/\n__pycache__/\n")
+        await _run_git(tmp_path, "add", ".gitignore")
+        await _run_git(tmp_path, "commit", "-m", "Initial with gitignore")
+
+        result = await init_git_repo(tmp_path, "main")
+
+        assert result.success is True
+        assert result.gitignore_created is False
+        assert result.gitignore_updated is True
+        assert result.committed is True
+        content = (tmp_path / ".gitignore").read_text()
+        # Original content preserved
+        assert "node_modules/" in content
+        assert "__pycache__/" in content
+        # Kagan added
+        assert ".kagan/" in content
+
+    async def test_scenario3_existing_repo_without_gitignore(self, tmp_path: Path) -> None:
+        """Scenario 3: Existing git repo without .gitignore.
+
+        Expected: .gitignore created with kagan exclusion, commit made.
+        """
+        # Set up existing repo without .gitignore
+        await _run_git(tmp_path, "init", "-b", "main")
+        await configure_git_user(tmp_path)
+        (tmp_path / "README.md").write_text("# Project\n")
+        await _run_git(tmp_path, "add", "README.md")
+        await _run_git(tmp_path, "commit", "-m", "Initial commit")
+
+        result = await init_git_repo(tmp_path, "main")
+
+        assert result.success is True
+        assert result.gitignore_created is True
+        assert result.gitignore_updated is False
+        assert result.committed is True
+        assert (tmp_path / ".gitignore").exists()
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".kagan/" in content
+
+    async def test_existing_repo_with_kagan_already_in_gitignore(self, tmp_path: Path) -> None:
+        """When .kagan/ is already in .gitignore, no changes should be made."""
+        # Set up existing repo with .kagan/ already in .gitignore
+        await _run_git(tmp_path, "init", "-b", "main")
+        await configure_git_user(tmp_path)
+        (tmp_path / ".gitignore").write_text("node_modules/\n.kagan/\n")
+        await _run_git(tmp_path, "add", ".gitignore")
+        await _run_git(tmp_path, "commit", "-m", "Initial with gitignore")
+
+        result = await init_git_repo(tmp_path, "main")
+
+        assert result.success is True
+        assert result.gitignore_created is False
+        assert result.gitignore_updated is False
+        assert result.committed is False  # Nothing to commit
+
+    async def test_existing_repo_with_no_commits(self, tmp_path: Path) -> None:
+        """Scenario 4: Repo initialized but no commits yet - should create initial commit."""
+        # Set up existing repo with no commits (user ran git init but never committed)
+        await _run_git(tmp_path, "init", "-b", "main")
+        await configure_git_user(tmp_path)
+
+        result = await init_git_repo(tmp_path, "main")
+
+        assert result.success is True
+        assert result.gitignore_created is True  # Created .gitignore
+        assert result.gitignore_updated is False
+        assert result.committed is True  # Created initial commit
+        assert (tmp_path / ".gitignore").exists()
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".kagan/" in content
+
+        # Verify there's now a commit
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "log",
+            "--oneline",
+            cwd=tmp_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        assert proc.returncode == 0
+        assert "Initial commit (kagan)" in stdout.decode()
+
+
+class TestInitGitRepoErrors:
+    """Tests for git error handling in init_git_repo."""
+
+    async def test_git_version_too_low(self, tmp_path: Path) -> None:
+        """When git version is below 2.5, returns version_low error."""
+        from kagan.git_utils import GitVersion
+
+        with patch("kagan.git_utils.get_git_version") as mock_version:
+            mock_version.return_value = GitVersion(
+                major=2, minor=4, patch=0, raw="git version 2.4.0"
+            )
+            result = await init_git_repo(tmp_path, "main")
+
+            assert result.success is False
+            assert result.error is not None
+            assert result.error.error_type == "version_low"
+            assert "2.4" in result.error.message
+            assert result.error.details is not None
+            assert "2.5" in result.error.details
+
+    async def test_git_not_installed(self, tmp_path: Path) -> None:
+        """When git is not installed, returns version_low error with install message."""
+        with patch("kagan.git_utils.get_git_version") as mock_version:
+            mock_version.return_value = None
+            result = await init_git_repo(tmp_path, "main")
+
+            assert result.success is False
+            assert result.error is not None
+            assert result.error.error_type == "version_low"
+            assert "not installed" in result.error.message.lower()
+
+    async def test_git_user_not_configured(self, tmp_path: Path) -> None:
+        """When git user is not configured, returns user_not_configured error."""
+        with patch("kagan.git_utils.check_git_user_configured") as mock_user:
+            mock_user.return_value = (False, "Git user.name is not configured")
+            result = await init_git_repo(tmp_path, "main")
+
+            assert result.success is False
+            assert result.error is not None
+            assert result.error.error_type == "user_not_configured"
+            assert "user" in result.error.message.lower()
+
+    async def test_commit_failure(self, tmp_path: Path) -> None:
+        """When commit fails (not 'nothing to commit'), returns commit_failed error."""
+        await configure_git_user(tmp_path)
+        original_exec = asyncio.create_subprocess_exec
+        commit_call_count = [0]
+
+        async def mock_subprocess(*args, **kwargs):
+            # Allow version check, user config, init, add to succeed
+            if len(args) > 1 and args[1] in ("--version", "config", "init", "add"):
+                return await original_exec(*args, **kwargs)
+            if len(args) > 1 and args[1] == "commit":
+                commit_call_count[0] += 1
+                # Make commit fail with a real error
+                mock_proc = MagicMock()
+                mock_proc.communicate = AsyncMock(
+                    return_value=(b"", b"fatal: unable to auto-detect email")
+                )
+                mock_proc.returncode = 1
+                return mock_proc
+            return await original_exec(*args, **kwargs)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess):
+            result = await init_git_repo(tmp_path, "main")
+
+            assert result.success is False
+            assert result.error is not None
+            assert result.error.error_type == "commit_failed"

--- a/tests/integration/test_preflight.py
+++ b/tests/integration/test_preflight.py
@@ -1,0 +1,238 @@
+"""Tests for pre-flight check orchestration in __main__.py."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestPreflightAgentSelection:
+    """Tests for agent selection during pre-flight checks."""
+
+    def test_uses_available_agent_when_any_available(self):
+        """When at least one agent is available, pre-flight should use it.
+
+        This tests the fix for the bug where:
+        1. any_agent_available() returned True (OpenCode installed)
+        2. But pre-flight still checked Claude (from config) which wasn't installed
+        3. Resulting in unnecessary troubleshooting screen
+        """
+        from kagan.data.builtin_agents import (
+            any_agent_available,
+            get_first_available_agent,
+        )
+
+        # Simulate: OpenCode available, Claude not available
+        def mock_which(cmd: str) -> str | None:
+            if cmd == "opencode":
+                return "/usr/local/bin/opencode"
+            return None  # claude, npx not available
+
+        with patch("shutil.which", side_effect=mock_which):
+            # Step 1: any_agent_available() should return True
+            assert any_agent_available() is True
+
+            # Step 2: get_first_available_agent() should return OpenCode
+            agent = get_first_available_agent()
+            assert agent is not None
+            assert agent.config.short_name == "opencode"
+            assert agent.config.name == "OpenCode"
+
+    def test_uses_claude_when_both_available(self):
+        """When both agents are available, Claude should be preferred (priority)."""
+        from kagan.data.builtin_agents import get_first_available_agent
+
+        def mock_which(cmd: str) -> str | None:
+            if cmd in ("claude", "opencode", "npx"):
+                return f"/usr/local/bin/{cmd}"
+            return None
+
+        with patch("shutil.which", side_effect=mock_which):
+            agent = get_first_available_agent()
+            assert agent is not None
+            assert agent.config.short_name == "claude"
+
+    def test_no_agents_available_returns_none(self):
+        """When no agents are available, get_first_available_agent returns None."""
+        from kagan.data.builtin_agents import (
+            any_agent_available,
+            get_first_available_agent,
+        )
+
+        with patch("shutil.which", return_value=None):
+            assert any_agent_available() is False
+            assert get_first_available_agent() is None
+
+    def test_npx_only_does_not_make_claude_available(self):
+        """When only npx is installed (no actual agents), Claude should NOT be available.
+
+        This is the key bug fix: on a system with node/nvm installed, npx exists
+        but claude-code-acp package is not installed. Just having npx should NOT
+        count as Claude being available.
+        """
+        from kagan.data.builtin_agents import (
+            any_agent_available,
+            get_first_available_agent,
+        )
+
+        def mock_which(cmd: str) -> str | None:
+            # Simulate: npx and tmux available, but NO agent binaries
+            if cmd in ("npx", "tmux"):
+                return f"/usr/bin/{cmd}"
+            return None  # claude, opencode, claude-code-acp not available
+
+        with patch("shutil.which", side_effect=mock_which):
+            # No agents should be available
+            assert any_agent_available() is False
+            assert get_first_available_agent() is None
+
+    def test_opencode_available_with_npx_but_no_claude(self):
+        """When OpenCode is installed but Claude is not (even with npx), use OpenCode.
+
+        This is the Ubuntu scenario: node/npm/npx installed, OpenCode installed,
+        but Claude Code not installed.
+        """
+        from kagan.data.builtin_agents import (
+            any_agent_available,
+            get_first_available_agent,
+        )
+
+        def mock_which(cmd: str) -> str | None:
+            # Simulate: npx, tmux, and opencode available, but NOT claude or claude-code-acp
+            if cmd in ("npx", "tmux", "opencode"):
+                return f"/usr/bin/{cmd}"
+            return None
+
+        with patch("shutil.which", side_effect=mock_which):
+            assert any_agent_available() is True
+            agent = get_first_available_agent()
+            assert agent is not None
+            # Should be OpenCode, NOT Claude (even though npx exists)
+            assert agent.config.short_name == "opencode"
+
+
+class TestPreflightDetectIssues:
+    """Tests for detect_issues with available agent."""
+
+    def test_detect_issues_passes_with_available_agent(self):
+        """When agent is available, detect_issues should not find agent issues."""
+        from kagan.data.builtin_agents import get_first_available_agent
+        from kagan.ui.screens.troubleshooting import detect_issues
+
+        def mock_which(cmd: str) -> str | None:
+            # Simulate OpenCode available, tmux available
+            if cmd in ("opencode", "tmux"):
+                return f"/usr/local/bin/{cmd}"
+            return None
+
+        with patch("shutil.which", side_effect=mock_which):
+            agent = get_first_available_agent()
+            assert agent is not None
+
+            # Run detect_issues with the available agent
+            result = detect_issues(
+                check_lock=False,
+                agent_config=agent.config,
+                agent_name=agent.config.name,
+                agent_install_command=agent.install_command,
+            )
+
+            # Should not have blocking issues (agent is available)
+            assert result.has_blocking_issues is False
+
+    def test_detect_issues_fails_with_unavailable_agent(self):
+        """When agent is not available, detect_issues should report it."""
+        from kagan.data.builtin_agents import BUILTIN_AGENTS
+        from kagan.ui.screens.troubleshooting import IssueType, detect_issues
+
+        # Get Claude agent config but simulate it's not installed
+        claude = BUILTIN_AGENTS["claude"]
+
+        def mock_which(cmd: str) -> str | None:
+            # Only tmux available, no agents
+            if cmd == "tmux":
+                return "/usr/bin/tmux"
+            return None
+
+        with patch("shutil.which", side_effect=mock_which):
+            result = detect_issues(
+                check_lock=False,
+                agent_config=claude.config,
+                agent_name=claude.config.name,
+                agent_install_command=claude.install_command,
+            )
+
+            # Should have blocking issue for missing agent
+            assert result.has_blocking_issues is True
+            issue_types = [issue.preset.type for issue in result.issues]
+            assert (
+                IssueType.AGENT_MISSING in issue_types or IssueType.ACP_AGENT_MISSING in issue_types
+            )
+
+
+class TestPreflightFlowIntegration:
+    """Integration tests for the complete pre-flight flow logic."""
+
+    def test_preflight_flow_skips_troubleshooting_with_available_agent(self):
+        """Complete flow: available agent should skip troubleshooting.
+
+        This is the key integration test that would have caught the original bug.
+        It tests the actual orchestration logic from __main__.py.
+        """
+        from kagan.data.builtin_agents import any_agent_available, get_first_available_agent
+        from kagan.ui.screens.troubleshooting import detect_issues
+
+        def mock_which(cmd: str) -> str | None:
+            # Simulate: Only OpenCode available (not Claude)
+            if cmd == "opencode":
+                return "/usr/local/bin/opencode"
+            if cmd == "tmux":
+                return "/usr/bin/tmux"
+            return None  # claude, npx not available
+
+        with patch("shutil.which", side_effect=mock_which):
+            # This is the logic from __main__.py
+
+            # Step 1: Check if ANY agent is available
+            if not any_agent_available():
+                pytest.fail("Should have at least one agent available")
+
+            # Step 2: Get the first available agent (this is the fix!)
+            best_agent = get_first_available_agent()
+            assert best_agent is not None, "Should have found OpenCode"
+            assert best_agent.config.short_name == "opencode"
+
+            # Step 3: Run detect_issues with the AVAILABLE agent
+            result = detect_issues(
+                check_lock=False,
+                agent_config=best_agent.config,
+                agent_name=best_agent.config.name,
+                agent_install_command=best_agent.install_command,
+            )
+
+            # Step 4: Should NOT have blocking issues
+            assert result.has_blocking_issues is False, (
+                f"Should not show troubleshooting when agent is available. "
+                f"Issues found: {[i.preset.type for i in result.issues]}"
+            )
+
+    def test_preflight_flow_shows_troubleshooting_when_no_agents(self):
+        """When no agents are available, should show troubleshooting."""
+        from kagan.data.builtin_agents import any_agent_available
+        from kagan.ui.screens.troubleshooting import create_no_agents_issues
+
+        with patch("shutil.which", return_value=None):
+            # Step 1: No agents available
+            assert any_agent_available() is False
+
+            # Step 2: Create issues for all agents
+            issues = create_no_agents_issues()
+            assert len(issues) >= 2  # At least Claude and OpenCode
+
+            # Verify each issue has install instructions
+            for issue in issues:
+                assert issue.preset.hint is not None
+                assert len(issue.preset.hint) > 0

--- a/tests/snapshot/test_snapshots.py
+++ b/tests/snapshot/test_snapshots.py
@@ -31,7 +31,6 @@ TicketCard {
 TicketCard:focus { border: solid #e75535; background: #171c24; }
 TicketCard.session-active { border: solid #98c379; }
 TicketCard.agent-active { border: solid #c678dd; }
-TicketCard.agent-pulse { border: solid #e5c07b; background: #171c24; }
 TicketCard .card-title { width: 100%; height: 1; text-style: bold; color: #dfe0e1; padding: 0; }
 TicketCard .card-title-continued { width: 100%; height: 1; color: #dfe0e1; }
 TicketCard .card-desc { width: 100%; height: 1; color: #5c6773; }

--- a/tests/unit/test_builtin_agents.py
+++ b/tests/unit/test_builtin_agents.py
@@ -1,0 +1,298 @@
+"""Unit tests for builtin_agents agent availability detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from kagan.data.builtin_agents import (
+    AGENT_PRIORITY,
+    BUILTIN_AGENTS,
+    AgentAvailability,
+    _check_command_available,
+    any_agent_available,
+    check_agent_availability,
+    get_all_agent_availability,
+    get_first_available_agent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestCheckCommandAvailable:
+    """Test _check_command_available helper function."""
+
+    def test_simple_command_available(self, mocker):
+        """Simple command returns True when in PATH."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value="/usr/bin/claude")
+
+        assert _check_command_available("claude") is True
+
+    def test_simple_command_not_available(self, mocker):
+        """Simple command returns False when not in PATH."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        assert _check_command_available("claude") is False
+
+    def test_none_command_returns_false(self, mocker):
+        """None command returns False."""
+        assert _check_command_available(None) is False
+
+    def test_empty_command_returns_false(self, mocker):
+        """Empty string command returns False."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        assert _check_command_available("") is False
+
+    def test_npx_command_with_only_npx_available(self, mocker):
+        """npx command returns False when only npx is available (binary not installed).
+
+        This is the key test: just having npx is NOT sufficient.
+        The package binary must be globally installed for availability check.
+        """
+
+        def which_side_effect(cmd):
+            if cmd == "npx":
+                return "/usr/bin/npx"
+            return None  # claude-code-acp not installed
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        # Should be False because only npx exists, not the actual binary
+        assert _check_command_available("npx claude-code-acp") is False
+
+    def test_npx_command_with_global_binary(self, mocker):
+        """npx command returns True when package binary is globally installed."""
+
+        def which_side_effect(cmd):
+            if cmd == "claude-code-acp":
+                return "/usr/local/bin/claude-code-acp"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        assert _check_command_available("npx claude-code-acp") is True
+
+    def test_npx_command_neither_available(self, mocker):
+        """npx command returns False when neither npx nor binary is available."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        assert _check_command_available("npx claude-code-acp") is False
+
+    def test_command_with_args(self, mocker):
+        """Command with arguments checks first part only."""
+
+        def which_side_effect(cmd):
+            if cmd == "opencode":
+                return "/usr/bin/opencode"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        assert _check_command_available("opencode acp") is True
+
+    def test_malformed_command_string(self, mocker):
+        """Malformed command string is handled gracefully."""
+        # shlex.split will fail on unbalanced quotes, but function handles it
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        # This should not raise, but return False
+        result = _check_command_available("echo 'unclosed")
+        assert result is False
+
+
+class TestCheckAgentAvailability:
+    """Test check_agent_availability function."""
+
+    def test_agent_fully_available(self, mocker):
+        """Agent with both commands available is fully available.
+
+        Note: For Claude, ACP requires the claude-code-acp binary to be globally
+        installed. Just having npx is not sufficient for availability check.
+        """
+
+        def which_side_effect(cmd):
+            # Both claude CLI and claude-code-acp binary must be available
+            if cmd in ("claude", "claude-code-acp"):
+                return f"/usr/bin/{cmd}"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        agent = BUILTIN_AGENTS["claude"]
+        result = check_agent_availability(agent)
+
+        assert result.is_available is True
+        assert result.interactive_available is True
+        assert result.acp_available is True
+        assert result.install_hint == agent.install_command
+        assert result.docs_url == agent.docs_url
+
+    def test_agent_only_interactive_available(self, mocker):
+        """Agent with only interactive command is still available."""
+
+        def which_side_effect(cmd):
+            if cmd == "claude":
+                return "/usr/bin/claude"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        agent = BUILTIN_AGENTS["claude"]
+        result = check_agent_availability(agent)
+
+        assert result.is_available is True
+        assert result.interactive_available is True
+        assert result.acp_available is False
+
+    def test_agent_not_available(self, mocker):
+        """Agent with no commands available is not available."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        agent = BUILTIN_AGENTS["claude"]
+        result = check_agent_availability(agent)
+
+        assert result.is_available is False
+        assert result.interactive_available is False
+        assert result.acp_available is False
+
+
+class TestGetAllAgentAvailability:
+    """Test get_all_agent_availability function."""
+
+    def test_returns_agents_in_priority_order(self, mocker):
+        """Returns agents in AGENT_PRIORITY order."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        result = get_all_agent_availability()
+
+        assert len(result) == len(AGENT_PRIORITY)
+        for i, key in enumerate(AGENT_PRIORITY):
+            assert result[i].agent.config.short_name == key
+
+    def test_returns_availability_for_all_agents(self, mocker):
+        """Returns AgentAvailability for all builtin agents."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        result = get_all_agent_availability()
+
+        assert all(isinstance(a, AgentAvailability) for a in result)
+
+
+class TestGetFirstAvailableAgent:
+    """Test get_first_available_agent function."""
+
+    def test_returns_claude_when_available(self, mocker):
+        """Returns claude when it's available (priority first)."""
+
+        def which_side_effect(cmd):
+            if cmd in ("claude", "opencode"):
+                return f"/usr/bin/{cmd}"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        result = get_first_available_agent()
+
+        assert result is not None
+        assert result.config.short_name == "claude"
+
+    def test_returns_opencode_when_claude_not_available(self, mocker):
+        """Returns opencode when claude is not available."""
+
+        def which_side_effect(cmd):
+            if cmd == "opencode":
+                return "/usr/bin/opencode"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        result = get_first_available_agent()
+
+        assert result is not None
+        assert result.config.short_name == "opencode"
+
+    def test_returns_none_when_no_agents_available(self, mocker):
+        """Returns None when no agents are available."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        result = get_first_available_agent()
+
+        assert result is None
+
+
+class TestAnyAgentAvailable:
+    """Test any_agent_available function."""
+
+    def test_returns_true_when_any_available(self, mocker):
+        """Returns True when at least one agent is available."""
+
+        def which_side_effect(cmd):
+            if cmd == "opencode":
+                return "/usr/bin/opencode"
+            return None
+
+        mocker.patch("kagan.data.builtin_agents.shutil.which", side_effect=which_side_effect)
+
+        assert any_agent_available() is True
+
+    def test_returns_false_when_none_available(self, mocker):
+        """Returns False when no agents are available."""
+        mocker.patch("kagan.data.builtin_agents.shutil.which", return_value=None)
+
+        assert any_agent_available() is False
+
+
+class TestAgentAvailabilityDataclass:
+    """Test AgentAvailability dataclass properties."""
+
+    def test_is_available_both_true(self):
+        """is_available returns True when both modes available."""
+        agent = BUILTIN_AGENTS["claude"]
+        avail = AgentAvailability(
+            agent=agent,
+            interactive_available=True,
+            acp_available=True,
+        )
+        assert avail.is_available is True
+
+    def test_is_available_only_interactive(self):
+        """is_available returns True when only interactive available."""
+        agent = BUILTIN_AGENTS["claude"]
+        avail = AgentAvailability(
+            agent=agent,
+            interactive_available=True,
+            acp_available=False,
+        )
+        assert avail.is_available is True
+
+    def test_is_available_only_acp(self):
+        """is_available returns True when only ACP available."""
+        agent = BUILTIN_AGENTS["claude"]
+        avail = AgentAvailability(
+            agent=agent,
+            interactive_available=False,
+            acp_available=True,
+        )
+        assert avail.is_available is True
+
+    def test_is_available_neither(self):
+        """is_available returns False when neither available."""
+        agent = BUILTIN_AGENTS["claude"]
+        avail = AgentAvailability(
+            agent=agent,
+            interactive_available=False,
+            acp_available=False,
+        )
+        assert avail.is_available is False
+
+    def test_install_hint_property(self):
+        """install_hint returns agent's install command."""
+        agent = BUILTIN_AGENTS["claude"]
+        avail = AgentAvailability(agent=agent)
+        assert avail.install_hint == agent.install_command
+
+    def test_docs_url_property(self):
+        """docs_url returns agent's docs URL."""
+        agent = BUILTIN_AGENTS["claude"]
+        avail = AgentAvailability(agent=agent)
+        assert avail.docs_url == agent.docs_url

--- a/tests/unit/test_troubleshooting_agent.py
+++ b/tests/unit/test_troubleshooting_agent.py
@@ -133,9 +133,14 @@ class TestPreflightResult:
 class TestIssuePresets:
     """Test that all issue presets are properly defined."""
 
+    # Issue types that are dynamically generated (not in ISSUE_PRESETS)
+    DYNAMIC_ISSUE_TYPES = {IssueType.NO_AGENTS_AVAILABLE}
+
     def test_all_issue_types_have_presets(self):
-        """Every IssueType has a corresponding preset."""
+        """Every IssueType (except dynamic ones) has a corresponding preset."""
         for issue_type in IssueType:
+            if issue_type in self.DYNAMIC_ISSUE_TYPES:
+                continue
             assert issue_type in ISSUE_PRESETS, f"Missing preset for {issue_type}"
 
     def test_all_presets_have_required_fields(self):

--- a/tests/unit/test_troubleshooting_unit.py
+++ b/tests/unit/test_troubleshooting_unit.py
@@ -16,34 +16,36 @@ pytestmark = pytest.mark.unit
 class TestDetectIssuesWindows:
     """Test Windows OS detection."""
 
-    def test_detects_windows_os(self, mocker):
+    async def test_detects_windows_os(self, mocker):
         """Windows detection returns a blocking issue."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Windows")
 
-        result = detect_issues()
+        result = await detect_issues()
 
         assert result.has_blocking_issues
         assert len(result.issues) == 1
         assert result.issues[0].preset.type == IssueType.WINDOWS_OS
         assert result.issues[0].preset.severity == IssueSeverity.BLOCKING
 
-    def test_windows_detection_exits_early(self, mocker):
+    async def test_windows_detection_exits_early(self, mocker):
         """Windows detection should return only Windows issue, skipping other checks."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Windows")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value=None)
 
-        result = detect_issues(check_lock=True, lock_acquired=False)
+        result = await detect_issues(check_lock=True, lock_acquired=False)
 
         # Should only have Windows issue, not lock or tmux issues
         assert len(result.issues) == 1
         assert result.issues[0].preset.type == IssueType.WINDOWS_OS
 
-    def test_non_windows_passes(self, mocker):
+    async def test_non_windows_passes(self, mocker):
         """Non-Windows platforms pass the Windows check."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Darwin")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value="/usr/bin/tmux")
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_version", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_user", return_value=None)
 
-        result = detect_issues()
+        result = await detect_issues()
 
         # No Windows issue
         assert not any(i.preset.type == IssueType.WINDOWS_OS for i in result.issues)
@@ -52,32 +54,38 @@ class TestDetectIssuesWindows:
 class TestDetectIssuesInstanceLock:
     """Test instance lock detection."""
 
-    def test_detects_lock_failure(self, mocker):
+    async def test_detects_lock_failure(self, mocker):
         """Lock failure is detected when check_lock=True and lock_acquired=False."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Darwin")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value="/usr/bin/tmux")
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_version", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_user", return_value=None)
 
-        result = detect_issues(check_lock=True, lock_acquired=False)
+        result = await detect_issues(check_lock=True, lock_acquired=False)
 
         assert result.has_blocking_issues
         assert any(i.preset.type == IssueType.INSTANCE_LOCKED for i in result.issues)
 
-    def test_lock_success_no_issue(self, mocker):
+    async def test_lock_success_no_issue(self, mocker):
         """Successful lock acquisition produces no issue."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Darwin")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value="/usr/bin/tmux")
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_version", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_user", return_value=None)
 
-        result = detect_issues(check_lock=True, lock_acquired=True)
+        result = await detect_issues(check_lock=True, lock_acquired=True)
 
         assert not any(i.preset.type == IssueType.INSTANCE_LOCKED for i in result.issues)
 
-    def test_lock_not_checked_by_default(self, mocker):
+    async def test_lock_not_checked_by_default(self, mocker):
         """Lock is not checked when check_lock=False (default)."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Darwin")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value="/usr/bin/tmux")
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_version", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_user", return_value=None)
 
         # Even with lock_acquired=False, should not report issue if check_lock=False
-        result = detect_issues(check_lock=False, lock_acquired=False)
+        result = await detect_issues(check_lock=False, lock_acquired=False)
 
         assert not any(i.preset.type == IssueType.INSTANCE_LOCKED for i in result.issues)
 
@@ -85,21 +93,25 @@ class TestDetectIssuesInstanceLock:
 class TestDetectIssuesTmux:
     """Test tmux availability detection."""
 
-    def test_detects_missing_tmux(self, mocker):
+    async def test_detects_missing_tmux(self, mocker):
         """Missing tmux is detected."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Darwin")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_version", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_user", return_value=None)
 
-        result = detect_issues()
+        result = await detect_issues()
 
         assert result.has_blocking_issues
         assert any(i.preset.type == IssueType.TMUX_MISSING for i in result.issues)
 
-    def test_tmux_available_no_issue(self, mocker):
+    async def test_tmux_available_no_issue(self, mocker):
         """Available tmux produces no issue."""
         mocker.patch("kagan.ui.screens.troubleshooting.platform.system", return_value="Darwin")
         mocker.patch("kagan.ui.screens.troubleshooting.shutil.which", return_value="/usr/bin/tmux")
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_version", return_value=None)
+        mocker.patch("kagan.ui.screens.troubleshooting._check_git_user", return_value=None)
 
-        result = detect_issues()
+        result = await detect_issues()
 
         assert not any(i.preset.type == IssueType.TMUX_MISSING for i in result.issues)


### PR DESCRIPTION
## Description

This pull request enhances the pre-flight checks and troubleshooting experience by dynamically detecting available AI agents and providing clear installation instructions when no agents are found. It also addresses UI glitches by using explicit foreground colors in the troubleshooting screen.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🎨 Style/UI update (no functional changes)

## Related Issues

Fixes #
Relates to #

## Changes Made

- Implements dynamic agent detection during pre-flight checks, prioritizing Claude and falling back to OpenCode if available.
- Introduces a new troubleshooting screen that displays installation options for all supported agents when none are detected.
- Enhances the welcome screen to show the availability status of each agent and pre-select the first available one.
- Adds documentation URLs for the agents
- Uses explicit foreground colors for better readability on the troubleshooting screen.

## Testing

- [x] All existing tests pass (`uv run poe check`)
- [x] Added new tests for new functionality
- [x] Tested manually in the TUI

### Manual Testing Steps

1. Run Kagan with no agents installed to verify the new troubleshooting screen.
2. Install OpenCode and run Kagan to ensure it is correctly detected.
3. Install both Claude and OpenCode and verify that Claude is prioritized.
4. Verify the new UI elements and their contrast

## Screenshots/Demo



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `uv run poe fix` to format my code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes