### PR TITLE
feat: selective GitHub issue import with preview workflow

### DIFF
--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -19,37 +19,74 @@ Kagan has built-in GitHub issue import. Bring existing issues onto your board in
 
 ## Import in the TUI
 
+GitHub import uses a two-step flow:
+
+**Step 1 — Filter:**
+
 1. Open your project board in `kagan`
 1. Open Actions with `.`
 1. Run `github import`
 1. Enter your repository in `owner/repo` format
 1. Choose issue state (`open`, `closed`, or `all`)
-1. Press `Enter` to import
+1. Optionally enter comma-separated labels to filter by (e.g. `bug, feature`)
+1. Optionally set a limit (default 100)
+1. Press `Enter` to preview matching issues
+
+**Step 2 — Select:**
+
+1. Review the list of matching issues — already-synced ones are shown with `(synced)` and deselected by default
+1. Use `Space` to toggle individual issues, `a` to select all, `n` to deselect all
+1. Press `Enter` to import selected issues, or `Esc` to go back and adjust filters
 
 Kagan shows a summary with created, skipped, and error counts.
 
-## Import from CLI
+## Preview before import
+
+See what issues match your filters before committing to the import:
 
 ```bash
-kagan import github --repo octocat/hello-world
+kagan plugins preview github --repo octocat/hello-world
 ```
 
 Optional flags:
 
 - `--state open|closed|all`
-- `--label <label>` to import only matching issues
-- `--yes` to skip confirmation
+- `--label <label>` (repeatable) — filter by one or more labels
+- `--limit <n>` — cap the number of issues returned (default 100)
 
-If you omit `--repo`, Kagan prompts for it interactively.
+Output shows issue number, title, state, labels, and whether the issue is already synced.
+
+## Import from CLI
+
+```bash
+kagan plugins sync github --repo octocat/hello-world
+```
+
+Optional flags:
+
+- `--state open|closed|all`
+- `--label <label>` (repeatable) — filter by one or more labels
+- `--limit <n>` — max issues to fetch (default 100)
+- `--issues 1,2,42` — import only specific issue numbers
+
+Examples:
+
+```bash
+# Import only bug issues
+kagan plugins sync github --repo octocat/hello-world --label bug
+
+# Import multiple label filters
+kagan plugins sync github --repo octocat/hello-world --label bug --label priority:high
+
+# Import specific issues by number
+kagan plugins sync github --repo octocat/hello-world --issues 12,34,56
+```
 
 ## Label mapping
 
 These labels map automatically when importing:
 
 - `priority:critical`, `priority:high`, `priority:medium`, `priority:low`
-- `kagan:auto`, `kagan:pair`
-
-Legacy `kagan:auto` / `kagan:pair` labels are ignored. Imported tasks have no run style baked in; choose Start or Attach when you launch them.
 
 Other labels are kept in the task description as tags.
 

--- a/docs/internal/features/plugins.md
+++ b/docs/internal/features/plugins.md
@@ -42,11 +42,12 @@ ______________________________________________________________________
 ## 4. GitHub Import
 
 - Configure with owner/repo before sync — raises `PluginError` if not configured
-- Fetch open issues from GitHub using `gh` CLI (JSON output)
+- Fetch issues from GitHub using `gh` CLI (JSON output)
+- Supports filtering by state (`open`, `closed`, `all`), labels (multiple), and limit
+- Selective import: pass `issue_numbers` to `GitHubImportConfig` to restrict to specific issues
 - Create kagan tasks from issues: title, description (body + URL + unmapped labels)
 - Map GitHub labels to task properties:
   - `priority:critical` / `priority:high` / `priority:medium` / `priority:low` → Priority
-- `kagan:auto` / `kagan:pair` are ignored as legacy labels
 - Unmapped labels appear as `[label]` tags in description
 - Sync is idempotent: issue→task mapping persisted in settings table
 - Previously-synced issues are skipped
@@ -59,6 +60,12 @@ ______________________________________________________________________
 ## 5. CLI Commands
 
 - `kagan plugins sync <name> --repo owner/repo` — sync issues into active project
+  - `--label <label>` (repeatable) — filter by label
+  - `--limit <n>` — cap issue count (default 100)
+  - `--issues 1,2,3` — import only specific issue numbers
+- `kagan plugins preview <name> --repo owner/repo` — preview matching issues without importing
+  - `--label <label>` (repeatable) — filter by label
+  - `--limit <n>` — cap issue count (default 100)
 - `kagan plugins list` — show installed plugins with built-in/community labels
 - `kagan plugins check [name]` — run preflight checks for one or all plugins
 
@@ -67,6 +74,7 @@ ______________________________________________________________________
 ## 6. MCP Tools
 
 - `plugins_sync` (Admin tier) — sync issues via MCP, returns created/skipped/errors
+- `plugins_preview` (Readonly tier) — preview issues matching filters, returns list without importing
 - `plugins_preflight` (Readonly tier) — check plugin prerequisites, returns checks and readiness
 
 ______________________________________________________________________
@@ -78,3 +86,14 @@ ______________________________________________________________________
 - Filter preflight check results to blocking (non-pass) entries
 - Format actionable setup messages from blocking preflight checks (fix hints, descriptions)
 - Parse `owner/repo` slug from git remote URLs (HTTPS, SSH, `git@` forms) — return `None` for unsupported
+
+______________________________________________________________________
+
+## 8. Issue Preview
+
+- `preview_github_issues()` fetches issues matching config and returns `GitHubIssuePreview` dicts
+- Each preview includes: `number`, `title`, `state`, `labels`, `url`, `already_synced`
+- `already_synced` is `True` if the issue number appears in the persisted sync map
+- Preview does not create any tasks — read-only operation
+- TUI two-step flow: Phase 1 filters issues via preview, Phase 2 presents a `SelectionList` for selective import
+- Already-synced issues are shown with `(synced)` suffix and deselected by default

