### PR TITLE
fix: wire repo_id for multi-repo project support

### DIFF
--- a/packages/web/src/components/layout/context-bar.tsx
+++ b/packages/web/src/components/layout/context-bar.tsx
@@ -4,7 +4,7 @@ import { useSetAtom } from 'jotai';
 import { toast } from 'sonner';
 import { apiClient } from '@/lib/api/client';
 import type { WireProject, WireRepository } from '@/lib/api/types';
-import { projectSwitchVersionAtom } from '@/lib/atoms/board';
+import { boardRepoFilterAtom, projectSwitchVersionAtom } from '@/lib/atoms/board';
 import { CreateProjectDialog } from '@/components/layout/create-project-dialog';
 import { AddRepoDialog } from '@/components/layout/add-repo-dialog';
 import { Button } from '@/components/ui/button';
@@ -42,6 +42,7 @@ export function ContextBar() {
   const [deleteRepoOpen, setDeleteRepoOpen] = useState(false);
 
   const bumpProjectVersion = useSetAtom(projectSwitchVersionAtom);
+  const setRepoFilter = useSetAtom(boardRepoFilterAtom);
 
   const activeProject = projects.find((p) => p.active) ?? null;
   const activeRepo = repos.find((r) => r.selected) ?? null;
@@ -137,11 +138,13 @@ export function ContextBar() {
       try {
         await apiClient.selectProjectRepo(activeProject.id, repoId);
         await loadRepos(activeProject.id);
+        setRepoFilter(repoId);
+        bumpProjectVersion((v) => v + 1);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to select repo');
       }
     },
-    [activeProject, loadRepos],
+    [activeProject, loadRepos, setRepoFilter, bumpProjectVersion],
   );
 
   const handleProjectCreated = useCallback(

--- a/packages/web/src/lib/api/client.ts
+++ b/packages/web/src/lib/api/client.ts
@@ -139,9 +139,12 @@ export class KaganApiClient {
 
   // -- Tasks ----------------------------------------------------------------
 
-  /** GET /api/tasks?status=... */
-  async getTasks(status?: TaskStatus): Promise<WireTask[]> {
-    const query = status ? `?status=${encodeURIComponent(status)}` : '';
+  /** GET /api/tasks?status=...&repo_id=... */
+  async getTasks(status?: TaskStatus, repoId?: string): Promise<WireTask[]> {
+    const params = new URLSearchParams();
+    if (status) params.set('status', status);
+    if (repoId) params.set('repo_id', repoId);
+    const query = params.toString() ? `?${params.toString()}` : '';
     return this.request<WireTask[]>(`/api/tasks${query}`);
   }
 

--- a/packages/web/src/lib/api/generated-wire-types.ts
+++ b/packages/web/src/lib/api/generated-wire-types.ts
@@ -28,6 +28,7 @@ export interface TaskResponse {
   status: string;
   priority: string;
   base_branch?: string | null;
+  repo_id?: string | null;
   acceptance_criteria?: string[];
   agent_backend?: string | null;
   launcher?: string | null;

--- a/packages/web/src/lib/api/types.ts
+++ b/packages/web/src/lib/api/types.ts
@@ -82,6 +82,7 @@ export interface CreateTaskInput {
     acceptance_criteria?: string[];
     agent_backend?: string;
     launcher?: string;
+    repo_id?: string;
 }
 
 export interface CreateChatSessionInput {

--- a/packages/web/src/lib/atoms/board.test.ts
+++ b/packages/web/src/lib/atoms/board.test.ts
@@ -79,6 +79,7 @@ describe('board atoms', () => {
       query: 'query',
       status: 'DONE',
       sort: 'recent',
+      repoId: null,
     });
   });
 
@@ -87,6 +88,7 @@ describe('board atoms', () => {
       query: 'login',
       status: 'IN_PROGRESS',
       sort: 'priority',
+      repoId: 'some-repo',
     });
 
     store.set(resetBoardFiltersAtom);
@@ -95,6 +97,7 @@ describe('board atoms', () => {
       query: '',
       status: 'ALL',
       sort: 'default',
+      repoId: null,
     });
   });
 

--- a/packages/web/src/lib/atoms/board.ts
+++ b/packages/web/src/lib/atoms/board.ts
@@ -10,6 +10,7 @@ export interface BoardFilters {
   query: string;
   status: TaskStatus | 'ALL';
   sort: SortOption;
+  repoId: string | null;
 }
 
 function createEmptyGroups(): TaskGroups {
@@ -27,6 +28,7 @@ export const boardFiltersAtom = atom<BoardFilters>({
   query: '',
   status: 'ALL',
   sort: 'default',
+  repoId: null,
 });
 export const searchQueryAtom = atom(
   (get) => get(boardFiltersAtom).query,
@@ -40,11 +42,16 @@ export const boardSortAtom = atom(
   (get) => get(boardFiltersAtom).sort,
   (_get, set, value: SortOption) => set(boardFiltersAtom, (prev) => ({ ...prev, sort: value })),
 );
+export const boardRepoFilterAtom = atom(
+  (get) => get(boardFiltersAtom).repoId,
+  (_get, set, value: string | null) => set(boardFiltersAtom, (prev) => ({ ...prev, repoId: value })),
+);
 export const resetBoardFiltersAtom = atom(null, (_get, set) => {
   set(boardFiltersAtom, {
     query: '',
     status: 'ALL',
     sort: 'default',
+    repoId: null,
   });
 });
 
@@ -96,7 +103,7 @@ function sortTasks(tasks: WireTask[], sort: SortOption): WireTask[] {
 
 export const filteredGroupedTasksAtom = atom((get) => {
   const grouped = get(groupedTasksAtom);
-  const { query, status: statusFilter, sort } = get(boardFiltersAtom);
+  const { query, status: statusFilter, sort, repoId } = get(boardFiltersAtom);
   const normalizedQuery = query.toLowerCase().trim();
 
   const result = createEmptyGroups();
@@ -107,20 +114,22 @@ export const filteredGroupedTasksAtom = atom((get) => {
     }
     const filtered = grouped[status].filter(
       (task) =>
-        !normalizedQuery ||
-        task.title.toLowerCase().includes(normalizedQuery) ||
-        task.description?.toLowerCase().includes(normalizedQuery),
+        (!normalizedQuery ||
+          task.title.toLowerCase().includes(normalizedQuery) ||
+          task.description?.toLowerCase().includes(normalizedQuery)) &&
+        (!repoId || task.repo_id === repoId),
     );
     result[status] = sortTasks(filtered, sort);
   }
   return result;
 });
 
-export const fetchTasksAtom = atom(null, async (_get, set) => {
+export const fetchTasksAtom = atom(null, async (get, set) => {
   set(boardLoadingAtom, true);
   set(boardErrorAtom, null);
   try {
-    const tasks = await apiClient.getTasks();
+    const { repoId } = get(boardFiltersAtom);
+    const tasks = await apiClient.getTasks(undefined, repoId ?? undefined);
     set(tasksAtom, tasks);
   } catch (error) {
     set(boardErrorAtom, error instanceof Error ? error.message : 'Failed to load board');

--- a/src/kagan/cli/chat/_chat_ui.py
+++ b/src/kagan/cli/chat/_chat_ui.py
@@ -110,6 +110,15 @@ def print_project_info(*, project_name: str | None, project_id: str | None) -> N
         _console.print("[dim]No active project.[/dim]")
 
 
+def print_repo_info(*, repo_name: str | None, repo_id: str | None) -> None:
+    """Render /repo info."""
+    if repo_name:
+        _console.print(f"[bold]Repo:[/bold] {repo_name}")
+        _console.print(f"[dim]ID:[/dim] {repo_id or 'unknown'}")
+    else:
+        _console.print("[dim]No repo selected.[/dim]")
+
+
 def print_session_list(items: list[Any]) -> None:
     """Render a table of sessions for non-interactive terminals."""
     table = Table(box=None, show_header=False, pad_edge=False)

--- a/src/kagan/cli/chat/commands.py
+++ b/src/kagan/cli/chat/commands.py
@@ -54,6 +54,8 @@ class SlashAction(Enum):
     SWITCH_PROJECT = "switch_project"
     SHOW_PROJECT = "show_project"
     SHOW_INFO = "show_info"
+    SWITCH_REPO = "switch_repo"
+    SHOW_REPO = "show_repo"
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,6 +77,8 @@ class SlashCommandOutcome:
     status_requested: bool = False
     project_switch_requested: str | None = None
     project_info_requested: bool = False
+    repo_switch_requested: str | None = None
+    repo_info_requested: bool = False
     action: SlashAction = SlashAction.NONE
     data: str | None = None
 
@@ -231,6 +235,19 @@ def _handle_project(
     )
 
 
+def _handle_repo(
+    invocation: SlashCommandInvocation, _ctx: _SlashCommandContext
+) -> SlashCommandOutcome:
+    arg = invocation.arg.strip()
+    if arg:
+        return SlashCommandOutcome(
+            handled=True, repo_switch_requested=arg, action=SlashAction.SWITCH_REPO, data=arg
+        )
+    return SlashCommandOutcome(
+        handled=True, repo_info_requested=True, action=SlashAction.SHOW_REPO
+    )
+
+
 def _handle_delete(
     invocation: SlashCommandInvocation, _ctx: _SlashCommandContext
 ) -> SlashCommandOutcome:
@@ -341,6 +358,11 @@ def _build_slash_command_registry() -> SlashCommandRegistry:
         name="project",
         description="Show or switch active project",
         handler=_handle_project,
+    )
+    registry.register(
+        name="repo",
+        description="Show or switch active repo",
+        handler=_handle_repo,
     )
     registry.register(
         name="delete",

--- a/src/kagan/cli/chat/controller.py
+++ b/src/kagan/cli/chat/controller.py
@@ -25,6 +25,7 @@ from kagan.cli.chat._chat_ui import (
     build_session_picker_option,
     print_help_documentation,
     print_project_info,
+    print_repo_info,
     print_restored_messages,
     print_session_list,
     print_status_panel,
@@ -128,6 +129,8 @@ class ChatController:
         self._session_title: str | None = None
         self._title_task: asyncio.Task[None] | None = None
         self._project_name: str | None = None
+        self._selected_repo_id: str | None = None
+        self._selected_repo_name: str | None = None
         self._watcher = DBWatcher(client)
 
     # ------------------------------------------------------------------
@@ -364,6 +367,7 @@ class ChatController:
         if project is not None:
             await self.client.projects.set_active(project.id)
             self._project_name = project.name
+            await self._auto_select_repo(project.id)
             return True
 
         # 2. Try to match by git root.
@@ -377,12 +381,15 @@ class ChatController:
                     if Path(repo.path).expanduser().resolve() == resolved_git_root:
                         await self.client.projects.set_active(proj.id)
                         await self._refresh_project_name()
+                        await self._auto_select_repo(proj.id)
                         return True
 
         # 3. No match — bootstrap a new project for this CWD.
         result = await self._bootstrap_project()
         if result:
             await self._refresh_project_name()
+            if self.client.active_project_id:
+                await self._auto_select_repo(self.client.active_project_id)
         return result
 
     async def _refresh_project_name(self) -> None:
@@ -393,6 +400,15 @@ class ChatController:
                 self._project_name = p.name
                 return
         self._project_name = None
+
+    async def _auto_select_repo(self, project_id: str) -> None:
+        repos = await self.client.projects.repos(project_id)
+        if len(repos) == 1:
+            self._selected_repo_id = repos[0].id
+            self._selected_repo_name = repos[0].name
+        else:
+            self._selected_repo_id = None
+            self._selected_repo_name = None
 
     async def _bootstrap_project(self) -> bool:
         cwd = Path.cwd()
@@ -954,6 +970,13 @@ class ChatController:
                 )
             case SlashAction.SWITCH_PROJECT:
                 await self._switch_project(result.data or result.project_switch_requested or "")
+            case SlashAction.SWITCH_REPO:
+                await self._switch_repo(result.data or result.repo_switch_requested or "")
+            case SlashAction.SHOW_REPO:
+                print_repo_info(
+                    repo_name=self._selected_repo_name,
+                    repo_id=self._selected_repo_id,
+                )
             case SlashAction.CLOSE:
                 return True
             case _:
@@ -977,6 +1000,27 @@ class ChatController:
         self._project_name = target.name
         _TOOLBAR_STATE.project_name = target.name
         _console.print(f"[green]Switched to project:[/green] {target.name}")
+        await self._auto_select_repo(target.id)
+
+    async def _switch_repo(self, name: str) -> None:
+        if not self.client.active_project_id:
+            _console.print("[red]No active project.[/red]")
+            return
+        repos = await self.client.projects.repos(self.client.active_project_id)
+        target = None
+        for r in repos:
+            if r.name.casefold() == name.casefold() or r.id == name:
+                target = r
+                break
+        if target is None:
+            _console.print(f"[red]Repo not found:[/red] {name}")
+            available = ", ".join(r.name for r in repos)
+            if available:
+                _console.print(f"[dim]Available repos:[/dim] {available}")
+            return
+        self._selected_repo_id = target.id
+        self._selected_repo_name = target.name
+        _console.print(f"[green]Switched to repo:[/green] {target.name}")
 
     async def _switch_agent(self, new_backend: str) -> bool:
         if new_backend == self.agent_backend:

--- a/src/kagan/core/_tasks.py
+++ b/src/kagan/core/_tasks.py
@@ -109,11 +109,12 @@ async def create_task(
         raise NotFoundError("Project", project_id)
 
     if repo_id is not None:
-        repo_ok = await _db_async(
-            engine,
-            lambda s: s.get(Repository, repo_id) is not None
-            and getattr(s.get(Repository, repo_id), "project_id", None) == project_id,
-        )
+
+        def _check_repo(s: Any) -> bool:
+            repo = s.get(Repository, repo_id)
+            return repo is not None and repo.project_id == project_id
+
+        repo_ok = await _db_async(engine, _check_repo)
         if not repo_ok:
             raise NotFoundError("Repository", repo_id)
 

--- a/src/kagan/core/_tasks.py
+++ b/src/kagan/core/_tasks.py
@@ -25,7 +25,16 @@ from kagan.core._transitions import validate_move
 from kagan.core._utils import utc_iso
 from kagan.core.enums import Priority, SessionEventType, SessionStatus, TaskStatus
 from kagan.core.errors import KaganError, NotFoundError, SessionError
-from kagan.core.models import AuditEntry, Project, Session, SessionEvent, Task, TaskNote, Worktree
+from kagan.core.models import (
+    AuditEntry,
+    Project,
+    Repository,
+    Session,
+    SessionEvent,
+    Task,
+    TaskNote,
+    Worktree,
+)
 
 if TYPE_CHECKING:
     from kagan.core.client import KaganCore
@@ -71,6 +80,7 @@ async def create_task(
     acceptance_criteria: list[str] | None = None,
     agent_backend: str | None = None,
     launcher: str | None = None,
+    repo_id: str | None = None,
     active_project_id: str | None = None,
     events: Events | None = None,
     on_stale_project: Any = None,
@@ -98,6 +108,15 @@ async def create_task(
             on_stale_project(project_id)
         raise NotFoundError("Project", project_id)
 
+    if repo_id is not None:
+        repo_ok = await _db_async(
+            engine,
+            lambda s: s.get(Repository, repo_id) is not None
+            and getattr(s.get(Repository, repo_id), "project_id", None) == project_id,
+        )
+        if not repo_ok:
+            raise NotFoundError("Repository", repo_id)
+
     task = Task(
         project_id=project_id,
         title=title,
@@ -107,6 +126,7 @@ async def create_task(
         acceptance_criteria=acceptance_criteria or [],
         agent_backend=agent_backend,
         launcher=launcher,
+        repo_id=repo_id,
     )
 
     def op(s):
@@ -150,12 +170,15 @@ async def list_tasks(
     *,
     status: TaskStatus | None = None,
     project_id: str | None = None,
+    repo_id: str | None = None,
 ) -> list[Task]:
     if project_id is None:
         raise SessionError(None, "No active project. Call client.projects.set_active() first.")
     stmt = select(Task).where(Task.project_id == project_id)
     if status is not None:
         stmt = stmt.where(Task.status == status)
+    if repo_id is not None:
+        stmt = stmt.where(Task.repo_id == repo_id)
     return await _db_async(engine, lambda s: list(s.exec(stmt).all()))
 
 
@@ -170,6 +193,7 @@ async def update_task(
     acceptance_criteria: builtins.list[str] | None = None,
     agent_backend: str | None = None,
     launcher: str | None | object = _UNSET,
+    repo_id: str | None | object = _UNSET,
     events: Events | None = None,
 ) -> Task:
     task = await get_task(engine, task_id)
@@ -181,6 +205,7 @@ async def update_task(
         "acceptance_criteria": acceptance_criteria,
         "agent_backend": agent_backend,
         "launcher": launcher,
+        "repo_id": repo_id,
     }
     changed_fields: dict[str, object] = {}
 
@@ -194,6 +219,12 @@ async def update_task(
             if field == "launcher":
                 db_task.launcher = value if isinstance(value, str) else None
                 changed_fields["launcher"] = _serialize_value(
+                    value if isinstance(value, str) else None
+                )
+                continue
+            if field == "repo_id":
+                db_task.repo_id = value if isinstance(value, str) else None
+                changed_fields["repo_id"] = _serialize_value(
                     value if isinstance(value, str) else None
                 )
                 continue
@@ -612,6 +643,7 @@ class Tasks:
         acceptance_criteria: list[str] | None = None,
         agent_backend: str | None = None,
         launcher: str | None = None,
+        repo_id: str | None = None,
     ) -> Task:
         return await create_task(
             self._engine,
@@ -622,6 +654,7 @@ class Tasks:
             acceptance_criteria=acceptance_criteria,
             agent_backend=agent_backend,
             launcher=launcher,
+            repo_id=repo_id,
             active_project_id=self._require_project(),
             events=self.events,
             on_stale_project=self._clear_stale_active_project,
@@ -634,8 +667,11 @@ class Tasks:
         self,
         *,
         status: TaskStatus | None = None,
+        repo_id: str | None = None,
     ) -> list[Task]:
-        return await list_tasks(self._engine, status=status, project_id=self._require_project())
+        return await list_tasks(
+            self._engine, status=status, project_id=self._require_project(), repo_id=repo_id
+        )
 
     async def update(
         self,
@@ -648,6 +684,7 @@ class Tasks:
         acceptance_criteria: builtins.list[str] | None = None,
         agent_backend: str | None = None,
         launcher: str | None | object = _UNSET,
+        repo_id: str | None | object = _UNSET,
     ) -> Task:
         return await update_task(
             self._engine,
@@ -659,6 +696,7 @@ class Tasks:
             acceptance_criteria=acceptance_criteria,
             agent_backend=agent_backend,
             launcher=launcher,
+            repo_id=repo_id,
             events=self.events,
         )
 

--- a/src/kagan/core/_worktrees.py
+++ b/src/kagan/core/_worktrees.py
@@ -143,9 +143,14 @@ async def create_worktree(
     repos = await get_repos_fn(project_id)
     if not repos:
         raise SessionError(None, f"No repos linked to project {project_id!r}.")
-    if len(repos) != 1:
+    if task.repo_id is not None:
+        repo = next((r for r in repos if r.id == task.repo_id), None)
+        if repo is None:
+            raise SessionError(None, f"Repo {task.repo_id!r} not found in project {project_id!r}.")
+    elif len(repos) == 1:
+        repo = repos[0]
+    else:
         raise MultiRepoUnsupportedError(len(repos))
-    repo = repos[0]
 
     if not await git.is_git_repo(repo.path):
         raise WorktreeError(f"Not a git repository: {repo.path}")

--- a/src/kagan/core/adapters/db/migrations/versions/a1b2c3d4e5f6_add_repo_id_to_tasks.py
+++ b/src/kagan/core/adapters/db/migrations/versions/a1b2c3d4e5f6_add_repo_id_to_tasks.py
@@ -1,0 +1,29 @@
+"""add repo_id to tasks"""
+
+import sqlalchemy as sa
+import sqlmodel.sql.sqltypes
+from alembic import op
+from sqlalchemy import inspect as sa_inspect
+
+
+revision = 'a1b2c3d4e5f6'
+down_revision = '10d186827872'
+branch_labels = None
+depends_on = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    cols = {c["name"] for c in sa_inspect(conn).get_columns(table)}
+    return column in cols
+
+
+def upgrade() -> None:
+    if not _has_column("tasks", "repo_id"):
+        op.add_column('tasks', sa.Column('repo_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+        op.create_index(op.f('ix_tasks_repo_id'), 'tasks', ['repo_id'])
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_tasks_repo_id'), 'tasks')
+    op.drop_column('tasks', 'repo_id')

--- a/src/kagan/core/adapters/db/migrations/versions/a1b2c3d4e5f6_add_repo_id_to_tasks.py
+++ b/src/kagan/core/adapters/db/migrations/versions/a1b2c3d4e5f6_add_repo_id_to_tasks.py
@@ -25,5 +25,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(op.f('ix_tasks_repo_id'), 'tasks')
-    op.drop_column('tasks', 'repo_id')
+    if _has_column('tasks', 'repo_id'):
+        op.drop_index(op.f('ix_tasks_repo_id'), 'tasks')
+        op.drop_column('tasks', 'repo_id')

--- a/src/kagan/core/errors.py
+++ b/src/kagan/core/errors.py
@@ -25,7 +25,7 @@ class WorktreeError(KaganError):
 
 class MultiRepoUnsupportedError(WorktreeError):
     code = "MULTI_REPO_UNSUPPORTED"
-    hint = "Link exactly one repository to the project."
+    hint = "Specify repo_id on the task, or link exactly one repository to the project."
 
     def __init__(self, repo_count: int) -> None:
         self.repo_count = repo_count

--- a/src/kagan/core/models.py
+++ b/src/kagan/core/models.py
@@ -53,6 +53,7 @@ class Task(SQLModel, table=True):
 
     id: str = Field(default_factory=_new_id, primary_key=True)
     project_id: str = Field(foreign_key="projects.id", index=True)
+    repo_id: str | None = Field(default=None, foreign_key="repos.id", index=True)
     title: str = Field(index=True)
     description: str = Field(default="")
     status: TaskStatus = Field(default=TaskStatus.BACKLOG, index=True)

--- a/src/kagan/server/_task_routes.py
+++ b/src/kagan/server/_task_routes.py
@@ -90,7 +90,8 @@ def register_task_routes(mcp: FastMCP) -> None:
     async def list_tasks(request: Request, *, ctx: Any) -> JSONResponse:
         status_value = request.query_params.get("status")
         status_enum = TaskStatus(status_value) if status_value else None
-        tasks = await ctx.client.tasks.list(status=status_enum)
+        repo_id = request.query_params.get("repo_id") or None
+        tasks = await ctx.client.tasks.list(status=status_enum, repo_id=repo_id)
         runtime = await ctx.client.tasks.runtime_summaries([task.id for task in tasks])
         return _ok([task_to_wire_dict(task, runtime=runtime.get(task.id)) for task in tasks])
 
@@ -112,6 +113,7 @@ def register_task_routes(mcp: FastMCP) -> None:
             acceptance_criteria=body.acceptance_criteria,
             agent_backend=body.agent_backend,
             launcher=body.launcher,
+            repo_id=body.repo_id,
         )
         runtime = await ctx.client.tasks.runtime_summary(task.id)
         return _ok(task_to_wire_dict(task, runtime=runtime))

--- a/src/kagan/server/mcp/toolsets/tasks.py
+++ b/src/kagan/server/mcp/toolsets/tasks.py
@@ -23,6 +23,7 @@ class _BatchTaskEntry(TypedDict, total=False):
     acceptance_criteria: list[str] | None
     agent_backend: str | None
     launcher: str | None
+    repo_id: str | None
 
 
 def _resolve_task_id(ctx: Context, task_id: str | None) -> str:
@@ -54,6 +55,7 @@ def _task_to_dict(task: Any) -> dict[str, Any]:
         "acceptance_criteria": getattr(task, "acceptance_criteria", []),
         "agent_backend": getattr(task, "agent_backend", None),
         "launcher": getattr(task, "launcher", None),
+        "repo_id": getattr(task, "repo_id", None),
         "review_approved": getattr(task, "review_approved", False),
         "review_verdicts": getattr(task, "review_verdicts", []) or [],
     }
@@ -176,14 +178,14 @@ async def _task_get(ctx: Context, task_id: str | None = None) -> dict:
 
 
 @mcp_error_boundary
-async def _task_list(ctx: Context, status: str | None = None) -> dict:
-    """List tasks, optionally filtered by status.
+async def _task_list(ctx: Context, status: str | None = None, repo_id: str | None = None) -> dict:
+    """List tasks, optionally filtered by status and/or repo.
 
     Use this to inspect project state before planning or mutating work.
     """
     app = get_context(ctx)
     status_enum = TaskStatus(status) if status else None
-    tasks = await app.client.tasks.list(status=status_enum)
+    tasks = await app.client.tasks.list(status=status_enum, repo_id=repo_id)
     result_tasks = [_task_to_dict(t) for t in tasks]
     if app.bound_session_id is not None:
         for t in result_tasks:
@@ -201,6 +203,7 @@ async def _task_create(
     acceptance_criteria: list[str] | None = None,
     agent_backend: str | None = None,
     launcher: str | None = None,
+    repo_id: str | None = None,
 ) -> dict:
     """Create a task on the active board.
 
@@ -216,6 +219,7 @@ async def _task_create(
         acceptance_criteria=acceptance_criteria,
         agent_backend=agent_backend,
         launcher=launcher,
+        repo_id=repo_id,
     )
     result = _task_to_dict(task)
     if app.bound_session_id is not None:
@@ -235,6 +239,7 @@ async def _task_update(
     agent_backend: str | None = None,
     launcher: str | None = None,
     status: str | None = None,
+    repo_id: str | None = None,
 ) -> dict:
     """Update task fields or transition task status.
 
@@ -253,6 +258,7 @@ async def _task_update(
         acceptance_criteria=acceptance_criteria,
         agent_backend=agent_backend,
         launcher=launcher,
+        repo_id=repo_id,
     )
     if status_enum is not None:
         task = await app.client.tasks.set_status(resolved_task_id, status_enum)
@@ -505,6 +511,7 @@ async def _task_batch_create(ctx: Context, tasks: list[_BatchTaskEntry]) -> dict
                 acceptance_criteria=criteria,
                 agent_backend=entry.get("agent_backend"),
                 launcher=entry.get("launcher"),
+                repo_id=entry.get("repo_id"),
             )
             created.append(_task_to_dict(task))
         except (KaganError, ValueError, TypeError, KeyError) as exc:

--- a/src/kagan/server/requests.py
+++ b/src/kagan/server/requests.py
@@ -36,6 +36,7 @@ class CreateTaskRequest(_CriteriaMixin):
     base_branch: str | None = Field(default=None, max_length=255)
     agent_backend: str | None = Field(default=None, max_length=255)
     launcher: str | None = Field(default=None, max_length=255)
+    repo_id: str | None = Field(default=None, max_length=255)
 
 
 class UpdateTaskRequest(_CriteriaMixin):
@@ -45,6 +46,7 @@ class UpdateTaskRequest(_CriteriaMixin):
     base_branch: str | None = Field(default=None, max_length=255)
     agent_backend: str | None = Field(default=None, max_length=255)
     launcher: str | None = Field(default=None, max_length=255)
+    repo_id: str | None = Field(default=None, max_length=255)
 
 
 class UpdateTaskStatusRequest(BaseModel):

--- a/src/kagan/server/responses.py
+++ b/src/kagan/server/responses.py
@@ -85,6 +85,7 @@ class TaskResponse(_OrmBase):
     status: str
     priority: str
     base_branch: str | None = None
+    repo_id: str | None = None
     acceptance_criteria: list[str] = Field(default_factory=list)
     agent_backend: str | None = None
     launcher: str | None = None

--- a/src/kagan/tui/screens/kanban.py
+++ b/src/kagan/tui/screens/kanban.py
@@ -379,7 +379,7 @@ class KanbanScreen(Screen[None]):
         self._update_review_queue_hint()
 
     async def _reload_tasks(self) -> None:
-        tasks = await self.kagan_app.core.tasks.list()
+        tasks = await self.kagan_app.core.tasks.list(repo_id=self.kagan_app.selected_repo_id)
         if not self.is_mounted:
             return
         self._all_tasks = sorted(

--- a/tests/core/test_db_migrations.py
+++ b/tests/core/test_db_migrations.py
@@ -311,7 +311,7 @@ def test_known_legacy_alembic_revision_is_remapped_to_head(tmp_path: Path) -> No
         conn = sqlite3.connect(db_path)
         try:
             head = conn.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert head == ("10d186827872",)
+            assert head == ("a1b2c3d4e5f6",)
         finally:
             conn.close()
     finally:

--- a/tests/core/test_sessions_attached.py
+++ b/tests/core/test_sessions_attached.py
@@ -61,6 +61,45 @@ async def test_attached_rejects_multi_repo_projects_explicitly(tmp_path) -> None
         await driver.teardown()
 
 
+async def test_multi_repo_workspace_succeeds_when_task_has_repo_id(tmp_path) -> None:
+    """Multi-repo project: task with explicit repo_id provisions worktree correctly."""
+    repo_one = tmp_path / "repo-one"
+    repo_two = tmp_path / "repo-two"
+    await make_git_repo(repo_one, base_branch="main")
+    await make_git_repo(repo_two, base_branch="main")
+
+    driver = await KaganDriver.boot(tmp_path)
+    try:
+        await driver.create_project("Multi Repo OK", repo_path=str(repo_one))
+        repo_two_id = await driver.add_repo(repo_two)
+        task = await driver.create_task(
+            "Task targeting repo two", launcher="tmux", repo_id=repo_two_id
+        )
+        assert task.repo_id == repo_two_id
+
+        ws_id = await driver.provision_workspace(task.id)
+        assert ws_id is not None
+    finally:
+        await driver.teardown()
+
+
+async def test_single_repo_auto_resolves_without_repo_id(tmp_path) -> None:
+    """Single-repo project: task without repo_id auto-resolves to the only repo."""
+    repo = tmp_path / "solo-repo"
+    await make_git_repo(repo, base_branch="main")
+
+    driver = await KaganDriver.boot(tmp_path)
+    try:
+        await driver.create_project("Solo Repo", repo_path=str(repo))
+        task = await driver.create_task("Auto-resolve task", launcher="tmux")
+        assert task.repo_id is None
+
+        ws_id = await driver.provision_workspace(task.id)
+        assert ws_id is not None
+    finally:
+        await driver.teardown()
+
+
 async def test_attached_with_workspace_creates_session(git_board: KaganDriver) -> None:
     task = await git_board.create_task("Attached Session Task", launcher="tmux")
     await git_board.move_task(task.id, TaskStatus.IN_PROGRESS)

--- a/tests/helpers/core_driver.py
+++ b/tests/helpers/core_driver.py
@@ -44,6 +44,7 @@ class TaskView:
     acceptance_criteria: list[str]
     project_id: str
     launcher: str | None = None
+    repo_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,6 +170,7 @@ class CoreDriver:
         base_branch: str | None = None,
         agent_backend: str | None = None,
         launcher: str | None = None,
+        repo_id: str | None = None,
     ) -> TaskView:
         """Create a task and return its view."""
         # If a specific project_id is requested, temporarily switch active project
@@ -184,6 +186,7 @@ class CoreDriver:
             acceptance_criteria=acceptance_criteria,
             agent_backend=agent_backend,
             launcher=launcher,
+            repo_id=repo_id,
         )
 
         # Restore original active project if we switched
@@ -508,6 +511,7 @@ class CoreDriver:
             base_branch=task.base_branch,
             acceptance_criteria=task.acceptance_criteria or [],
             project_id=task.project_id,
+            repo_id=getattr(task, "repo_id", None),
         )
 
 

--- a/tests/helpers/driver.py
+++ b/tests/helpers/driver.py
@@ -143,6 +143,7 @@ class KaganDriver:
         base_branch: str | None = None,
         agent_backend: str | None = None,
         launcher: str | None = None,
+        repo_id: str | None = None,
     ) -> TaskView:
         """Create a task in the current project."""
         return await self._driver.create_task(
@@ -153,6 +154,7 @@ class KaganDriver:
             base_branch=base_branch,
             agent_backend=agent_backend,
             launcher=launcher,
+            repo_id=repo_id,
         )
 
     async def get_task(self, task_id: str) -> TaskView:

--- a/tests/server/test_integration.py
+++ b/tests/server/test_integration.py
@@ -22,7 +22,7 @@ class _FakeTasksClient:
         self._seq = 0
         self._tasks: dict[str, Any] = {}
 
-    async def list(self, status: TaskStatus | None = None) -> list[Any]:
+    async def list(self, status: TaskStatus | None = None, repo_id: str | None = None) -> list[Any]:
         tasks = list(self._tasks.values())
         if status is None:
             return tasks
@@ -38,6 +38,7 @@ class _FakeTasksClient:
         acceptance_criteria: list[str] | None = None,
         agent_backend: str | None = None,
         launcher: str | None = None,
+        repo_id: str | None = None,
     ) -> Any:
         self._seq += 1
         task = Task(
@@ -51,6 +52,7 @@ class _FakeTasksClient:
             acceptance_criteria=acceptance_criteria or [],
             agent_backend=agent_backend,
             launcher=launcher,
+            repo_id=repo_id,
             review_approved=False,
         )
         self._tasks[task.id] = task

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -118,6 +118,7 @@ def test_slash_command_registry_is_canonical() -> None:
         "help",
         "new",
         "project",
+        "repo",
         "sessions",
         "status",
         "tool",


### PR DESCRIPTION
## Summary

- Add optional `repo_id` field to Task model with DB migration, enabling tasks to target specific repos in multi-repo projects
- Fix `create_worktree()` to use `task.repo_id` for repo selection instead of hard-failing with `MultiRepoUnsupportedError`
- Surface `repo_id` through MCP tools (`task_create`, `task_batch_create`, `task_list`), HTTP API (routes, requests, responses), web frontend (board filtering via repo selector), TUI (kanban reload on repo switch), and chat CLI (new `/repo` command)

## Test plan

- [x] `uv run poe lint` — all checks passed
- [x] `uv run poe typecheck` — 0 errors
- [x] `uv run pytest tests/ -m "not snapshot" -n auto` — 1111 passed
- [x] `pnpm run web:test` — 155 passed (31 test files)
- [ ] Smoke: create 2-repo project, create task with `repo_id`, verify `run_start` uses correct repo worktree
- [ ] Verify single-repo projects still auto-resolve without `repo_id`