### PR TITLE
fix(tui): defer _reload_projects to survive pytest-xdist race

### DIFF
--- a/src/kagan/tui/screens/welcome.py
+++ b/src/kagan/tui/screens/welcome.py
@@ -97,6 +97,9 @@ class WelcomeScreen(Screen[None]):
             yield KeybindingHint(id="welcome-hint")
 
     async def on_mount(self) -> None:
+        self.call_after_refresh(self._on_mount_deferred)
+
+    async def _on_mount_deferred(self) -> None:
         await self._reload_projects()
         await self._maybe_hide_cwd_banner()
         self._update_cwd_banner_hint()


### PR DESCRIPTION
## Summary
- CI has been red on every push event for days — root cause is a `query_one` race in `WelcomeScreen.on_mount` that manifests under pytest-xdist parallel workers.
- Latest CI failure (run 24829443418 on 45335d14): `test_doctor_modal_skip_button_dismisses_modal` failed with `No nodes match '#project-list' on WelcomeScreen(id='welcome-screen')` — `on_mount` fires before the composed children are queryable.
- Fix: wrap the `on_mount` body in `call_after_refresh(self._on_mount_deferred)` so reload runs after the DOM is stable. Textual's idiomatic defer pattern.

## Test plan
- [x] 5× parallel runs of the specific failing test under `pytest -n auto` — all pass.
- [x] Full `tests/tui/ -m "not snapshot" -n auto` — 129/129 pass.
- [x] Sequential `tests/tui/test_doctor_modal.py` — 16/16 pass (no regression in non-parallel mode).
- [ ] CI matrix green on this PR.

## Known follow-ups (not in this PR)
- `WelcomeScreen.on_screen_resume` has the same pattern — lower risk but worth deferring for consistency.
- `_update_cwd_banner_hint` and `_cwd_banner_visible` both call `query_one` without guard — could race during early resumes.
- Other files show the same pattern (`session_resume_modal.py`, `kanban.py` etc) — systematic audit needed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)