### PR TITLE
fix(tui): defer on_mount/on_screen_resume work across screens (xdist race)

### DIFF
--- a/src/kagan/tui/screens/kanban.py
+++ b/src/kagan/tui/screens/kanban.py
@@ -1893,9 +1893,12 @@ class KanbanScreen(Screen[None]):
         self.app.push_screen(TaskEditorModal())
 
     async def on_screen_resume(self) -> None:
+        self.call_after_refresh(self._on_screen_resume_deferred)
+
+    async def _on_screen_resume_deferred(self) -> None:
         await self._reload_tasks()
         self._sync_layout_state()
-        self.call_after_refresh(self._auto_focus_board)
+        self._auto_focus_board()
 
     def _handle_search_key(self, event: events.Key) -> bool:
         search_bar = self.query_one(SearchBar)

--- a/src/kagan/tui/screens/session_resume_modal.py
+++ b/src/kagan/tui/screens/session_resume_modal.py
@@ -54,7 +54,7 @@ class SessionResumeModal(ModalScreen[RecentSessionSelection | None]):
         yield Footer(show_command_palette=False)
 
     async def on_mount(self) -> None:
-        await self._reload_sessions()
+        self.call_after_refresh(self._reload_sessions)
 
     async def _reload_sessions(self) -> None:
         option_list = self.query_one("#session-resume-options", OptionList)

--- a/src/kagan/tui/screens/welcome.py
+++ b/src/kagan/tui/screens/welcome.py
@@ -106,6 +106,9 @@ class WelcomeScreen(Screen[None]):
         self._update_keybinding_hints()
 
     async def on_screen_resume(self) -> None:
+        self.call_after_refresh(self._on_screen_resume_deferred)
+
+    async def _on_screen_resume_deferred(self) -> None:
         await self._reload_projects()
         await self._maybe_hide_cwd_banner()
         self._update_cwd_banner_hint()

--- a/src/kagan/tui/screens/workspace.py
+++ b/src/kagan/tui/screens/workspace.py
@@ -97,12 +97,15 @@ class WorkspaceScreen(Screen[None]):
         )
 
     async def on_screen_resume(self) -> None:
+        self.call_after_refresh(self._on_screen_resume_deferred)
+
+    async def _on_screen_resume_deferred(self) -> None:
         await self.kagan_app.orchestrator_sessions.reload()
         panel = self.query_one(ChatPanel)
         await self._load_workspace_panel_state(panel)
         self._refresh_header()
         await self._refresh_header_context()
-        self.call_after_refresh(self._focus_sidebar)
+        self._focus_sidebar()
 
     async def on_unmount(self) -> None:
         if self._chat_message_task is not None:


### PR DESCRIPTION
## Summary
Systematic follow-up to #121. My earlier fix only covered `WelcomeScreen.on_mount` but the `test_doctor_modal_skip_button_dismisses_modal` CI failure actually hit `on_screen_resume` (DoctorModal dismiss → WelcomeScreen resume → `_reload_projects` → `query_one('#project-list')` race under `pytest-xdist`).

This PR audits every `on_mount` / `on_screen_resume` in `src/kagan/tui/screens/` and applies `call_after_refresh(…)` deferral wherever a `query_one` can race with DOM readiness.

## Files changed
- `welcome.py` — `on_screen_resume` (the CI-blocker)
- `session_resume_modal.py` — `on_mount` (matches CI failure on commit `32dcf1e`: `No nodes match '#column-backlog'`)
- `kanban.py` — `on_screen_resume`
- `workspace.py` — `on_screen_resume`

## Test plan
- [x] `test_doctor_modal_skip_button_dismisses_modal` under `-n auto` — 5/5 pass
- [x] Full `tests/tui/ -n auto -m "not snapshot"` — 3/3 runs pass (129 tests each)
- [x] Sequential sanity — passes
- [ ] CI matrix green on this PR

## Notes
Spotted but left alone (no observed race, deferred via existing `call_after_refresh` elsewhere, or children composed by same screen so always ready at mount time):
- `kanban.on_mount` — multiple `query_one` but guarded; `_focus_default_widget` already uses `call_after_refresh`.
- `workspace.on_mount` — `query_one(ChatPanel)` but `ChatPanel` is composed by `workspace.py` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)