--- a/packages/web/src/components/board/plugin-import-dialog.tsx
+++ b/packages/web/src/components/board/plugin-import-dialog.tsx
@@ -1,14 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Download } from 'lucide-react';
+import { Download, ArrowLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { apiClient } from '@/lib/api/client';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -16,18 +12,35 @@ import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 
+interface GitHubIssuePreview {
+  number: number;
+  title: string;
+  state: string;
+  labels: string[];
+  url: string;
+  already_synced: boolean;
+}
+
 interface PluginImportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
 export function PluginImportDialog({ open, onOpenChange }: PluginImportDialogProps) {
+  // Filter state
   const [repo, setRepo] = useState('');
   const [state, setState] = useState<'open' | 'closed' | 'all'>('open');
-  const [label, setLabel] = useState('');
+  const [labels, setLabels] = useState('');
+  const [limit, setLimit] = useState(100);
   const [ready, setReady] = useState<boolean | null>(null);
   const [preflightMsg, setPreflightMsg] = useState('');
   const [detecting, setDetecting] = useState(false);
+
+  // Preview state
+  const [step, setStep] = useState<'filter' | 'select'>('filter');
+  const [issues, setIssues] = useState<GitHubIssuePreview[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [previewing, setPreviewing] = useState(false);
   const [importing, setImporting] = useState(false);
 
   const detect = useCallback(async () => {
@@ -53,36 +66,50 @@ export function PluginImportDialog({ open, onOpenChange }: PluginImportDialogPro
 
   useEffect(() => {
     if (!open) return;
-    setRepo('');
-    setState('open');
-    setLabel('');
-    setReady(null);
-    setPreflightMsg('');
+    setRepo(''); setState('open'); setLabels(''); setLimit(100);
+    setReady(null); setPreflightMsg('');
+    setStep('filter'); setIssues([]); setSelected(new Set());
     void detect();
   }, [open, detect]);
 
-  const handleImport = async () => {
-    if (!repo.trim()) {
-      toast.error('Repository slug is required');
-      return;
+  const handlePreview = async () => {
+    if (!repo.trim()) { toast.error('Repository slug is required'); return; }
+    setPreviewing(true);
+    try {
+      const result = await apiClient.previewPluginIssues('github', {
+        repo_slug: repo.trim(),
+        state,
+        labels: labels.trim() || undefined,
+        limit,
+      });
+      setIssues(result.issues);
+      // Auto-select non-synced issues
+      setSelected(new Set(result.issues.filter((i) => !i.already_synced).map((i) => i.number)));
+      setStep('select');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Preview failed');
+    } finally {
+      setPreviewing(false);
     }
+  };
+
+  const handleImport = async () => {
+    if (selected.size === 0) return;
     setImporting(true);
     try {
       const config: Record<string, unknown> = {
-        repo: repo.trim(),
+        repo_slug: repo.trim(),
         state,
+        issue_numbers: Array.from(selected),
+        limit,
       };
-      if (label.trim()) config.labels = label.trim();
+      if (labels.trim()) config.labels = labels.trim().split(',').map((l) => l.trim());
       const result = await apiClient.runPluginImport('github', config);
       const parts: string[] = [];
       if (result.created > 0) parts.push(`${result.created} created`);
-      if (result.updated > 0) parts.push(`${result.updated} updated`);
       if (result.skipped > 0) parts.push(`${result.skipped} skipped`);
       if (result.errors.length > 0) parts.push(`${result.errors.length} errors`);
       toast.success(parts.length > 0 ? parts.join(', ') : 'Import complete');
-      if (result.errors.length > 0) {
-        toast.error(result.errors.slice(0, 3).join('\n'));
-      }
       onOpenChange(false);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Import failed');
@@ -91,88 +118,115 @@ export function PluginImportDialog({ open, onOpenChange }: PluginImportDialogPro
     }
   };
 
+  const toggleIssue = (num: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(num)) next.delete(num); else next.add(num);
+      return next;
+    });
+  };
+
+  const syncedCount = issues.filter((i) => i.already_synced).length;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Download className="size-4" />
             Import from GitHub
           </DialogTitle>
           <DialogDescription>
-            Import issues from a GitHub repository as tasks.
+            {step === 'filter'
+              ? 'Configure filters, then preview matching issues.'
+              : `${issues.length} issues found${syncedCount > 0 ? ` (${syncedCount} already synced)` : ''}`}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          {/* Preflight indicator */}
-          <div className="flex items-center gap-2 text-xs">
-            {detecting ? (
-              <>
-                <Spinner className="size-3" />
-                <span className="text-[var(--muted-foreground)]">Detecting repository…</span>
-              </>
-            ) : ready === true ? (
-              <>
-                <span className="inline-block size-2 rounded-full bg-[var(--kagan-rail-running)]" />
-                <span className="text-[var(--muted-foreground)]">GitHub plugin ready</span>
-              </>
-            ) : ready === false ? (
-              <>
-                <span className="inline-block size-2 rounded-full bg-amber-500" />
-                <span className="text-[var(--muted-foreground)]">{preflightMsg}</span>
-              </>
-            ) : null}
-          </div>
-
-          {/* Repo slug */}
-          <div>
-            <Label htmlFor="plugin-repo" className="mb-1">Repository</Label>
-            <Input
-              id="plugin-repo"
-              value={repo}
-              onChange={(e) => setRepo(e.target.value)}
-              placeholder="owner/repo"
-              className="font-mono text-sm"
-              autoFocus
-            />
-          </div>
-
-          {/* State filter */}
-          <div className="flex gap-4">
-            <div className="flex-1">
-              <Label htmlFor="plugin-state" className="mb-1">State</Label>
-              <NativeSelect
-                id="plugin-state"
-                value={state}
-                onChange={(e) => setState(e.target.value as 'open' | 'closed' | 'all')}
-                className="w-full"
-              >
-                <NativeSelectOption value="open">Open</NativeSelectOption>
-                <NativeSelectOption value="closed">Closed</NativeSelectOption>
-                <NativeSelectOption value="all">All</NativeSelectOption>
-              </NativeSelect>
+        {step === 'filter' ? (
+          <div className="space-y-4">
+            {/* Preflight indicator */}
+            <div className="flex items-center gap-2 text-xs">
+              {detecting ? (
+                <><Spinner className="size-3" /><span className="text-[var(--muted-foreground)]">Detecting repository…</span></>
+              ) : ready === true ? (
+                <><span className="inline-block size-2 rounded-full bg-[var(--kagan-rail-running)]" /><span className="text-[var(--muted-foreground)]">GitHub plugin ready</span></>
+              ) : ready === false ? (
+                <><span className="inline-block size-2 rounded-full bg-amber-500" /><span className="text-[var(--muted-foreground)]">{preflightMsg}</span></>
+              ) : null}
             </div>
-            <div className="flex-1">
-              <Label htmlFor="plugin-label" className="mb-1">Label filter</Label>
-              <Input
-                id="plugin-label"
-                value={label}
-                onChange={(e) => setLabel(e.target.value)}
-                placeholder="e.g. bug"
-              />
+
+            <div>
+              <Label htmlFor="plugin-repo" className="mb-1">Repository</Label>
+              <Input id="plugin-repo" value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="owner/repo" className="font-mono text-sm" autoFocus />
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <Label htmlFor="plugin-state" className="mb-1">State</Label>
+                <NativeSelect id="plugin-state" value={state} onChange={(e) => setState(e.target.value as 'open' | 'closed' | 'all')} className="w-full">
+                  <NativeSelectOption value="open">Open</NativeSelectOption>
+                  <NativeSelectOption value="closed">Closed</NativeSelectOption>
+                  <NativeSelectOption value="all">All</NativeSelectOption>
+                </NativeSelect>
+              </div>
+              <div className="flex-1">
+                <Label htmlFor="plugin-labels" className="mb-1">Labels</Label>
+                <Input id="plugin-labels" value={labels} onChange={(e) => setLabels(e.target.value)} placeholder="bug, feature" />
+              </div>
+            </div>
+
+            <div>
+              <Label htmlFor="plugin-limit" className="mb-1">Limit</Label>
+              <Input id="plugin-limit" type="number" min={1} max={500} value={limit} onChange={(e) => setLimit(Number(e.target.value) || 100)} className="w-24" />
             </div>
           </div>
-        </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Button variant="ghost" size="sm" onClick={() => setStep('filter')}>
+                <ArrowLeft className="size-3 mr-1" /> Filters
+              </Button>
+              <div className="flex gap-2">
+                <Button variant="ghost" size="sm" onClick={() => setSelected(new Set(issues.map((i) => i.number)))}>Select all</Button>
+                <Button variant="ghost" size="sm" onClick={() => setSelected(new Set())}>Deselect all</Button>
+              </div>
+            </div>
+
+            <div className="max-h-72 overflow-y-auto space-y-1 border rounded-md p-2">
+              {issues.map((issue) => (
+                <label key={issue.number} className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm cursor-pointer hover:bg-[var(--accent)] ${issue.already_synced ? 'opacity-50' : ''}`}>
+                  <input
+                    type="checkbox"
+                    checked={selected.has(issue.number)}
+                    onChange={() => toggleIssue(issue.number)}
+                    className="size-4 shrink-0"
+                  />
+                  <span className="font-mono text-xs text-[var(--muted-foreground)]">#{issue.number}</span>
+                  <span className="flex-1 truncate">{issue.title}</span>
+                  {issue.labels.map((lbl) => (
+                    <span key={lbl} className="text-[10px] px-1.5 py-0.5 rounded-full bg-[var(--accent)] text-[var(--accent-foreground)]">{lbl}</span>
+                  ))}
+                  {issue.already_synced && <span className="text-[10px] text-[var(--muted-foreground)]">(synced)</span>}
+                </label>
+              ))}
+              {issues.length === 0 && <p className="text-sm text-[var(--muted-foreground)] text-center py-4">No issues match the filters.</p>}
+            </div>
+          </div>
+        )}
 
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleImport} disabled={importing || detecting || ready === false}>
-            <Download className="size-4" />
-            {importing ? 'Importing…' : 'Import'}
-          </Button>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>Cancel</Button>
+          {step === 'filter' ? (
+            <Button onClick={handlePreview} disabled={previewing || detecting || ready === false}>
+              {previewing ? <><Spinner className="size-4 mr-1" /> Fetching…</> : 'Preview Issues'}
+            </Button>
+          ) : (
+            <Button onClick={handleImport} disabled={importing || selected.size === 0}>
+              <Download className="size-4" />
+              {importing ? 'Importing…' : `Import ${selected.size} Selected`}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/web/src/lib/api/client.ts
+++ b/packages/web/src/lib/api/client.ts
@@ -546,6 +546,19 @@ export class KaganApiClient {
     return this.request(`/api/plugins/${name}/detect-repo`);
   }
 
+  /** GET /api/plugins/:name/preview */
+  async previewPluginIssues(
+    name: string,
+    params: { repo_slug: string; state?: string; labels?: string; limit?: number },
+  ): Promise<{ plugin: string; issues: Array<{ number: number; title: string; state: string; labels: string[]; url: string; already_synced: boolean }>; total: number }> {
+    const qs = new URLSearchParams();
+    qs.set('repo_slug', params.repo_slug);
+    if (params.state) qs.set('state', params.state);
+    if (params.labels) qs.set('labels', params.labels);
+    if (params.limit) qs.set('limit', String(params.limit));
+    return this.request(`/api/plugins/${name}/preview?${qs.toString()}`);
+  }
+
   /** POST /api/plugins/:name/import */
   async runPluginImport(name: string, config: Record<string, unknown>): Promise<{ created: number; updated: number; skipped: number; errors: string[] }> {
     return this.request(`/api/plugins/${name}/import`, { method: 'POST', body: config });

--- a/src/kagan/cli/imports.py
+++ b/src/kagan/cli/imports.py
@@ -29,10 +29,10 @@ def import_cmd() -> None:
     show_default=True,
     help="Issue state to import",
 )
-@click.option("--label", "import_label", default=None, help="Only import issues with this label")
+@click.option("--label", "labels", multiple=True, help="Filter by label (repeatable)")
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
-def import_github(repo: str | None, state: str, import_label: str | None, yes: bool) -> None:
-    run_async(_import_github(repo=repo, state=state, import_label=import_label, yes=yes))
+def import_github(repo: str | None, state: str, labels: tuple[str, ...], yes: bool) -> None:
+    run_async(_import_github(repo=repo, state=state, labels=labels, yes=yes))
 
 
 def _print_setup_checks() -> None:
@@ -52,7 +52,7 @@ async def _resolve_project(client) -> Project | None:
 
 
 async def _import_github(
-    *, repo: str | None, state: str, import_label: str | None, yes: bool
+    *, repo: str | None, state: str, labels: tuple[str, ...], yes: bool,
 ) -> None:
     client = make_client()
     try:
@@ -102,7 +102,7 @@ async def _import_github(
             project_id=project.id,
             repo_slug=repo_slug,
             state=normalized_state,
-            import_label=import_label,
+            labels=list(labels),
         )
         click.echo(
             f"Import complete: {result.created} created, "

--- a/src/kagan/cli/plugins.py
+++ b/src/kagan/cli/plugins.py
@@ -95,6 +95,8 @@ async def _sync(
 @click.option("--limit", default=100, type=int, show_default=True, help="Max issues to fetch")
 def preview(plugin_name: str, repo: str, state: str, labels: tuple[str, ...], limit: int) -> None:
     """Preview available issues from a plugin source."""
+    if "/" not in repo:
+        raise click.BadParameter("Must be in owner/repo format", param_hint="--repo")
     run_async(_preview(plugin_name, repo, state, labels, limit))
 
 

--- a/src/kagan/cli/plugins.py
+++ b/src/kagan/cli/plugins.py
@@ -14,16 +14,33 @@ def plugins() -> None:
 @click.argument("plugin_name")
 @click.option("--repo", required=True, help="Repository in owner/repo format")
 @click.option("--state", default="open", show_default=True, help="Issue state: open, closed, all")
-@click.option("--label", "import_label", default=None, help="Only sync issues with this label")
-def sync(plugin_name: str, repo: str, state: str, import_label: str | None) -> None:
+@click.option("--label", "labels", multiple=True, help="Filter by label (repeatable)")
+@click.option("--limit", default=100, type=int, show_default=True, help="Max issues to fetch")
+@click.option("--issues", "issue_numbers", default=None, help="Comma-separated issue numbers")
+def sync(
+    plugin_name: str,
+    repo: str,
+    state: str,
+    labels: tuple[str, ...],
+    limit: int,
+    issue_numbers: str | None,
+) -> None:
     """Sync external items from a plugin source into the active project."""
     if "/" not in repo:
         raise click.BadParameter("Must be in owner/repo format", param_hint="--repo")
 
-    run_async(_sync(plugin_name, repo, state, import_label))
+    parsed_numbers = [int(n.strip()) for n in issue_numbers.split(",")] if issue_numbers else None
+    run_async(_sync(plugin_name, repo, state, labels, limit, parsed_numbers))
 
 
-async def _sync(plugin_name: str, repo: str, state: str, import_label: str | None) -> None:
+async def _sync(
+    plugin_name: str,
+    repo: str,
+    state: str,
+    labels: tuple[str, ...],
+    limit: int,
+    issue_numbers: list[int] | None,
+) -> None:
     from kagan.core.plugins import PluginManager
 
     client = make_client()
@@ -52,7 +69,9 @@ async def _sync(plugin_name: str, repo: str, state: str, import_label: str | Non
             owner=owner,
             repo=repo_name,
             state=state,
-            import_label=import_label,
+            labels=tuple(labels),
+            limit=limit,
+            issue_numbers=tuple(issue_numbers) if issue_numbers else (),
         )
         import_plugin = manager.get_import(plugin_name)
         import_plugin.configure(config)
@@ -64,6 +83,55 @@ async def _sync(plugin_name: str, repo: str, state: str, import_label: str | Non
         )
         for err in result.errors:
             click.echo(f"  error: {err}")
+    finally:
+        client.close()
+
+
+@plugins.command()
+@click.argument("plugin_name")
+@click.option("--repo", required=True, help="Repository in owner/repo format")
+@click.option("--state", default="open", show_default=True, help="Issue state: open, closed, all")
+@click.option("--label", "labels", multiple=True, help="Filter by label (repeatable)")
+@click.option("--limit", default=100, type=int, show_default=True, help="Max issues to fetch")
+def preview(plugin_name: str, repo: str, state: str, labels: tuple[str, ...], limit: int) -> None:
+    """Preview available issues from a plugin source."""
+    run_async(_preview(plugin_name, repo, state, labels, limit))
+
+
+async def _preview(
+    plugin_name: str, repo: str, state: str, labels: tuple[str, ...], limit: int,
+) -> None:
+    from kagan.core.integrations.github import preview_github_issues
+
+    client = make_client()
+    try:
+        projects = await client.projects.list()
+        if not projects:
+            click.echo("No projects found. Create a project first.")
+            return
+        await client.projects.set_active(projects[0].id)
+
+        issues = await preview_github_issues(
+            client,
+            project_id=projects[0].id,
+            repo_slug=repo,
+            state=state,
+            labels=list(labels),
+            limit=limit,
+        )
+        if not issues:
+            click.echo("No issues match the filters.")
+            return
+
+        click.echo(f"{'#':<6} {'Title':<50} {'State':<8} {'Labels':<20} {'Synced'}")
+        click.echo("-" * 90)
+        for issue in issues:
+            labels_str = ", ".join(issue["labels"][:3])
+            synced = "yes" if issue["already_synced"] else ""
+            num = issue["number"]
+            title = issue["title"][:49]
+            st = issue["state"]
+            click.echo(f"#{num:<5} {title:<50} {st:<8} {labels_str[:19]:<20} {synced}")
     finally:
         client.close()
 

--- a/src/kagan/core/integrations/github.py
+++ b/src/kagan/core/integrations/github.py
@@ -111,6 +111,38 @@ async def github_preflight_checks(client: KaganCore) -> list[PreflightCheckResul
     return manager.get("github").preflight()
 
 
+async def _configure_github_plugin(
+    client: KaganCore,
+    *,
+    repo_slug: str,
+    state: str = "open",
+    labels: list[str] | None = None,
+    limit: int = 100,
+    issue_numbers: list[int] | None = None,
+) -> tuple[PluginManager, str]:
+    """Validate inputs, load the github plugin, configure it. Returns (manager, canonical_slug)."""
+    normalized_state = normalize_github_state(state)
+    canonical = canonical_repo_slug(repo_slug)
+    owner, repo = canonical.split("/", 1)
+
+    manager = PluginManager(client)
+    await manager.load()
+    if "github" not in manager.available:
+        raise ValueError("GitHub import is unavailable in this installation.")
+
+    manager.get_import("github").configure(
+        GitHubImportConfig(
+            owner=owner,
+            repo=repo,
+            state=normalized_state,
+            labels=tuple(labels or ()),
+            limit=limit,
+            issue_numbers=tuple(issue_numbers or ()),
+        )
+    )
+    return manager, canonical
+
+
 async def sync_github_issues(
     client: KaganCore,
     *,
@@ -121,25 +153,9 @@ async def sync_github_issues(
     limit: int = 100,
     issue_numbers: list[int] | None = None,
 ) -> ImportResult:
-    normalized_state = normalize_github_state(state)
-    canonical_repo = canonical_repo_slug(repo_slug)
-    owner, repo = canonical_repo.split("/", 1)
-
-    manager = PluginManager(client)
-    await manager.load()
-    if "github" not in manager.available:
-        raise ValueError("GitHub import is unavailable in this installation.")
-
-    import_plugin = manager.get_import("github")
-    import_plugin.configure(
-        GitHubImportConfig(
-            owner=owner,
-            repo=repo,
-            state=normalized_state,
-            labels=tuple(labels or ()),
-            limit=limit,
-            issue_numbers=tuple(issue_numbers or ()),
-        )
+    manager, _ = await _configure_github_plugin(
+        client, repo_slug=repo_slug, state=state,
+        labels=labels, limit=limit, issue_numbers=issue_numbers,
     )
     return await manager.sync("github", project_id=project_id)
 
@@ -154,24 +170,8 @@ async def preview_github_issues(
     limit: int = 100,
     issue_numbers: list[int] | None = None,
 ) -> list:
-    normalized_state = normalize_github_state(state)
-    canonical_repo = canonical_repo_slug(repo_slug)
-    owner, repo = canonical_repo.split("/", 1)
-
-    manager = PluginManager(client)
-    await manager.load()
-    if "github" not in manager.available:
-        raise ValueError("GitHub import is unavailable in this installation.")
-
-    import_plugin = manager.get_import("github")
-    import_plugin.configure(
-        GitHubImportConfig(
-            owner=owner,
-            repo=repo,
-            state=normalized_state,
-            labels=tuple(labels or ()),
-            limit=limit,
-            issue_numbers=tuple(issue_numbers or ()),
-        )
+    manager, _ = await _configure_github_plugin(
+        client, repo_slug=repo_slug, state=state,
+        labels=labels, limit=limit, issue_numbers=issue_numbers,
     )
-    return await import_plugin.preview(project_id)
+    return await manager.get_import("github").preview(project_id)

--- a/src/kagan/core/integrations/github.py
+++ b/src/kagan/core/integrations/github.py
@@ -117,7 +117,9 @@ async def sync_github_issues(
     project_id: str,
     repo_slug: str,
     state: str = "open",
-    import_label: str | None = None,
+    labels: list[str] | None = None,
+    limit: int = 100,
+    issue_numbers: list[int] | None = None,
 ) -> ImportResult:
     normalized_state = normalize_github_state(state)
     canonical_repo = canonical_repo_slug(repo_slug)
@@ -134,7 +136,42 @@ async def sync_github_issues(
             owner=owner,
             repo=repo,
             state=normalized_state,
-            import_label=import_label,
+            labels=tuple(labels or ()),
+            limit=limit,
+            issue_numbers=tuple(issue_numbers or ()),
         )
     )
     return await manager.sync("github", project_id=project_id)
+
+
+async def preview_github_issues(
+    client: KaganCore,
+    *,
+    project_id: str,
+    repo_slug: str,
+    state: str = "open",
+    labels: list[str] | None = None,
+    limit: int = 100,
+    issue_numbers: list[int] | None = None,
+) -> list:
+    normalized_state = normalize_github_state(state)
+    canonical_repo = canonical_repo_slug(repo_slug)
+    owner, repo = canonical_repo.split("/", 1)
+
+    manager = PluginManager(client)
+    await manager.load()
+    if "github" not in manager.available:
+        raise ValueError("GitHub import is unavailable in this installation.")
+
+    import_plugin = manager.get_import("github")
+    import_plugin.configure(
+        GitHubImportConfig(
+            owner=owner,
+            repo=repo,
+            state=normalized_state,
+            labels=tuple(labels or ()),
+            limit=limit,
+            issue_numbers=tuple(issue_numbers or ()),
+        )
+    )
+    return await import_plugin.preview(project_id)

--- a/src/kagan/core/plugins/_base.py
+++ b/src/kagan/core/plugins/_base.py
@@ -19,6 +19,7 @@ import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from importlib.metadata import Distribution, PackageNotFoundError, entry_points, version
+from typing import Any
 
 from loguru import logger
 
@@ -164,6 +165,10 @@ class ImporterPlugin(Plugin, ABC):
 
     def configure(self, config: object) -> None:
         """Configure the plugin before sync. Subclasses override to accept typed config."""
+
+    async def preview(self, project_id: str) -> list[dict[str, Any]]:
+        """Preview available items before import. Default: empty list."""
+        return []
 
     @abstractmethod
     async def sync(self, project_id: str) -> ImportResult:

--- a/src/kagan/core/plugins/_github.py
+++ b/src/kagan/core/plugins/_github.py
@@ -8,8 +8,6 @@ needed. Label conventions on the GitHub side auto-map to kagan task properties:
     priority:high      →  Priority.HIGH
     priority:medium    →  Priority.MEDIUM
     priority:low       →  Priority.LOW
-    kagan:detached     →  ignored (legacy label)
-    kagan:attached     →  ignored (legacy label)
 
 Sync is idempotent: a mapping of issue numbers → task IDs is persisted in
 the kagan settings table. Re-running sync skips already-imported issues.
@@ -40,6 +38,15 @@ class GitHubIssue(TypedDict, total=False):
     url: str
 
 
+class GitHubIssuePreview(TypedDict):
+    number: int
+    title: str
+    state: str
+    labels: list[str]
+    url: str
+    already_synced: bool
+
+
 # Label prefix → (task field, mapping)
 _PRIORITY_LABELS: Final[dict[str, Priority]] = {
     "priority:critical": Priority.CRITICAL,
@@ -47,8 +54,6 @@ _PRIORITY_LABELS: Final[dict[str, Priority]] = {
     "priority:medium": Priority.MEDIUM,
     "priority:low": Priority.LOW,
 }
-
-_MODE_LABELS: Final[set[str]] = {"kagan:detached", "kagan:attached"}
 
 _GH_JSON_FIELDS = "number,title,body,labels,state,url"
 
@@ -60,7 +65,9 @@ class GitHubImportConfig:
     owner: str
     repo: str
     state: str = "open"
-    import_label: str | None = None
+    labels: tuple[str, ...] = ()
+    limit: int = 100
+    issue_numbers: tuple[int, ...] = ()
 
     @property
     def repo_slug(self) -> str:
@@ -102,10 +109,10 @@ async def _gh_fetch_issues(config: GitHubImportConfig) -> list[GitHubIssue]:
         "--json",
         _GH_JSON_FIELDS,
         "--limit",
-        "100",
+        str(config.limit),
     ]
-    if config.import_label:
-        cmd.extend(["--label", config.import_label])
+    for lbl in config.labels:
+        cmd.extend(["--label", lbl])
 
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -138,16 +145,12 @@ def _extract_label_names(issue: GitHubIssue) -> list[str]:
 def _map_labels(label_names: list[str]) -> tuple[Priority, list[str]]:
     priority = Priority.MEDIUM
     remaining: list[str] = []
-
     for name in label_names:
         lower = name.lower()
         if lower in _PRIORITY_LABELS:
             priority = _PRIORITY_LABELS[lower]
-        elif lower in _MODE_LABELS:
-            continue
         else:
             remaining.append(name)
-
     return priority, remaining
 
 
@@ -289,6 +292,10 @@ class GitHubImporter(ImporterPlugin):
             config.repo_slug,
         )
 
+        if config.issue_numbers:
+            allowed = set(config.issue_numbers)
+            issues = [i for i in issues if i.get("number") in allowed]
+
         settings_key = config.settings_key()
         sync_map = await _load_sync_map(client, settings_key)
         result = ImportResult()
@@ -321,6 +328,37 @@ class GitHubImporter(ImporterPlugin):
             len(result.errors),
         )
         return result
+
+    async def preview(self, project_id: str) -> list[GitHubIssuePreview]:
+        """Fetch issues matching config and return preview without importing."""
+        if self._client is None:
+            raise PluginError("Plugin not set up — call setup() first")
+        if self._config is None:
+            raise PluginError("Plugin not configured — call configure() first")
+
+        issues = await _gh_fetch_issues(self._config)
+
+        if self._config.issue_numbers:
+            allowed = set(self._config.issue_numbers)
+            issues = [i for i in issues if i.get("number") in allowed]
+
+        sync_map = await _load_sync_map(self._client, self._config.settings_key())
+
+        previews: list[GitHubIssuePreview] = []
+        for issue in issues:
+            number = issue.get("number")
+            title = (issue.get("title") or "").strip()
+            if not number or not title:
+                continue
+            previews.append(GitHubIssuePreview(
+                number=number,
+                title=title,
+                state=issue.get("state", "open"),
+                labels=_extract_label_names(issue),
+                url=issue.get("url", ""),
+                already_synced=str(number) in sync_map,
+            ))
+        return previews
 
     async def _sync_single_issue(
         self,
@@ -367,4 +405,5 @@ class GitHubImporter(ImporterPlugin):
 __all__ = [
     "GitHubImportConfig",
     "GitHubImporter",
+    "GitHubIssuePreview",
 ]

--- a/src/kagan/core/plugins/_github.py
+++ b/src/kagan/core/plugins/_github.py
@@ -271,30 +271,36 @@ class GitHubImporter(ImporterPlugin):
 
         return checks
 
-    async def sync(self, project_id: str) -> ImportResult:
+    async def _fetch_issues(self) -> list[GitHubIssue]:
+        """Validate prerequisites, fetch issues, apply issue_numbers filter."""
         if self._client is None:
             raise PluginError("Plugin not set up — call setup() first")
         if self._config is None:
             raise PluginError("Plugin not configured — call configure() first")
-
-        client = self._client
-        config = self._config
 
         if _gh_path() is None:
             raise PluginError("GitHub CLI (gh) not found. Install → https://cli.github.com")
         if not await _gh_is_authenticated():
             raise PluginError("GitHub CLI not authenticated. Run → gh auth login")
 
-        issues = await _gh_fetch_issues(config)
+        issues = await _gh_fetch_issues(self._config)
         logger.info(
-            "GitHub sync: fetched {} issues from {}",
+            "GitHub fetch: {} issues from {}",
             len(issues),
-            config.repo_slug,
+            self._config.repo_slug,
         )
 
-        if config.issue_numbers:
-            allowed = set(config.issue_numbers)
+        if self._config.issue_numbers:
+            allowed = set(self._config.issue_numbers)
             issues = [i for i in issues if i.get("number") in allowed]
+
+        return issues
+
+    async def sync(self, project_id: str) -> ImportResult:
+        issues = await self._fetch_issues()
+        client = self._client
+        config = self._config
+        assert client is not None and config is not None  # guaranteed by _fetch_issues
 
         settings_key = config.settings_key()
         sync_map = await _load_sync_map(client, settings_key)
@@ -331,16 +337,8 @@ class GitHubImporter(ImporterPlugin):
 
     async def preview(self, project_id: str) -> list[GitHubIssuePreview]:
         """Fetch issues matching config and return preview without importing."""
-        if self._client is None:
-            raise PluginError("Plugin not set up — call setup() first")
-        if self._config is None:
-            raise PluginError("Plugin not configured — call configure() first")
-
-        issues = await _gh_fetch_issues(self._config)
-
-        if self._config.issue_numbers:
-            allowed = set(self._config.issue_numbers)
-            issues = [i for i in issues if i.get("number") in allowed]
+        issues = await self._fetch_issues()
+        assert self._client is not None and self._config is not None
 
         sync_map = await _load_sync_map(self._client, self._config.settings_key())
 

--- a/src/kagan/server/_plugin_routes.py
+++ b/src/kagan/server/_plugin_routes.py
@@ -106,6 +106,35 @@ def register_plugin_routes(mcp: FastMCP) -> None:
             }
         )
 
+    @mcp.custom_route("/api/plugins/{name}/preview", methods=["GET"])
+    @require_context(mcp)
+    @handle_errors
+    async def plugin_preview(request: Request, *, ctx: Any) -> JSONResponse:
+        name = cast("str", request.path_params["name"])
+
+        project_id = ctx.client.active_project_id
+        if not project_id:
+            return _err("No active project", status=400)
+
+        repo_slug = canonical_repo_slug(request.query_params.get("repo_slug", ""))
+        state = normalize_github_state(request.query_params.get("state", "open"))
+        labels_raw = request.query_params.get("labels", "")
+        labels = [s.strip() for s in labels_raw.split(",") if s.strip()] if labels_raw else []
+        limit_raw = request.query_params.get("limit", "100")
+        limit = min(max(int(limit_raw), 1), 500)
+
+        from kagan.core.integrations.github import preview_github_issues
+
+        issues = await preview_github_issues(
+            ctx.client,
+            project_id=project_id,
+            repo_slug=repo_slug,
+            state=state,
+            labels=labels,
+            limit=limit,
+        )
+        return _ok({"plugin": name, "issues": issues, "total": len(issues)})
+
     @mcp.custom_route("/api/plugins/{name}/import", methods=["POST"])
     @require_context(mcp)
     @handle_errors
@@ -128,10 +157,17 @@ def register_plugin_routes(mcp: FastMCP) -> None:
         if name == "github":
             repo_slug = canonical_repo_slug(str(body.get("repo_slug", "")))
             state = normalize_github_state(str(body.get("state", "open")))
-            import_label_raw = body.get("import_label")
-            import_label = (
-                str(import_label_raw).strip() if import_label_raw is not None else None
-            ) or None
+            labels_raw = body.get("labels")
+            labels = (
+                tuple(str(s).strip() for s in labels_raw)
+                if isinstance(labels_raw, list) else ()
+            )
+            limit = min(max(int(body.get("limit", 100)), 1), 500)
+            issue_numbers_raw = body.get("issue_numbers")
+            issue_numbers = (
+                tuple(int(n) for n in issue_numbers_raw)
+                if isinstance(issue_numbers_raw, list) else ()
+            )
 
             owner, repo = repo_slug.split("/", 1)
             import_plugin.configure(
@@ -139,7 +175,9 @@ def register_plugin_routes(mcp: FastMCP) -> None:
                     owner=owner,
                     repo=repo,
                     state=state,
-                    import_label=import_label,
+                    labels=labels,
+                    limit=limit,
+                    issue_numbers=issue_numbers,
                 )
             )
         else:

--- a/src/kagan/server/_plugin_routes.py
+++ b/src/kagan/server/_plugin_routes.py
@@ -112,6 +112,9 @@ def register_plugin_routes(mcp: FastMCP) -> None:
     async def plugin_preview(request: Request, *, ctx: Any) -> JSONResponse:
         name = cast("str", request.path_params["name"])
 
+        if name != "github":
+            return _err(f"Plugin {name!r} does not support preview", status=400)
+
         project_id = ctx.client.active_project_id
         if not project_id:
             return _err("No active project", status=400)

--- a/src/kagan/server/mcp/_policy.py
+++ b/src/kagan/server/mcp/_policy.py
@@ -31,6 +31,7 @@ _WORKER_TOOLS = frozenset(
         "settings_get",
         "review_conflicts",
         "plugins_preflight",
+        "plugins_preview",
         "verify_step",
         "verification_summary",
         "checkpoint_create",

--- a/src/kagan/server/mcp/toolsets/plugins.py
+++ b/src/kagan/server/mcp/toolsets/plugins.py
@@ -46,6 +46,15 @@ async def _plugins_preview(
     if "/" not in repo:
         raise ValidationError("", "repo must be in owner/repo format (e.g. 'octocat/hello-world')")
 
+    from kagan.core.plugins import PluginManager
+
+    manager = PluginManager(app.client)
+    await manager.load()
+    available_public = _public_plugins(manager.available)
+    if plugin not in available_public:
+        available = ", ".join(available_public) or "(none)"
+        raise ValidationError("Unknown plugin", f"{plugin!r}. Installed: {available}")
+
     from kagan.core.integrations.github import preview_github_issues
 
     issues = await preview_github_issues(

--- a/src/kagan/server/mcp/toolsets/plugins.py
+++ b/src/kagan/server/mcp/toolsets/plugins.py
@@ -18,25 +18,70 @@ def _public_plugins(available: list[str]) -> list[str]:
 
 
 @mcp_error_boundary
+async def _plugins_preview(
+    ctx: Context,
+    plugin: str,
+    repo: str,
+    state: str = "open",
+    labels: list[str] | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Preview issues from a GitHub repository without importing.
+
+    Returns a list of issues matching the filters so the user can
+    select which ones to import via plugins_sync with issue_numbers.
+
+    Args:
+        plugin: Plugin name (e.g. "github").
+        repo: Repository in owner/repo format.
+        state: Issue state filter — "open", "closed", or "all".
+        labels: Filter by labels (AND logic).
+        limit: Maximum issues to fetch (1-500).
+    """
+    app = get_context(ctx)
+    project_id = app.bound_project_id or app.client.active_project_id
+    if project_id is None:
+        raise ValidationError("", "No active project. Create or open a project first.")
+
+    if "/" not in repo:
+        raise ValidationError("", "repo must be in owner/repo format (e.g. 'octocat/hello-world')")
+
+    from kagan.core.integrations.github import preview_github_issues
+
+    issues = await preview_github_issues(
+        app.client,
+        project_id=project_id,
+        repo_slug=repo,
+        state=state,
+        labels=labels or [],
+        limit=limit,
+    )
+    return {"plugin": plugin, "repo": repo, "issues": issues, "total": len(issues)}
+
+
+@mcp_error_boundary
 async def _plugins_sync(
     ctx: Context,
     plugin: str,
     repo: str,
     state: str = "open",
-    import_label: str | None = None,
+    labels: list[str] | None = None,
+    limit: int = 100,
+    issue_numbers: list[int] | None = None,
 ) -> dict[str, Any]:
     """Sync external items from a plugin source into the active project.
 
     Imports issues from the specified repository as kagan tasks.
-    Labels like ``priority:high`` and ``kagan:auto`` on GitHub issues
-    auto-map to task properties. Operation is idempotent — previously
-    synced issues are skipped.
+    Labels like ``priority:high`` on GitHub issues auto-map to task
+    properties. Operation is idempotent — previously synced issues are skipped.
 
     Args:
-        plugin: Plugin to sync (e.g. "github"). Use plugins_preflight to list available.
-        repo: Repository in owner/repo format (e.g. "octocat/hello-world").
+        plugin: Plugin to sync (e.g. "github").
+        repo: Repository in owner/repo format.
         state: Issue state filter — "open", "closed", or "all".
-        import_label: Only sync issues with this label.
+        labels: Only sync issues with ALL of these labels.
+        limit: Maximum issues to fetch (1-500).
+        issue_numbers: Import only these specific issue numbers.
     """
     app = get_context(ctx)
     project_id = app.bound_project_id or app.client.active_project_id
@@ -69,7 +114,9 @@ async def _plugins_sync(
             owner=owner,
             repo=repo_name,
             state=state,
-            import_label=import_label,
+            labels=tuple(labels or ()),
+            limit=limit,
+            issue_numbers=tuple(issue_numbers or ()),
         )
     )
     result = await import_plugin.sync(project_id)
@@ -147,6 +194,7 @@ async def _plugins_preflight(ctx: Context, plugin: str | None = None) -> dict[st
 def register(mcp: FastMCP, opts: ServerOptions) -> None:
     """Register plugin domain tools on mcp, filtered by opts."""
     _tools: list[tuple[str, Callable[..., Any]]] = [
+        ("plugins_preview", _plugins_preview),
         ("plugins_sync", _plugins_sync),
         ("plugins_preflight", _plugins_preflight),
     ]

--- a/src/kagan/tui/keybindings.py
+++ b/src/kagan/tui/keybindings.py
@@ -265,6 +265,8 @@ REPO_PICKER_BINDINGS: list[BindingType] = [
 GITHUB_IMPORT_BINDINGS: list[BindingType] = [
     Binding("enter", "run_import", "Import", key_display="Enter"),
     Binding("escape", "dismiss", "Close", key_display="Esc"),
+    Binding("a", "select_all", "Select All", show=False),
+    Binding("n", "select_none", "Select None", show=False),
 ]
 
 AGENT_PICKER_BINDINGS: list[BindingType] = [

--- a/src/kagan/tui/screens/github_import_modal.py
+++ b/src/kagan/tui/screens/github_import_modal.py
@@ -48,6 +48,11 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
         self._phase: str = "filter"
         self._previewed_issues: list = []
         self._selection_list: SelectionList | None = None
+        # Parsed form values cached after preview
+        self._parsed_repo: str = ""
+        self._parsed_state: str = "open"
+        self._parsed_labels: list[str] = []
+        self._parsed_limit: int = 100
 
     @property
     def kagan_app(self) -> "KaganApp":
@@ -188,6 +193,11 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
         if not ready:
             return
 
+        self._parsed_repo = repo
+        self._parsed_state = state
+        self._parsed_labels = labels
+        self._parsed_limit = limit
+
         self.app.notify("Fetching issues…", severity="information")
         try:
             issues = await preview_github_issues(
@@ -254,32 +264,14 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
             self.app.notify("No issues selected.", severity="warning")
             return
 
-        repo_input = self.query_one("#github-import-repo", Input).value
-        state_value = self.query_one("#github-import-state", Select).value
-        state_input = state_value if isinstance(state_value, str) else "open"
-        labels_raw = self.query_one("#github-import-label", Input).value.strip()
-        labels = [lbl.strip() for lbl in labels_raw.split(",") if lbl.strip()] if labels_raw else []
-        limit_raw = self.query_one("#github-import-limit", Input).value.strip()
-        try:
-            limit = int(limit_raw) if limit_raw else 100
-        except ValueError:
-            limit = 100
-
-        try:
-            repo = canonical_repo_slug(repo_input)
-            state = normalize_github_state(state_input)
-        except ValueError as exc:
-            self.app.notify(str(exc), severity="warning")
-            return
-
         try:
             result = await sync_github_issues(
                 self.kagan_app.core,
                 project_id=project.id,
-                repo_slug=repo,
-                state=state,
-                labels=labels,
-                limit=limit,
+                repo_slug=self._parsed_repo,
+                state=self._parsed_state,
+                labels=self._parsed_labels,
+                limit=self._parsed_limit,
                 issue_numbers=selected_numbers,
             )
         except (KaganError, OSError, RuntimeError, ValueError, TypeError) as exc:
@@ -287,8 +279,8 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
             return
 
         summary = GitHubImportSummary(
-            repo=repo,
-            state=state,
+            repo=self._parsed_repo,
+            state=self._parsed_state,
             created=result.created,
             skipped=result.skipped,
             errors=result.errors,

--- a/src/kagan/tui/screens/github_import_modal.py
+++ b/src/kagan/tui/screens/github_import_modal.py
@@ -361,6 +361,16 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
 
         return False, format_github_setup_message(checks)
 
+    def action_select_all(self) -> None:
+        if self._phase != "select" or self._selection_list is None:
+            return
+        self._selection_list.select_all()
+
+    def action_select_none(self) -> None:
+        if self._phase != "select" or self._selection_list is None:
+            return
+        self._selection_list.deselect_all()
+
     async def action_dismiss(self, result: GitHubImportSummary | None = None) -> None:
         if self._phase == "select":
             self.action_back_to_filter()

--- a/src/kagan/tui/screens/github_import_modal.py
+++ b/src/kagan/tui/screens/github_import_modal.py
@@ -5,7 +5,8 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Input, Select, Static
+from textual.widgets import Footer, Input, Select, SelectionList, Static
+from textual.widgets.selection_list import Selection
 
 from kagan.core.errors import KaganError
 from kagan.core.integrations.github import (
@@ -15,6 +16,7 @@ from kagan.core.integrations.github import (
     github_blocking_checks,
     github_preflight_checks,
     normalize_github_state,
+    preview_github_issues,
     sync_github_issues,
 )
 
@@ -43,6 +45,9 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
     def __init__(self) -> None:
         super().__init__()
         self._is_importing = False
+        self._phase: str = "filter"
+        self._previewed_issues: list = []
+        self._selection_list: SelectionList | None = None
 
     @property
     def kagan_app(self) -> "KaganApp":
@@ -76,13 +81,21 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
                 )
 
                 yield Static(
-                    "Only import issues with label (optional)",
+                    "Filter by labels (comma-separated, optional)",
                     classes="github-import-label",
                 )
                 yield Input(
-                    placeholder="bug",
+                    placeholder="bug, feature",
                     id="github-import-label",
                 )
+
+                yield Static("Limit", classes="github-import-label")
+                yield Input(
+                    placeholder="100",
+                    id="github-import-limit",
+                )
+
+            yield SelectionList(id="github-import-selection")
 
             with Horizontal(classes="modal-action-hint-row"):
                 yield Static(
@@ -97,12 +110,13 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
     async def on_mount(self) -> None:
         state_select = self.query_one("#github-import-state", Select)
         state_select.value = "open"
+        self.query_one("#github-import-selection", SelectionList).display = False
         await self._prefill_repo_from_selected_origin()
         await self.action_check_readiness()
         self.query_one("#github-import-repo", Input).focus()
         self.query_one("#github-import-hint", KeybindingHint).show_hints(
             [
-                ("Enter", "import"),
+                ("Enter", "preview"),
                 ("Esc", "close"),
             ]
         )
@@ -111,7 +125,9 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
     def _action_hint_text(self) -> str:
         import_key = get_key_for_action(GITHUB_IMPORT_BINDINGS, "run_import", default="Enter")
         close_key = get_key_for_action(GITHUB_IMPORT_BINDINGS, "dismiss", default="Esc")
-        return f"{import_key} import  {close_key} close"
+        if self._phase == "filter":
+            return f"{import_key} preview  {close_key} close"
+        return f"{import_key} import  {close_key} back"
 
     async def action_check_readiness(self) -> None:
         ready, message = await self._check_github_ready()
@@ -137,6 +153,12 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
             self._is_importing = False
 
     async def _run_import_once(self) -> None:
+        if self._phase == "filter":
+            await self._do_preview()
+        else:
+            await self._do_import()
+
+    async def _do_preview(self) -> None:
         project = self.kagan_app.project
         if project is None:
             self.app.notify("Open a project before importing from GitHub.", severity="warning")
@@ -145,7 +167,14 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
         repo_input = self.query_one("#github-import-repo", Input).value
         state_value = self.query_one("#github-import-state", Select).value
         state_input = state_value if isinstance(state_value, str) else "open"
-        import_label = self.query_one("#github-import-label", Input).value.strip() or None
+        labels_raw = self.query_one("#github-import-label", Input).value.strip()
+        labels = [lbl.strip() for lbl in labels_raw.split(",") if lbl.strip()] if labels_raw else []
+        limit_raw = self.query_one("#github-import-limit", Input).value.strip()
+        try:
+            limit = int(limit_raw) if limit_raw else 100
+        except ValueError:
+            self.app.notify("Limit must be a number.", severity="warning")
+            return
 
         try:
             repo = canonical_repo_slug(repo_input)
@@ -159,22 +188,88 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
         if not ready:
             return
 
-        from kagan.tui.screens.confirm import ConfirmModal
-
-        confirmed = await self.app.push_screen_wait(
-            ConfirmModal(
-                title="Start GitHub Import",
-                message=(
-                    f"Repository: {repo}\n"
-                    f"State: {state}\n"
-                    f"Label filter: {import_label or 'none'}\n\n"
-                    "Continue?"
-                ),
-                confirm_label="Import",
-                cancel_label="Cancel",
+        self.app.notify("Fetching issues…", severity="information")
+        try:
+            issues = await preview_github_issues(
+                self.kagan_app.core,
+                project_id=project.id,
+                repo_slug=repo,
+                state=state,
+                labels=labels,
+                limit=limit,
             )
+        except (KaganError, OSError, RuntimeError, ValueError, TypeError) as exc:
+            self.app.notify(f"Preview failed: {exc}", severity="error")
+            return
+
+        if not issues:
+            self.app.notify("No issues match the filters.", severity="warning")
+            return
+
+        self._previewed_issues = issues
+        self._switch_to_select_phase(issues)
+
+    def _switch_to_select_phase(self, issues: list) -> None:
+        self._phase = "select"
+
+        selections = [
+            Selection(
+                f"#{issue['number']}  {issue['title']}"
+                + (" (synced)" if issue["already_synced"] else ""),
+                issue["number"],
+                initial_state=not issue["already_synced"],
+            )
+            for issue in issues
+        ]
+
+        fields = self.query_one("#github-import-fields", Vertical)
+        fields.display = False
+
+        selection_list = self.query_one("#github-import-selection", SelectionList)
+        selection_list.clear_options()
+        for sel in selections:
+            selection_list.add_option(sel)
+        selection_list.display = True
+        self._selection_list = selection_list
+        selection_list.focus()
+
+        self.query_one("#github-import-hint", KeybindingHint).show_hints(
+            [
+                ("Enter", "import"),
+                ("Esc", "back"),
+            ]
         )
-        if not confirmed:
+        self.query_one("#github-import-action-hint", Static).update(self._action_hint_text())
+
+    async def _do_import(self) -> None:
+        project = self.kagan_app.project
+        if project is None:
+            self.app.notify("Open a project before importing from GitHub.", severity="warning")
+            return
+
+        selection_list = self.query_one("#github-import-selection", SelectionList)
+        selected_numbers: list[int] = list(selection_list.selected)
+
+        if not selected_numbers:
+            self.app.notify("No issues selected.", severity="warning")
+            return
+
+        repo_input = self.query_one("#github-import-repo", Input).value
+        state_value = self.query_one("#github-import-state", Select).value
+        state_input = state_value if isinstance(state_value, str) else "open"
+        labels_raw = self.query_one("#github-import-label", Input).value.strip()
+        labels = [lbl.strip() for lbl in labels_raw.split(",") if lbl.strip()] if labels_raw else []
+        limit_raw = self.query_one("#github-import-limit", Input).value.strip()
+        try:
+            limit = int(limit_raw) if limit_raw else 100
+        except ValueError:
+            limit = 100
+
+        try:
+            repo = canonical_repo_slug(repo_input)
+            state = normalize_github_state(state_input)
+        except ValueError as exc:
+            self.app.notify(str(exc), severity="warning")
             return
 
         try:
@@ -183,7 +278,9 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
                 project_id=project.id,
                 repo_slug=repo,
                 state=state,
-                import_label=import_label,
+                labels=labels,
+                limit=limit,
+                issue_numbers=selected_numbers,
             )
         except (KaganError, OSError, RuntimeError, ValueError, TypeError) as exc:
             self.app.notify(f"GitHub import failed: {exc}", severity="error")
@@ -205,6 +302,29 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
             severity=severity,
         )
         self.dismiss(summary)
+
+    def action_back_to_filter(self) -> None:
+        if self._phase != "select":
+            return
+        self._phase = "filter"
+        self._previewed_issues = []
+        self._selection_list = None
+
+        selection_list = self.query_one("#github-import-selection", SelectionList)
+        selection_list.display = False
+        selection_list.clear_options()
+
+        fields = self.query_one("#github-import-fields", Vertical)
+        fields.display = True
+
+        self.query_one("#github-import-hint", KeybindingHint).show_hints(
+            [
+                ("Enter", "preview"),
+                ("Esc", "close"),
+            ]
+        )
+        self.query_one("#github-import-action-hint", Static).update(self._action_hint_text())
+        self.query_one("#github-import-repo", Input).focus()
 
     @on(Input.Submitted)
     def _on_input_submitted(self) -> None:
@@ -242,4 +362,7 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
         return False, format_github_setup_message(checks)
 
     async def action_dismiss(self, result: GitHubImportSummary | None = None) -> None:
-        self.dismiss(result)
+        if self._phase == "select":
+            self.action_back_to_filter()
+        else:
+            self.dismiss(result)

--- a/tests/plugins/test_github_import.py
+++ b/tests/plugins/test_github_import.py
@@ -11,6 +11,7 @@ from kagan.core.plugins._github import (
     GitHubImportConfig,
     GitHubImporter,
     GitHubIssue,
+    GitHubIssuePreview,
     _build_description,
     _extract_label_names,
     _map_labels,
@@ -70,16 +71,16 @@ def test_map_labels_priority() -> None:
     assert remaining == ["bug"]
 
 
-def test_map_labels_ignores_legacy_mode_labels() -> None:
+def test_map_labels_unknown_labels_pass_through() -> None:
     priority, remaining = _map_labels(["kagan:detached", "enhancement"])
-    assert priority == Priority.MEDIUM  # default
-    assert remaining == ["enhancement"]
+    assert priority == Priority.MEDIUM
+    assert remaining == ["kagan:detached", "enhancement"]
 
 
 def test_map_labels_combined() -> None:
     priority, remaining = _map_labels(["priority:critical", "kagan:attached", "frontend", "bug"])
     assert priority == Priority.CRITICAL
-    assert remaining == ["frontend", "bug"]
+    assert remaining == ["kagan:attached", "frontend", "bug"]
 
 
 def test_map_labels_case_insensitive() -> None:
@@ -165,7 +166,7 @@ async def test_sync_creates_tasks_from_issues(
     """First sync creates tasks for each GitHub issue."""
     mock_fetch.return_value = _make_gh_issues(
         (1, "Bug report", ["bug", "priority:high"]),
-        (2, "Feature request", ["enhancement", "kagan:detached"]),
+        (2, "Feature request", ["enhancement"]),
     )
 
     result = await plugin.sync(client.active_project_id)
@@ -266,6 +267,65 @@ async def test_sync_persists_map_in_settings(
     assert key in settings
     sync_map = json.loads(settings[key])
     assert "42" in sync_map
+
+
+# ---------------------------------------------------------------------------
+# Preview (with mocked gh CLI)
+# ---------------------------------------------------------------------------
+
+
+@patch("kagan.core.plugins._github._gh_fetch_issues", new_callable=AsyncMock)
+@patch("kagan.core.plugins._github._gh_is_authenticated", new_callable=AsyncMock, return_value=True)
+@patch("kagan.core.plugins._github._gh_path", return_value="/usr/bin/gh")
+async def test_preview_returns_issues_without_importing(
+    _mock_path, _mock_auth, mock_fetch, plugin, client
+) -> None:
+    """Preview returns issue list without creating tasks."""
+    mock_fetch.return_value = _make_gh_issues(
+        (1, "Bug report", ["bug"]),
+        (2, "Feature", ["enhancement"]),
+    )
+    previews = await plugin.preview(client.active_project_id)
+    assert len(previews) == 2
+    assert previews[0]["number"] == 1
+    assert previews[0]["already_synced"] is False
+    # No tasks created
+    tasks = await client.tasks.list()
+    assert len(tasks) == 0
+
+
+@patch("kagan.core.plugins._github._gh_fetch_issues", new_callable=AsyncMock)
+@patch("kagan.core.plugins._github._gh_is_authenticated", new_callable=AsyncMock, return_value=True)
+@patch("kagan.core.plugins._github._gh_path", return_value="/usr/bin/gh")
+async def test_preview_marks_synced_issues(
+    _mock_path, _mock_auth, mock_fetch, plugin, client
+) -> None:
+    """Preview marks previously synced issues."""
+    issues = _make_gh_issues((1, "Bug", []))
+    mock_fetch.return_value = issues
+    await plugin.sync(client.active_project_id)
+
+    mock_fetch.return_value = _make_gh_issues((1, "Bug", []), (2, "New", []))
+    previews = await plugin.preview(client.active_project_id)
+    assert previews[0]["already_synced"] is True
+    assert previews[1]["already_synced"] is False
+
+
+@patch("kagan.core.plugins._github._gh_fetch_issues", new_callable=AsyncMock)
+@patch("kagan.core.plugins._github._gh_is_authenticated", new_callable=AsyncMock, return_value=True)
+@patch("kagan.core.plugins._github._gh_path", return_value="/usr/bin/gh")
+async def test_sync_with_issue_numbers_imports_only_selected(
+    _mock_path, _mock_auth, mock_fetch, plugin, client
+) -> None:
+    """Sync with issue_numbers only imports matching issues."""
+    mock_fetch.return_value = _make_gh_issues(
+        (1, "Bug", []), (2, "Feature", []), (3, "Docs", []),
+    )
+    plugin.configure(GitHubImportConfig(owner="octocat", repo="hello-world", issue_numbers=(1, 3)))
+    result = await plugin.sync(client.active_project_id)
+    assert result.created == 2  # only #1 and #3
+    tasks = await client.tasks.list()
+    assert {t.title for t in tasks} == {"Bug", "Docs"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_tool_profiles.py
+++ b/tests/unit/test_tool_profiles.py
@@ -28,6 +28,7 @@ def test_worker_role_tools() -> None:
         "settings_get",
         "review_conflicts",
         "plugins_preflight",
+        "plugins_preview",
         "session_compact",
         "verify_step",
         "verification_summary",


### PR DESCRIPTION
## Summary

- Add two-phase **preview → select → import** workflow for GitHub issues across all client interfaces
- Replace single `import_label` with multi-label `labels` filter, configurable `limit`, and `issue_numbers` selection
- Remove legacy `_MODE_LABELS` dead code (`kagan:detached`/`kagan:attached`)
- New `plugins_preview` MCP tool (read-only) and `GET /api/plugins/{name}/preview` HTTP endpoint
- Web: two-step dialog with filter form → checkbox issue list → import selected
- TUI: two-phase modal with `SelectionList` widget for issue selection
- CLI: new `kagan plugins preview` command; extended `sync` with `--label` (repeatable), `--limit`, `--issues`
- Updated docs and feature specs

## Test plan

- [x] `uv run poe lint` — all checks passed
- [x] `uv run poe typecheck` — 0 errors
- [x] `uv run pytest tests/ -m "not snapshot" -n auto` — 1116 passed
- [x] `pnpm run web:test` — 155 passed
- [x] No `import_label` or `_MODE_LABELS` references remain in src/
- [ ] E2E: `kagan plugins preview github --repo owner/repo --label bug`
- [ ] E2E: `kagan plugins sync github --repo owner/repo --issues 1,5,10`
- [ ] E2E: Web two-step dialog flow with real GitHub repo
- [ ] E2E: TUI SelectionList flow