### PR TITLE
docs: add MCP tool descriptions

### DIFF
--- a/src/kagan/mcp/prompts.py
+++ b/src/kagan/mcp/prompts.py
@@ -72,6 +72,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
     async def security_audit_persona_repo(
         repo: str, path: str = ".kagan/personas.json"
     ) -> list[UserMessage]:
+        """Return a read-only audit prompt for a persona preset repository."""
         return [
             UserMessage(
                 f"Audit persona preset source {repo} at path {path}.\n\n"

--- a/src/kagan/mcp/toolsets/projects.py
+++ b/src/kagan/mcp/toolsets/projects.py
@@ -9,6 +9,7 @@ from kagan.mcp.toolsets import mcp_error_boundary
 
 @mcp_error_boundary
 async def _project_list(ctx: Context) -> dict:
+    """List projects available to the current workspace."""
     app = get_context(ctx)
     projects = await app.client.projects.list()
     return {"projects": [{"id": p.id, "name": p.name} for p in projects]}
@@ -16,6 +17,7 @@ async def _project_list(ctx: Context) -> dict:
 
 @mcp_error_boundary
 async def _project_set_active(project_id: str, ctx: Context) -> dict:
+    """Set the active project for subsequent project-scoped operations."""
     app = get_context(ctx)
     await app.client.projects.set_active(project_id)
     return {"project_id": project_id}
@@ -23,6 +25,7 @@ async def _project_set_active(project_id: str, ctx: Context) -> dict:
 
 @mcp_error_boundary
 async def _project_add_repo(project_id: str, repo_path: str, ctx: Context) -> dict:
+    """Attach a repository path to a project."""
     app = get_context(ctx)
     await app.client.projects.add_repo(project_id, repo_path)
     return {"project_id": project_id, "repo_path": repo_path}
@@ -32,6 +35,7 @@ async def _project_add_repo(project_id: str, repo_path: str, ctx: Context) -> di
 async def _project_set_repo_default_branch(
     project_id: str, repo_id: str, branch: str, ctx: Context
 ) -> dict:
+    """Set the default base branch for a project repository."""
     app = get_context(ctx)
     await app.client.projects.get(project_id)
 
@@ -45,6 +49,7 @@ async def _project_set_repo_default_branch(
 
 @mcp_error_boundary
 async def _repo_list(project_id: str, ctx: Context) -> dict:
+    """List repositories attached to a project."""
     app = get_context(ctx)
     repos = await app.client.projects.repos(project_id)
     return {"repos": [{"id": r.id, "path": r.path} for r in repos]}
@@ -52,6 +57,7 @@ async def _repo_list(project_id: str, ctx: Context) -> dict:
 
 @mcp_error_boundary
 async def _project_create(name: str, ctx: Context) -> dict:
+    """Create a project by name."""
     app = get_context(ctx)
     project = await app.client.projects.create(name)
     return {"id": project.id, "name": project.name}
@@ -59,6 +65,7 @@ async def _project_create(name: str, ctx: Context) -> dict:
 
 @mcp_error_boundary
 async def _project_delete(project_id: str, ctx: Context) -> dict:
+    """Delete a project permanently."""
     app = get_context(ctx)
     await app.client.projects.delete(project_id)
     return {"project_id": project_id, "deleted": True}

--- a/src/kagan/mcp/toolsets/review.py
+++ b/src/kagan/mcp/toolsets/review.py
@@ -96,6 +96,7 @@ def _register_review_conflicts(mcp: FastMCP) -> None:
     @mcp.tool()
     @mcp_error_boundary
     async def review_conflicts(task_id: str, ctx: Context) -> dict:
+        """Return merge or rebase conflict details for a task."""
         app = get_context(ctx)
         return await app.client.reviews.conflicts(task_id)
 
@@ -104,6 +105,7 @@ def _register_review_continue_rebase(mcp: FastMCP) -> None:
     @mcp.tool()
     @mcp_error_boundary
     async def review_continue_rebase(task_id: str, ctx: Context) -> dict:
+        """Continue an in-progress rebase after conflicts are resolved."""
         app = get_context(ctx)
         await app.client.reviews.continue_rebase(task_id)
         return {"task_id": task_id, "action": "rebase_continue"}
@@ -113,6 +115,7 @@ def _register_review_abort_rebase(mcp: FastMCP) -> None:
     @mcp.tool()
     @mcp_error_boundary
     async def review_abort_rebase(task_id: str, ctx: Context) -> dict:
+        """Abort an in-progress rebase and restore the task branch."""
         app = get_context(ctx)
         await app.client.reviews.abort_rebase(task_id)
         return {"task_id": task_id, "action": "abort_conflicts"}

--- a/src/kagan/mcp/toolsets/sessions.py
+++ b/src/kagan/mcp/toolsets/sessions.py
@@ -108,6 +108,10 @@ async def _run_start(
     launcher: str | None = None,
     persona: str | None = None,
 ) -> dict:
+    """Start a managed or attached run for a task.
+
+    Creates the task worktree first if one does not already exist.
+    """
     app = get_context(ctx)
 
     ws = await app.client.worktrees.get(task_id)
@@ -155,6 +159,7 @@ async def _run_start(
 
 @mcp_error_boundary
 async def _run_cancel(session_id: str, task_id: str, ctx: Context) -> dict:
+    """Cancel a task run and stop its active session."""
     app = get_context(ctx)
     await app.client.tasks.cancel(task_id)
     return {"session_id": session_id, "task_id": task_id, "cancelled": True}
@@ -162,6 +167,7 @@ async def _run_cancel(session_id: str, task_id: str, ctx: Context) -> dict:
 
 @mcp_error_boundary
 async def _run_summary(ctx: Context, task_ids: list[str] | None = None) -> dict:
+    """Summarize runs, sessions, worktrees, and token usage for tasks."""
     app = get_context(ctx)
     tasks = await app.client.tasks.list()
     id_filter = set(task_ids or [])

--- a/src/kagan/mcp/toolsets/settings.py
+++ b/src/kagan/mcp/toolsets/settings.py
@@ -14,6 +14,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
         @mcp.tool()
         @mcp_error_boundary
         async def settings_get(ctx: Context) -> dict:
+            """Read allowlisted runtime settings."""
             app = get_context(ctx)
             return await app.client.settings.get()
 
@@ -22,6 +23,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
         @mcp.tool()
         @mcp_error_boundary
         async def audit_list(ctx: Context, limit: int | None = None) -> dict:
+            """List recent audit log entries."""
             app = get_context(ctx)
             entries = await app.client.audit_log.list(limit=limit)
             return {
@@ -41,6 +43,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
         @mcp.tool()
         @mcp_error_boundary
         async def settings_set(section: str, key: str, value: str, ctx: Context) -> dict:
+            """Update one allowlisted setting value."""
             app = get_context(ctx)
             await app.client.settings.set({key: value})
             return {"section": section, "key": key, "value": value}
@@ -55,6 +58,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
             path: str = ".kagan/personas.json",
             ref: str | None = None,
         ) -> dict:
+            """Audit a persona preset repository before import."""
             app = get_context(ctx)
             return await app.client.persona_presets.audit_repo(repo=repo, path=path, ref=ref)
 
@@ -71,6 +75,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
             acknowledge_risk: bool = False,
             merge_mode: str = "merge",
         ) -> dict:
+            """Import persona presets from GitHub into Kagan."""
             app = get_context(ctx)
             return await app.client.persona_presets.import_from_github(
                 repo=repo,
@@ -92,6 +97,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
             branch: str | None = None,
             commit_message: str = "chore: publish kagan persona presets",
         ) -> dict:
+            """Export local persona presets to GitHub."""
             app = get_context(ctx)
             return await app.client.persona_presets.export_to_github(
                 repo=repo,
@@ -105,6 +111,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
         @mcp.tool()
         @mcp_error_boundary
         async def persona_preset_whitelist_list(ctx: Context) -> dict:
+            """List trusted persona preset repositories."""
             app = get_context(ctx)
             return await app.client.persona_presets.whitelist_list()
 
@@ -113,6 +120,7 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
         @mcp.tool()
         @mcp_error_boundary
         async def persona_preset_whitelist_add(ctx: Context, repo: str) -> dict:
+            """Trust a persona preset repository for future imports."""
             app = get_context(ctx)
             return await app.client.persona_presets.whitelist_add(repo)
 
@@ -121,5 +129,6 @@ def register(mcp: FastMCP, opts: ServerOptions) -> None:
         @mcp.tool()
         @mcp_error_boundary
         async def persona_preset_whitelist_remove(ctx: Context, repo: str) -> dict:
+            """Remove a repository from the persona preset trust list."""
             app = get_context(ctx)
             return await app.client.persona_presets.whitelist_remove(repo)

--- a/src/kagan/mcp/toolsets/tasks.py
+++ b/src/kagan/mcp/toolsets/tasks.py
@@ -177,6 +177,10 @@ async def _task_get(ctx: Context, task_id: str | None = None) -> dict:
 
 @mcp_error_boundary
 async def _task_list(ctx: Context, status: str | None = None) -> dict:
+    """List tasks, optionally filtered by status.
+
+    Use this to inspect project state before planning or mutating work.
+    """
     app = get_context(ctx)
     status_enum = TaskStatus(status) if status else None
     tasks = await app.client.tasks.list(status=status_enum)
@@ -198,6 +202,10 @@ async def _task_create(
     agent_backend: str | None = None,
     launcher: str | None = None,
 ) -> dict:
+    """Create a task on the active board.
+
+    Include acceptance criteria when you want downstream review to stay concrete.
+    """
     app = get_context(ctx)
     priority_enum = parse_priority(priority)
     task = await app.client.tasks.create(
@@ -228,6 +236,10 @@ async def _task_update(
     launcher: str | None = None,
     status: str | None = None,
 ) -> dict:
+    """Update task fields or transition task status.
+
+    Check the verification payload to confirm the requested changes were applied.
+    """
     app = get_context(ctx)
     resolved_task_id = _resolve_task_id(ctx, task_id)
     priority_enum = parse_priority(priority) if priority is not None else None
@@ -261,6 +273,10 @@ async def _task_update(
 
 @mcp_error_boundary
 async def _task_add_note(ctx: Context, note: str, task_id: str | None = None) -> dict:
+    """Append a timestamped reasoning note to a task scratchpad.
+
+    Use this for durable agent notes, not for status changes.
+    """
     app = get_context(ctx)
     resolved_task_id = _resolve_task_id(ctx, task_id)
     await app.client.tasks.add_note(resolved_task_id, note)
@@ -269,6 +285,7 @@ async def _task_add_note(ctx: Context, note: str, task_id: str | None = None) ->
 
 @mcp_error_boundary
 async def _task_search(ctx: Context, query: str) -> dict:
+    """Search tasks by free-text query within the active project."""
     app = get_context(ctx)
     tasks = await app.client.tasks.search(query)
     return {"tasks": [_task_to_dict(t) for t in tasks]}
@@ -284,6 +301,10 @@ async def _task_events(
     max_payload_bytes: int = 16384,
     max_total_bytes: int = 262144,
 ) -> dict:
+    """Fetch paginated execution events for a task.
+
+    Use payload flags to inspect logs while keeping responses bounded for agent context.
+    """
     app = get_context(ctx)
     resolved_task_id = _resolve_task_id(ctx, task_id)
     safe_limit = _clamp_int(limit, minimum=1, maximum=200)
@@ -362,6 +383,10 @@ async def _tasks_wait(
     wait_for_status: list[str] | str | None = None,
     resolve_when_any: bool = False,
 ) -> dict:
+    """Wait for tasks to reach completion or target statuses.
+
+    Use this to gate dependent work or synchronize concurrent agents.
+    """
     app = get_context(ctx)
     resolved_task_ids = _resolve_task_ids(ctx, task_ids)
     statuses = _parse_wait_for_task_statuses(wait_for_status)
@@ -438,12 +463,14 @@ async def _tasks_wait(
 
 @mcp_error_boundary
 async def _task_counts(ctx: Context) -> dict:
+    """Return task counts grouped by board status."""
     app = get_context(ctx)
     return await app.client.tasks.counts()
 
 
 @mcp_error_boundary
 async def _task_delete(ctx: Context, task_id: str) -> dict:
+    """Delete a task permanently."""
     app = get_context(ctx)
     await app.client.tasks.delete(task_id)
     return {"task_id": task_id, "deleted": True}


### PR DESCRIPTION
## Summary
- add concise docstrings for MCP tools that Glama was rendering without descriptions
- cover task, session, project, review, settings, persona preset, and prompt handlers
- keep descriptions short and action-oriented so agent clients can understand when to call each capability

## Validation
- `python -m compileall src/kagan/mcp`
- AST check confirming the exported handlers patched in this change now have docstrings