### PR TITLE
fix: Windows support across fs/browse, agent spawn, env, and signals

### DIFF
--- a/packages/web/src/components/shared/path-picker.test.tsx
+++ b/packages/web/src/components/shared/path-picker.test.tsx
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '@/test/render';
+import { PathPicker } from '@/components/shared/path-picker';
+import type { FsBrowseResponse } from '@/lib/api/types';
+
+// vi.mock is hoisted — factory must be self-contained (no outer-scope refs).
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    browsePath: vi.fn(),
+  },
+}));
+
+// A minimal valid FsEntry for populating fixtures (so the ".." button renders).
+const DUMMY_ENTRY = {
+  name: 'some-folder',
+  path: '/dummy/path',
+  is_dir: true,
+  is_git_repo: false,
+  is_link: false,
+};
+
+const DUMMY_WIN_ENTRY = {
+  name: 'some-folder',
+  path: 'C:\\dummy\\path',
+  is_dir: true,
+  is_git_repo: false,
+  is_link: false,
+};
+
+// Helper: build a POSIX browse response fixture.
+function posixResponse(path: string, overrides: Partial<FsBrowseResponse> = {}): FsBrowseResponse {
+  const segments = path.split('/').filter(Boolean);
+  // Parent: strip last segment; null when at FS root (single segment or empty).
+  let parent: string | null;
+  if (segments.length <= 1) {
+    parent = null;
+  } else {
+    parent = '/' + segments.slice(0, -1).join('/');
+  }
+  return {
+    path,
+    parent,
+    separator: '/',
+    roots: ['/'],
+    entries: [DUMMY_ENTRY],
+    ...overrides,
+  };
+}
+
+// Helper: build a Windows browse response fixture.
+function winResponse(path: string, overrides: Partial<FsBrowseResponse> = {}): FsBrowseResponse {
+  // path looks like "C:\\Users\\you"
+  const segments = path.split('\\').filter(Boolean);
+  // parent: remove last segment, re-join; if only one segment left (drive), parent is null.
+  let parent: string | null;
+  if (segments.length <= 1) {
+    parent = null;
+  } else if (segments.length === 2) {
+    parent = segments[0] + '\\';
+  } else {
+    parent = segments.slice(0, -1).join('\\');
+  }
+  return {
+    path,
+    parent,
+    separator: '\\',
+    roots: ['C:\\', 'D:\\'],
+    entries: [DUMMY_WIN_ENTRY],
+    ...overrides,
+  };
+}
+
+describe('PathPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // POSIX breadcrumbs
+  // ---------------------------------------------------------------------------
+
+  describe('POSIX breadcrumbs', () => {
+    it('renders correct breadcrumb labels for /Users/you/dev', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        posixResponse('/Users/you/dev'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Users')).toBeVisible();
+        expect(screen.getByText('you')).toBeVisible();
+        expect(screen.getByText('dev')).toBeVisible();
+      });
+    });
+
+    it('clicking a breadcrumb segment calls browsePath with the correct partial path', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        posixResponse('/Users/you/dev'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('Users')).toBeVisible());
+
+      fireEvent.click(screen.getByText('Users'));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('/Users');
+      });
+    });
+
+    it('up arrow navigates to parent path from server response', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        posixResponse('/Users/you/dev', { parent: '/Users/you' }),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      // Wait for entries area to show ".." button (parent is not null)
+      await waitFor(() => expect(screen.getByText('..')).toBeVisible());
+
+      fireEvent.click(screen.getByText('..'));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('/Users/you');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Windows breadcrumbs
+  // ---------------------------------------------------------------------------
+
+  describe('Windows breadcrumbs', () => {
+    it('renders correct breadcrumb labels for C:\\Users\\you', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users\\you'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => {
+        // "C:" appears in both root picker and breadcrumb — use getAllByText.
+        const cElements = screen.getAllByText('C:');
+        expect(cElements.length).toBeGreaterThanOrEqual(1);
+        expect(cElements[0]).toBeVisible();
+        expect(screen.getByText('Users')).toBeVisible();
+        expect(screen.getByText('you')).toBeVisible();
+      });
+    });
+
+    it('clicking the C: breadcrumb navigates to C:\\ (with trailing separator)', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users\\you'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      // Wait for breadcrumbs to load.
+      await waitFor(() => expect(screen.getAllByText('C:').length).toBeGreaterThan(0));
+
+      // Click the root-picker "Browse C:\\" button — guaranteed to navigate to C:\.
+      fireEvent.click(screen.getByRole('button', { name: 'Browse C:\\' }));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('C:\\');
+      });
+    });
+
+    it('up arrow from C:\\Users navigates to C:\\', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      // At C:\Users, parent is C:\
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users', { parent: 'C:\\' }),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('..')).toBeVisible());
+
+      fireEvent.click(screen.getByText('..'));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('C:\\');
+      });
+    });
+
+    it('up button is hidden when parent is null (at filesystem root)', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\', { parent: null }),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      // Wait for entries to render (the dummy entry should appear)
+      await waitFor(() => expect(screen.getByText('some-folder')).toBeVisible());
+
+      // ".." should not appear when parent is null
+      expect(screen.queryByText('..')).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Root pickers (Windows multi-drive)
+  // ---------------------------------------------------------------------------
+
+  describe('roots / drive pickers', () => {
+    it('renders two drive buttons when roots has C:\\ and D:\\', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => {
+        // Root picker buttons are rendered with aria-label "Browse C:\" etc.
+        expect(screen.getByRole('button', { name: 'Browse C:\\' })).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Browse D:\\' })).toBeVisible();
+      });
+    });
+
+    it('clicking D: root button calls browsePath with D:\\', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Browse D:\\' })).toBeVisible(),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Browse D:\\' }));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('D:\\');
+      });
+    });
+
+    it('does not render root picker buttons on POSIX (single root)', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        posixResponse('/Users/you'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('Users')).toBeVisible());
+
+      // No "Browse /" aria-label root picker buttons should appear
+      expect(screen.queryByRole('button', { name: 'Browse /' })).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Home button
+  // ---------------------------------------------------------------------------
+
+  describe('Home button', () => {
+    it('home button navigates to ~ on POSIX', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        posixResponse('/Users/you/dev'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('Users')).toBeVisible());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Home' }));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('~');
+      });
+    });
+
+    it('home button navigates to ~ on Windows', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users\\you'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() => expect(screen.getByText('you')).toBeVisible());
+
+      fireEvent.click(screen.getByRole('button', { name: 'Home' }));
+
+      await waitFor(() => {
+        expect(apiClient.browsePath).toHaveBeenCalledWith('~');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Select button label
+  // ---------------------------------------------------------------------------
+
+  describe('Select button label', () => {
+    it('shows last segment as label on POSIX', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        posixResponse('/Users/you/dev'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Select dev/i })).toBeVisible(),
+      );
+    });
+
+    it('shows last segment as label on Windows', async () => {
+      const { apiClient } = await import('@/lib/api/client');
+      vi.mocked(apiClient.browsePath).mockResolvedValue(
+        winResponse('C:\\Users\\you'),
+      );
+
+      renderWithProviders(
+        <PathPicker open onOpenChange={vi.fn()} onSelect={vi.fn()} />,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Select you/i })).toBeVisible(),
+      );
+    });
+  });
+});

--- a/packages/web/src/components/shared/path-picker.tsx
+++ b/packages/web/src/components/shared/path-picker.tsx
@@ -5,6 +5,7 @@ import {
   FolderGit2,
   FolderOpen,
   Home,
+  Link2,
   Loader2,
 } from 'lucide-react';
 import { apiClient } from '@/lib/api/client';
@@ -30,6 +31,52 @@ interface PathPickerProps {
   gitOnly?: boolean;
 }
 
+/**
+ * Build breadcrumb segments from a resolved path and server-provided context.
+ *
+ * Returns an array of { label, target } pairs where:
+ * - label  — the display name of the segment
+ * - target — the absolute path to navigate to when the crumb is clicked
+ *
+ * Examples:
+ *   POSIX /Users/you/dev  → [{ label:'Users', target:'/Users' }, { label:'you', target:'/Users/you' }, ...]
+ *   Windows C:\Users\you  → [{ label:'C:', target:'C:\\' }, { label:'Users', target:'C:\\Users' }, ...]
+ */
+function buildBreadcrumbs(
+  resolvedPath: string,
+  separator: string,
+  roots: string[],
+): { label: string; target: string }[] {
+  const segments = resolvedPath.split(separator).filter(Boolean);
+  if (segments.length === 0) return [];
+
+  // Determine if this is a Windows-style path by checking whether the first
+  // segment matches any known root (e.g. "C:" matches root "C:\").
+  const firstSegment = segments[0] ?? '';
+  const firstMatchedRoot = roots.find(
+    (r) => r.toUpperCase() === firstSegment.toUpperCase() + separator,
+  );
+  const isWindowsStyle = firstMatchedRoot !== undefined;
+
+  return segments.map((segment, i) => {
+    let target: string;
+
+    if (isWindowsStyle) {
+      if (i === 0) {
+        // Drive root: navigate to "C:\" not "C:" (bare drive = cwd on that drive).
+        target = firstMatchedRoot!;
+      } else {
+        target = firstMatchedRoot! + segments.slice(1, i + 1).join(separator);
+      }
+    } else {
+      // POSIX: paths are rooted with a leading separator.
+      target = separator + segments.slice(0, i + 1).join(separator);
+    }
+
+    return { label: segment, target };
+  });
+}
+
 export function PathPicker({
   open,
   onOpenChange,
@@ -40,6 +87,9 @@ export function PathPicker({
 }: PathPickerProps) {
   const [currentPath, setCurrentPath] = useState('~');
   const [resolvedPath, setResolvedPath] = useState('');
+  const [parent, setParent] = useState<string | null>(null);
+  const [separator, setSeparator] = useState('/');
+  const [roots, setRoots] = useState<string[]>(['/']);
   const [entries, setEntries] = useState<FsEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -51,6 +101,9 @@ export function PathPicker({
     try {
       const result = await apiClient.browsePath(path);
       setResolvedPath(result.path);
+      setParent(result.parent);
+      setSeparator(result.separator);
+      setRoots(result.roots);
       setEntries(result.entries);
       setManualPath(result.path);
     } catch (err) {
@@ -72,8 +125,9 @@ export function PathPicker({
   };
 
   const navigateUp = () => {
-    const parent = resolvedPath.split('/').slice(0, -1).join('/') || '/';
-    navigateTo(parent);
+    if (parent !== null) {
+      navigateTo(parent);
+    }
   };
 
   const handleManualNav = () => {
@@ -86,7 +140,11 @@ export function PathPicker({
     onOpenChange(false);
   };
 
-  const breadcrumbs = resolvedPath.split('/').filter(Boolean);
+  const breadcrumbs = buildBreadcrumbs(resolvedPath, separator, roots);
+
+  // Last segment for the Select button label
+  const lastSegment =
+    resolvedPath.split(separator).filter(Boolean).at(-1) ?? 'folder';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -104,7 +162,7 @@ export function PathPicker({
               value={manualPath}
               onChange={(e) => setManualPath(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleManualNav()}
-              placeholder="/path/to/directory"
+              placeholder="Enter a path or browse"
               className="h-9 pl-10 pr-4 font-mono text-sm"
             />
           </div>
@@ -113,30 +171,51 @@ export function PathPicker({
           </Button>
         </div>
 
-        {/* Breadcrumb */}
+        {/* Breadcrumb + home + root pickers */}
         <div className="flex flex-wrap items-center gap-1 text-xs text-[var(--muted-foreground)]">
+          {/* Home button — always navigates to "~" so the server expands correctly */}
           <button
             type="button"
-            onClick={() => navigateTo('/')}
+            onClick={() => navigateTo('~')}
             className="inline-flex items-center gap-1 px-1.5 py-0.5 hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+            aria-label="Home"
           >
             <Home className="size-3" />
           </button>
-          {breadcrumbs.map((segment, i) => {
-            const segmentPath = '/' + breadcrumbs.slice(0, i + 1).join('/');
-            return (
-              <span key={segmentPath} className="inline-flex items-center gap-1">
-                <ChevronRight className="size-3" />
+
+          {/* Drive/root pickers — only shown when the server reports multiple roots (Windows) */}
+          {roots.length > 1 &&
+            roots.map((root) => {
+              // Display "C:" not "C:\" for brevity
+              const label = root.endsWith(separator)
+                ? root.slice(0, -separator.length)
+                : root;
+              return (
                 <button
+                  key={root}
                   type="button"
-                  onClick={() => navigateTo(segmentPath)}
-                  className=" px-1.5 py-0.5 hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+                  onClick={() => navigateTo(root)}
+                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 font-mono hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+                  aria-label={`Browse ${root}`}
                 >
-                  {segment}
+                  {label}
                 </button>
-              </span>
-            );
-          })}
+              );
+            })}
+
+          {/* Breadcrumb segments built from server-provided separator */}
+          {breadcrumbs.map(({ label, target }) => (
+            <span key={target} className="inline-flex items-center gap-1">
+              <ChevronRight className="size-3" />
+              <button
+                type="button"
+                onClick={() => navigateTo(target)}
+                className="px-1.5 py-0.5 hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+              >
+                {label}
+              </button>
+            </span>
+          ))}
         </div>
 
         {/* Entry list */}
@@ -153,15 +232,17 @@ export function PathPicker({
             </div>
           ) : (
             <div className="divide-y divide-[color:var(--border-subtle)]">
-              {/* Go up */}
-              <button
-                type="button"
-                onClick={navigateUp}
-                className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors hover:bg-[color:var(--surface-2)]"
-              >
-                <Folder className="size-4 text-[var(--muted-foreground)]" />
-                <span className="text-[var(--muted-foreground)]">..</span>
-              </button>
+              {/* Go up — disabled (hidden) when at a filesystem root */}
+              {parent !== null && (
+                <button
+                  type="button"
+                  onClick={navigateUp}
+                  className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors hover:bg-[color:var(--surface-2)]"
+                >
+                  <Folder className="size-4 text-[var(--muted-foreground)]" />
+                  <span className="text-[var(--muted-foreground)]">..</span>
+                </button>
+              )}
               {entries.map((entry) => (
                 <button
                   type="button"
@@ -181,9 +262,7 @@ export function PathPicker({
                     }
                   }}
                   className={`flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors hover:bg-[color:var(--surface-2)] ${
-                    entry.is_git_repo
-                      ? 'bg-[var(--primary)]/5'
-                      : ''
+                    entry.is_git_repo ? 'bg-[var(--primary)]/5' : ''
                   }`}
                 >
                   {entry.is_git_repo ? (
@@ -195,6 +274,12 @@ export function PathPicker({
                   {entry.is_git_repo && (
                     <span className="shrink-0 border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--primary)]">
                       git repo
+                    </span>
+                  )}
+                  {entry.is_link && (
+                    <span className="inline-flex shrink-0 items-center gap-0.5 border border-[var(--muted-foreground)]/30 bg-[var(--muted)]/40 px-2 py-0.5 text-[10px] font-medium text-[var(--muted-foreground)]">
+                      <Link2 className="size-2.5" />
+                      link
                     </span>
                   )}
                   <ChevronRight className="size-3.5 text-[var(--muted-foreground)]" />
@@ -210,7 +295,7 @@ export function PathPicker({
           </Button>
           <Button onClick={handleSelect} disabled={!resolvedPath}>
             <FolderOpen className="size-4" />
-            Select {resolvedPath.split('/').at(-1) || 'folder'}
+            Select {lastSegment}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/packages/web/src/lib/api/generated-wire-types.ts
+++ b/packages/web/src/lib/api/generated-wire-types.ts
@@ -135,3 +135,19 @@ export interface DoctorReportResponse {
   fail_count: number;
   warn_count: number;
 }
+
+export interface FsEntryResponse {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  is_git_repo: boolean;
+  is_link: boolean;
+}
+
+export interface FsBrowseResponse {
+  path: string;
+  parent: string | null;
+  separator: string;
+  roots: string[];
+  entries: FsEntryResponse[];
+}

--- a/packages/web/src/lib/api/types.ts
+++ b/packages/web/src/lib/api/types.ts
@@ -11,6 +11,7 @@ import type {
     ChatSessionResponse,
     ChatSessionSummaryResponse,
     EventResponse,
+    FsEntryResponse,
     ProjectResponse,
     RepositoryResponse,
     ReviewVerdictResponse,
@@ -205,21 +206,8 @@ export interface WorkflowResolvedSettings {
 // Filesystem browsing
 // ---------------------------------------------------------------------------
 
-export interface FsEntry {
-    name: string;
-    path: string;
-    is_dir: boolean;
-    is_git_repo: boolean;
-    is_link: boolean;
-}
-
-export interface FsBrowseResponse {
-    path: string;
-    parent: string | null;
-    separator: string;
-    roots: string[];
-    entries: FsEntry[];
-}
+export type FsEntry = FsEntryResponse;
+export type { FsBrowseResponse } from "./generated-wire-types";
 
 // ---------------------------------------------------------------------------
 // Client presence

--- a/packages/web/src/lib/api/types.ts
+++ b/packages/web/src/lib/api/types.ts
@@ -210,10 +210,14 @@ export interface FsEntry {
     path: string;
     is_dir: boolean;
     is_git_repo: boolean;
+    is_link: boolean;
 }
 
 export interface FsBrowseResponse {
     path: string;
+    parent: string | null;
+    separator: string;
+    roots: string[];
     entries: FsEntry[];
 }
 

--- a/src/kagan/cli/chat/acp.py
+++ b/src/kagan/cli/chat/acp.py
@@ -37,6 +37,7 @@ from kagan.core import (
     get_backend_spec,
     resolve_orchestrator_prompt,
 )
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.errors import AgentError
 
 _ACP_CLIENT_NAME = "kagan"
@@ -165,6 +166,7 @@ async def run_orchestrator_turn(
         return ""
 
     exe, exe_args = _resolve_acp_command_for_backend(agent_backend)
+    resolved_cmd = resolve_spawn_command(exe, *exe_args)
     session_id = mcp_session_id or uuid4().hex[:16]
     db_path = str(default_db_path())
     resolved_cwd = cwd or Path.cwd()
@@ -191,8 +193,8 @@ async def run_orchestrator_turn(
     try:
         async with acp.spawn_agent_process(
             capture_client,
-            exe,
-            *exe_args,
+            resolved_cmd[0],
+            *resolved_cmd[1:],
             cwd=str(resolved_cwd),
             env=env,
             transport_kwargs={"limit": _ACP_STDIO_BUFFER_LIMIT_BYTES},

--- a/src/kagan/core/_agent.py
+++ b/src/kagan/core/_agent.py
@@ -23,6 +23,7 @@ from typing import Any, Final, Literal, TypedDict, cast
 
 from loguru import logger
 
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.errors import AgentError
 from kagan.runtime_env import build_sanitized_subprocess_environment
 
@@ -691,7 +692,7 @@ def _copilot_builtin_acp_supported() -> bool:
 
     try:
         completed = subprocess.run(
-            ["copilot", "--acp", "--help"],
+            resolve_spawn_command("copilot", "--acp", "--help"),
             capture_output=True,
             text=True,
             timeout=5,
@@ -801,7 +802,7 @@ async def _prepare_spawn(
                 ) from exc
             raise AgentError(f"Failed to write MCP manifest to {mcp_path}: {exc}") from exc
 
-    cmd: list[str] = [entry["executable"]]
+    cmd: list[str] = list(resolve_spawn_command(entry["executable"]))
     if entry["workdir_flag"]:
         cmd += [entry["workdir_flag"], str(worktree_path)]
 
@@ -984,7 +985,7 @@ async def spawn_agent_via_acp(
     )
     acp_cmd = resolve_acp_command(backend_name)
     if acp_cmd:
-        cmd = list(acp_cmd)
+        cmd = list(resolve_spawn_command(acp_cmd[0], *acp_cmd[1:]))
     if spec.acp_args:
         cmd.extend(spec.acp_args)
 

--- a/src/kagan/core/_agent.py
+++ b/src/kagan/core/_agent.py
@@ -10,9 +10,7 @@ import contextlib
 import errno
 import functools
 import json
-import os
 import shutil
-import signal
 import subprocess
 import sys
 from collections.abc import Callable, Mapping
@@ -30,36 +28,52 @@ from kagan.runtime_env import build_sanitized_subprocess_environment
 # Registry of spawned processes for cleanup
 _spawned_processes: dict[str, asyncio.subprocess.Process] = {}
 
-# Scheduled timeout handles for agent processes (pid -> TimerHandle)
-_AGENT_TIMEOUTS: dict[int, asyncio.TimerHandle] = {}
+
+@dataclass(slots=True)
+class _AgentTimeout:
+    """Bundles an asyncio Process handle with its pending timer handle."""
+
+    proc: asyncio.subprocess.Process
+    handle: asyncio.TimerHandle
+
+
+# Scheduled timeout records for agent processes (pid -> _AgentTimeout)
+_AGENT_TIMEOUTS: dict[int, _AgentTimeout] = {}
 
 _AGENT_TIMEOUT_GRACE_SECONDS: Final[float] = 5.0
 
 
-def _kill_agent(pid: int) -> None:
-    """Send SIGTERM to an agent process, then SIGKILL after a grace period."""
-    logger.warning("Agent pid={} exceeded timeout, sending SIGTERM", pid)
-    try:
-        os.kill(pid, signal.SIGTERM)
-    except ProcessLookupError:
-        _AGENT_TIMEOUTS.pop(pid, None)
-        return
+def _force_kill(proc: asyncio.subprocess.Process) -> None:
+    """Kill the process unconditionally after the grace period expires."""
+    pid = proc.pid
+    logger.warning(
+        "Agent pid={} did not exit after terminate grace period, force-killing", pid
+    )
+    if proc.returncode is None:
+        with contextlib.suppress(OSError, ProcessLookupError):
+            proc.kill()
+    _AGENT_TIMEOUTS.pop(pid, None)
 
-    def _force_kill(pid: int) -> None:
-        logger.warning("Agent pid={} did not exit after SIGTERM grace period, sending SIGKILL", pid)
-        with contextlib.suppress(ProcessLookupError):
-            os.kill(pid, signal.SIGKILL)
-        _AGENT_TIMEOUTS.pop(pid, None)
+
+def _kill_agent(proc: asyncio.subprocess.Process) -> None:
+    """Terminate an agent process via its handle, then force-kill after a grace period.
+
+    Uses ``proc.terminate()`` (POSIX: SIGTERM; Windows: TerminateProcess) so the
+    path is safe on Windows where ``signal.SIGKILL`` does not exist and
+    ``os.kill(pid, SIGTERM)`` is a no-op for detached processes.
+    """
+    pid = proc.pid
+    logger.warning("Agent pid={} exceeded timeout, terminating", pid)
+    with contextlib.suppress(OSError, ProcessLookupError):
+        proc.terminate()
 
     try:
         loop = asyncio.get_running_loop()
-        handle = loop.call_later(_AGENT_TIMEOUT_GRACE_SECONDS, _force_kill, pid)
-        _AGENT_TIMEOUTS[pid] = handle
+        handle = loop.call_later(_AGENT_TIMEOUT_GRACE_SECONDS, _force_kill, proc)
+        _AGENT_TIMEOUTS[pid] = _AgentTimeout(proc=proc, handle=handle)
     except RuntimeError:
-        # No running loop — best-effort force kill
-        with contextlib.suppress(ProcessLookupError):
-            os.kill(pid, signal.SIGKILL)
-        _AGENT_TIMEOUTS.pop(pid, None)
+        # No running loop — best-effort immediate kill
+        _force_kill(proc)
 
 
 async def register_spawned_process(session_id: str, proc: asyncio.subprocess.Process) -> None:
@@ -68,15 +82,23 @@ async def register_spawned_process(session_id: str, proc: asyncio.subprocess.Pro
 
 
 async def unregister_spawned_process(session_id: str) -> None:
-    """Unregister a process when it's no longer needed."""
-    _spawned_processes.pop(session_id, None)
+    """Unregister a process when it exits naturally.
+
+    Also cancels any pending timeout timer so the kill callback does not fire
+    on a process that has already been reclaimed.
+    """
+    proc = _spawned_processes.pop(session_id, None)
+    if proc is not None and proc.pid is not None:
+        entry = _AGENT_TIMEOUTS.pop(proc.pid, None)
+        if entry is not None:
+            entry.handle.cancel()
 
 
 async def cleanup_all_spawned_processes() -> None:
     """Terminate all tracked processes. Called on shutdown."""
     # Cancel all pending timeout handles
-    for _pid, handle in list(_AGENT_TIMEOUTS.items()):
-        handle.cancel()
+    for _pid, entry in list(_AGENT_TIMEOUTS.items()):
+        entry.handle.cancel()
     _AGENT_TIMEOUTS.clear()
 
     for _session_id, proc in list(_spawned_processes.items()):
@@ -872,8 +894,8 @@ async def spawn_agent(
     # Schedule a timeout kill if requested
     if timeout_seconds is not None and proc.pid is not None:
         loop = asyncio.get_running_loop()
-        handle = loop.call_later(timeout_seconds, _kill_agent, proc.pid)
-        _AGENT_TIMEOUTS[proc.pid] = handle
+        handle = loop.call_later(timeout_seconds, _kill_agent, proc)
+        _AGENT_TIMEOUTS[proc.pid] = _AgentTimeout(proc=proc, handle=handle)
         logger.debug("Agent process started, pid={}, timeout={}s", proc.pid, timeout_seconds)
     else:
         logger.debug("Agent process started, pid={}", proc.pid)

--- a/src/kagan/core/_launchers.py
+++ b/src/kagan/core/_launchers.py
@@ -21,6 +21,7 @@ from typing import Any
 from loguru import logger
 
 from kagan.core._agent import build_mcp_manifest, get_backend_spec
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.errors import AgentError
 from kagan.runtime_env import build_sanitized_subprocess_environment
 
@@ -129,20 +130,17 @@ async def _run_detached(
         kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
     kwargs["env"] = build_sanitized_subprocess_environment()
 
-    proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
+    resolved = resolve_spawn_command(cmd[0], *cmd[1:]) if cmd else list(cmd)
+    proc = await asyncio.create_subprocess_exec(*resolved, **kwargs)
     await proc.wait()
 
 
 async def _tmux_send_keys(session_name: str, text: str) -> None:
     """Send keys to a tmux session."""
     env = build_sanitized_subprocess_environment()
+    resolved = resolve_spawn_command("tmux", "send-keys", "-t", session_name, text, "Enter")
     proc = await asyncio.create_subprocess_exec(
-        "tmux",
-        "send-keys",
-        "-t",
-        session_name,
-        text,
-        "Enter",
+        *resolved,
         env=env,
         stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.DEVNULL,

--- a/src/kagan/core/_persona.py
+++ b/src/kagan/core/_persona.py
@@ -17,6 +17,7 @@ from kagan.core._prompts import (
     load_persona_repo_whitelist,
     serialize_persona_definitions,
 )
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.runtime_env import build_sanitized_subprocess_environment
 
 if TYPE_CHECKING:
@@ -349,8 +350,9 @@ def _validate_repo_path(path: str) -> None:
 
 
 async def _run_gh_cmd(*args: str) -> tuple[bytes, bytes, int]:
+    resolved = resolve_spawn_command(args[0], *args[1:]) if args else list(args)
     proc = await asyncio.create_subprocess_exec(
-        *args,
+        *resolved,
         env=build_sanitized_subprocess_environment(),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/src/kagan/core/_subprocess.py
+++ b/src/kagan/core/_subprocess.py
@@ -1,0 +1,79 @@
+"""Platform-aware command resolution for asyncio.create_subprocess_exec.
+
+On Windows, ``asyncio.create_subprocess_exec`` calls ``CreateProcess`` directly,
+which neither honours ``PATHEXT`` nor executes ``.cmd`` / ``.bat`` files.
+Node-based CLI tools (claude, codex, gemini, copilot, ...) and IDE launchers
+(code.cmd, cursor.cmd) install as ``.cmd`` shims, so bare-name invocations
+fail with ``FileNotFoundError`` and full ``.cmd`` paths fail with
+``WinError 193`` (not a valid Win32 application).
+
+``resolve_spawn_command`` wraps the executable in the appropriate interpreter
+so every spawn site works correctly on Windows while being a no-op on POSIX.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+__all__ = ["resolve_spawn_command"]
+
+
+def resolve_spawn_command(executable: str, *args: str) -> list[str]:
+    """Resolve a command for ``asyncio.create_subprocess_exec`` on any platform.
+
+    On POSIX returns ``[executable, *args]`` (or ``[resolved, *args]`` if
+    ``shutil.which`` finds an alternative path — functionally equivalent).
+
+    On Windows:
+
+    - Resolves via ``shutil.which()`` so ``PATHEXT`` is honoured (finds
+      ``.cmd`` / ``.bat`` / ``.ps1`` / ``.exe`` shims).
+    - If the resolved path ends in ``.cmd`` or ``.bat`` returns
+      ``["cmd.exe", "/c", resolved, *args]``.
+    - If the resolved path ends in ``.ps1`` returns
+      ``["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File",
+      resolved, *args]``.
+    - Otherwise (``.exe`` or a bare path that is a PE binary) returns
+      ``[resolved, *args]``.
+    - If ``shutil.which()`` returns ``None`` falls back to
+      ``[executable, *args]`` so the caller still sees ``FileNotFoundError``
+      with the original name in the error message.
+
+    Absolute paths skip ``which`` and have their suffix inspected directly.
+    Suffix matching is case-insensitive so ``.CMD`` and ``.cmd`` both work.
+    """
+    if sys.platform != "win32":
+        resolved = shutil.which(executable)
+        result_exe = resolved if resolved is not None else executable
+        return [result_exe, *args]
+
+    # --- Windows path ---
+
+    # If the caller passed an absolute path, skip which() and inspect suffix.
+    if Path(executable).is_absolute():
+        return _wrap_windows(executable, args)
+
+    resolved = shutil.which(executable)
+    if resolved is None:
+        # Fall back so FileNotFoundError names the original executable.
+        return [executable, *args]
+
+    return _wrap_windows(resolved, args)
+
+
+def _wrap_windows(resolved: str, args: tuple[str, ...]) -> list[str]:
+    """Wrap *resolved* in the correct Windows interpreter based on its suffix."""
+    suffix = Path(resolved).suffix.lower()
+    if suffix in {".cmd", ".bat"}:
+        return ["cmd.exe", "/c", resolved, *args]
+    if suffix == ".ps1":
+        return [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            resolved,
+            *args,
+        ]
+    return [resolved, *args]

--- a/src/kagan/core/plugins/_github.py
+++ b/src/kagan/core/plugins/_github.py
@@ -23,6 +23,7 @@ from typing import Any, Final, TypedDict
 from loguru import logger
 
 from kagan.core import CheckStatus, KaganCore, PreflightCheckResult
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.enums import Priority
 from kagan.core.errors import KaganError, NotFoundError
 from kagan.core.plugins import ImporterPlugin, ImportResult, PluginError, PluginSyncError
@@ -83,10 +84,9 @@ def _gh_path() -> str | None:
 
 async def _gh_is_authenticated() -> bool:
     try:
+        resolved = resolve_spawn_command("gh", "auth", "token")
         proc = await asyncio.create_subprocess_exec(
-            "gh",
-            "auth",
-            "token",
+            *resolved,
             env=build_sanitized_subprocess_environment(),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -114,8 +114,9 @@ async def _gh_fetch_issues(config: GitHubImportConfig) -> list[GitHubIssue]:
     for lbl in config.labels:
         cmd.extend(["--label", lbl])
 
+    resolved = resolve_spawn_command(cmd[0], *cmd[1:])
     proc = await asyncio.create_subprocess_exec(
-        *cmd,
+        *resolved,
         env=build_sanitized_subprocess_environment(),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -235,7 +236,7 @@ class GitHubImporter(ImporterPlugin):
 
         try:
             result = subprocess.run(
-                ["gh", "auth", "token"],
+                resolve_spawn_command("gh", "auth", "token"),
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/src/kagan/runtime_env.py
+++ b/src/kagan/runtime_env.py
@@ -9,8 +9,10 @@ import os
 import sys
 from collections.abc import Mapping, MutableMapping
 
-# Essential environment variables that should always be preserved in subprocesses
-_ESSENTIAL_ENV: frozenset[str] = frozenset(
+# Essential environment variables that should always be preserved in subprocesses.
+# Platform-specific sets are selected at call time via _essential_env().
+
+_ESSENTIAL_ENV_POSIX: frozenset[str] = frozenset(
     {
         "PATH",
         "HOME",
@@ -24,6 +26,50 @@ _ESSENTIAL_ENV: frozenset[str] = frozenset(
         "SSH_AUTH_SOCK",
     }
 )
+
+_ESSENTIAL_ENV_WINDOWS: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "TEMP",
+        "TMP",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "PROGRAMFILES",
+        "PROGRAMFILES(X86)",
+        "PROGRAMDATA",
+        "USERNAME",
+        "COMPUTERNAME",
+        "USERDOMAIN",
+        "LANG",
+        "LC_ALL",
+        "EDITOR",
+    }
+)
+
+# Backwards-compatible alias — points to the POSIX set (unchanged behaviour).
+_ESSENTIAL_ENV: frozenset[str] = _ESSENTIAL_ENV_POSIX
+
+
+def _essential_env(platform_name: str | None = None) -> frozenset[str]:
+    """Return the platform-appropriate set of essential environment variable names.
+
+    Args:
+        platform_name: Platform identifier (win32, linux, darwin, …).
+            Defaults to sys.platform.
+
+    Returns:
+        Frozenset of environment variable names that must be preserved.
+    """
+    key = (platform_name or sys.platform).lower()
+    return _ESSENTIAL_ENV_WINDOWS if key == "win32" else _ESSENTIAL_ENV_POSIX
+
 
 # Sensitive patterns that should be stripped from environment variables
 # These match anywhere in the variable name (case-insensitive)
@@ -143,11 +189,12 @@ def build_sanitized_subprocess_environment(
     base_env: Mapping[str, str] | None = None,
     *,
     allow_extra: Mapping[str, str] | None = None,
+    platform_name: str | None = None,
 ) -> dict[str, str]:
     """Build a sanitized environment for subprocess execution.
 
     This function creates an allowlist-based sanitized environment by:
-    1. Starting with essential environment variables (PATH, HOME, etc.)
+    1. Starting with essential environment variables (platform-aware allowlist)
     2. Adding any explicitly allowed extra variables
     3. Stripping variables matching sensitive patterns (tokens, keys, secrets)
     4. Stripping Python-specific variables (PYTHONPATH, PYTHONHOME, etc.)
@@ -157,6 +204,9 @@ def build_sanitized_subprocess_environment(
         base_env: Base environment to sanitize. Defaults to os.environ.
         allow_extra: Additional environment variables to allow (name -> value).
             These override base_env values and bypass sensitive pattern checks.
+        platform_name: Platform identifier (win32, linux, darwin, …).
+            Defaults to sys.platform. Pass an explicit value in tests to verify
+            cross-platform behaviour without running on the target OS.
 
     Returns:
         Sanitized environment dictionary safe for subprocess execution.
@@ -166,10 +216,11 @@ def build_sanitized_subprocess_environment(
         >>> # env contains only essential vars + MY_VAR, no secrets
     """
     source_env = base_env if base_env is not None else os.environ
+    essential = _essential_env(platform_name)
 
     # Start with essential variables from source environment
     sanitized: dict[str, str] = {}
-    for key in _ESSENTIAL_ENV:
+    for key in essential:
         if key in source_env:
             sanitized[key] = source_env[key]
 
@@ -192,6 +243,6 @@ def build_sanitized_subprocess_environment(
         sanitized.pop(key, None)
 
     # Also strip noisy platform-specific variables
-    strip_noisy_environment_variables(sanitized)
+    strip_noisy_environment_variables(sanitized, platform_name=platform_name)
 
     return sanitized

--- a/src/kagan/server/_helpers.py
+++ b/src/kagan/server/_helpers.py
@@ -63,6 +63,12 @@ def _error_response(exc: Exception) -> JSONResponse:
     if isinstance(exc, ValueError | TypeError):
         logger.debug("Route handler validation error: {}", exc)
         return _err(str(exc), status=400, error_code=error_code)
+    if isinstance(exc, FileNotFoundError | NotADirectoryError):
+        logger.debug("Route handler path error: {}", exc)
+        return _err(str(exc), status=400, error_code=error_code)
+    if isinstance(exc, PermissionError):
+        logger.debug("Route handler permission denied: {}", exc)
+        return _err(str(exc), status=403, error_code=error_code)
 
     logger.exception("Unexpected error in route handler")
     return _err("Internal server error", status=500)

--- a/src/kagan/server/_plugin_routes.py
+++ b/src/kagan/server/_plugin_routes.py
@@ -90,8 +90,6 @@ def register_plugin_routes(mcp: FastMCP) -> None:
         repo_path_param = request.query_params.get("repo_path")
         if repo_path_param:
             repo_path = Path(repo_path_param).resolve()
-            if not repo_path.is_relative_to(Path.home()):
-                return _err("Path outside allowed boundaries", status=403)
         else:
             repo_path = await _resolve_selected_repo_path(ctx)
         if repo_path is None:

--- a/src/kagan/server/_system_routes.py
+++ b/src/kagan/server/_system_routes.py
@@ -165,26 +165,22 @@ def register_system_routes(mcp: FastMCP) -> None:
             try:
                 with os.scandir(target) as it:
                     for entry in it:
-                        if _is_hidden(entry):
-                            continue
                         try:
+                            if _is_hidden(entry):
+                                continue
                             is_symlink = entry.is_symlink()
-                            # Include junctions (Windows) and symlinks.
-                            # is_junction() available from Python 3.12.
                             is_junction = (
                                 Path(entry.path).is_junction()
                                 if hasattr(Path, "is_junction")
                                 else False
                             )
                             is_link = is_symlink or is_junction
-                            # Follow links/junctions to determine if they point at a dir.
-                            is_dir = entry.is_dir(follow_symlinks=True)
+                            if not entry.is_dir(follow_symlinks=True):
+                                continue
+                            full_path = str(Path(entry.path).resolve())
+                            is_git = (Path(entry.path) / ".git").exists()
                         except OSError:
                             continue
-                        if not is_dir:
-                            continue
-                        full_path = str(Path(entry.path).resolve())
-                        is_git = (Path(entry.path) / ".git").exists()
                         entry_models.append(
                             FsEntryResponse(
                                 name=entry.name,

--- a/src/kagan/server/_system_routes.py
+++ b/src/kagan/server/_system_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -124,42 +125,86 @@ def register_system_routes(mcp: FastMCP) -> None:
     async def browse_filesystem(request: Request, *, ctx: Any) -> JSONResponse:
         import asyncio
 
+        from kagan.server.responses import FsBrowseResponse, FsEntryResponse
+
         raw_path = request.query_params.get("path", "~")
+
+        def _get_roots() -> list[str]:
+            """Return available filesystem roots for the current platform."""
+            if os.name == "nt":
+                import ctypes
+
+                bitmask: int = ctypes.windll.kernel32.GetLogicalDrives()  # type: ignore[attr-defined]  # Windows-only API
+                return [f"{chr(ord('A') + i)}:\\" for i in range(26) if bitmask & (1 << i)]
+            return ["/"]
+
+        def _is_hidden(entry: os.DirEntry[str]) -> bool:
+            """Return True if the entry should be hidden from the listing."""
+            if entry.name.startswith("."):
+                return True
+            if os.name == "nt":
+                try:
+                    file_stat = entry.stat(follow_symlinks=False)
+                    if getattr(file_stat, "st_file_attributes", 0) & stat.FILE_ATTRIBUTE_HIDDEN:  # type: ignore[attr-defined]  # Windows-only stat attribute
+                        return True
+                except OSError:
+                    pass
+            return False
 
         def _list_dir(raw: str) -> dict[str, Any]:
             target = Path(raw).expanduser().resolve()
-            if not target.is_relative_to(Path.home()):
-                raise ValueError("Path outside allowed boundaries")
+            if not target.exists():
+                raise FileNotFoundError(f"Path does not exist: {target}")
             if not target.is_dir():
-                raise ValueError("Invalid path: not a directory")
+                raise NotADirectoryError(f"Not a directory: {target}")
 
-            entries: list[dict[str, Any]] = []
+            parent_path = target.parent
+            parent: str | None = str(parent_path) if parent_path != target else None
+
+            entry_models: list[FsEntryResponse] = []
             try:
                 with os.scandir(target) as it:
                     for entry in it:
-                        if entry.name.startswith("."):
+                        if _is_hidden(entry):
                             continue
                         try:
-                            is_dir = entry.is_dir(follow_symlinks=False)
+                            is_symlink = entry.is_symlink()
+                            # Include junctions (Windows) and symlinks.
+                            # is_junction() available from Python 3.12.
+                            is_junction = (
+                                Path(entry.path).is_junction()
+                                if hasattr(Path, "is_junction")
+                                else False
+                            )
+                            is_link = is_symlink or is_junction
+                            # Follow links/junctions to determine if they point at a dir.
+                            is_dir = entry.is_dir(follow_symlinks=True)
                         except OSError:
                             continue
                         if not is_dir:
                             continue
                         full_path = str(Path(entry.path).resolve())
                         is_git = (Path(entry.path) / ".git").exists()
-                        entries.append(
-                            {
-                                "name": entry.name,
-                                "path": full_path,
-                                "is_dir": True,
-                                "is_git_repo": is_git,
-                            }
+                        entry_models.append(
+                            FsEntryResponse(
+                                name=entry.name,
+                                path=full_path,
+                                is_dir=True,
+                                is_git_repo=is_git,
+                                is_link=is_link,
+                            )
                         )
-            except PermissionError:
-                pass
+            except PermissionError as exc:
+                raise PermissionError(str(exc)) from exc
 
-            entries.sort(key=lambda e: (not e["is_git_repo"], e["name"].lower()))
-            return {"path": str(target), "entries": entries}
+            entry_models.sort(key=lambda e: (not e.is_git_repo, e.name.lower()))
+            return FsBrowseResponse(
+                path=str(target),
+                parent=parent,
+                separator=os.sep,
+                roots=_get_roots(),
+                entries=entry_models,
+            ).model_dump(mode="json")
 
         result = await asyncio.to_thread(_list_dir, raw_path)
         return _ok(result)

--- a/src/kagan/server/responses.py
+++ b/src/kagan/server/responses.py
@@ -221,6 +221,29 @@ class ChatSessionResponse(ChatSessionSummaryResponse):
     messages: list[ChatMessageResponse]
 
 
+# ── Filesystem browser ───────────────────────────────────────────────────────
+
+
+class FsEntryResponse(BaseModel):
+    """A single directory entry returned by GET /api/fs/browse."""
+
+    name: str
+    path: str
+    is_dir: bool
+    is_git_repo: bool
+    is_link: bool
+
+
+class FsBrowseResponse(BaseModel):
+    """Response shape for GET /api/fs/browse."""
+
+    path: str
+    parent: str | None
+    separator: str
+    roots: list[str]
+    entries: list[FsEntryResponse]
+
+
 # ── Doctor / preflight ───────────────────────────────────────────────────────
 
 
@@ -263,4 +286,6 @@ RESPONSE_MODELS: dict[str, type[BaseModel]] = {
     "ChatSessionResponse": ChatSessionResponse,
     "DoctorCheckResponse": DoctorCheckResponse,
     "DoctorReportResponse": DoctorReportResponse,
+    "FsEntryResponse": FsEntryResponse,
+    "FsBrowseResponse": FsBrowseResponse,
 }

--- a/src/kagan/tui/screens/kanban.py
+++ b/src/kagan/tui/screens/kanban.py
@@ -17,6 +17,7 @@ from kagan.cli.chat import (
     warm_orchestrator_backend,
 )
 from kagan.core import resolve_launcher
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.enums import ChatMode, Priority, SessionKind, TaskStatus
 from kagan.core.errors import KaganError
 from kagan.core.models import Task, Worktree
@@ -1235,11 +1236,9 @@ class KanbanScreen(Screen[None]):
         import asyncio as _aio
 
         try:
+            resolved = resolve_spawn_command("tmux", "attach-session", "-t", session_name)
             proc = await _aio.create_subprocess_exec(
-                "tmux",
-                "attach-session",
-                "-t",
-                session_name,
+                *resolved,
                 env=build_sanitized_subprocess_environment(),
             )
         except OSError:
@@ -1253,9 +1252,9 @@ class KanbanScreen(Screen[None]):
 
         target = str(prompt_path) if prompt_path.exists() else str(workspace_path)
         try:
+            resolved = resolve_spawn_command("nvim", target)
             proc = await _aio.create_subprocess_exec(
-                "nvim",
-                target,
+                *resolved,
                 cwd=str(workspace_path),
                 env=build_sanitized_subprocess_environment(),
             )

--- a/src/kagan/tui/screens/session_dashboard.py
+++ b/src/kagan/tui/screens/session_dashboard.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Input, Label, Select, Static
 
 from kagan.cli.chat import resolve_default_agent_backend
 from kagan.core import git
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.enums import ChatMode, SessionEventType, SessionKind, SessionStatus
 from kagan.core.errors import KaganError, NotFoundError, SessionError, WorktreeError
 from kagan.core.models import Session
@@ -786,13 +787,11 @@ class SessionDashboardScreen(Screen[None]):
         return await self.kagan_app.core.tasks.sessions.list_for_task(self._task_id)
 
     async def _load_commits(self, worktree_path: str, base_branch: str) -> list[tuple[str, str]]:
+        resolved = resolve_spawn_command(
+            "git", "-C", worktree_path, "log", "--pretty=format:%h%x09%s", f"{base_branch}..HEAD"
+        )
         proc = await asyncio.create_subprocess_exec(
-            "git",
-            "-C",
-            worktree_path,
-            "log",
-            "--pretty=format:%h%x09%s",
-            f"{base_branch}..HEAD",
+            *resolved,
             env=build_sanitized_subprocess_environment(),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,

--- a/tests/core/unit/test_subprocess_resolve.py
+++ b/tests/core/unit/test_subprocess_resolve.py
@@ -1,0 +1,168 @@
+"""Unit tests for kagan.core._subprocess.resolve_spawn_command."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from kagan.core._subprocess import resolve_spawn_command
+
+pytestmark = [pytest.mark.core, pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# POSIX behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_posix_bare_name_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with patch("kagan.core._subprocess.shutil.which", return_value="/usr/bin/npx"):
+        result = resolve_spawn_command("npx", "claude-code-acp")
+    assert result == ["/usr/bin/npx", "claude-code-acp"]
+
+
+def test_posix_which_none_falls_back_to_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with patch("kagan.core._subprocess.shutil.which", return_value=None):
+        result = resolve_spawn_command("missing-tool", "--flag")
+    assert result == ["missing-tool", "--flag"]
+
+
+def test_posix_no_extra_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    with patch("kagan.core._subprocess.shutil.which", return_value="/usr/local/bin/gh"):
+        result = resolve_spawn_command("gh")
+    assert result == ["/usr/local/bin/gh"]
+
+
+# ---------------------------------------------------------------------------
+# Windows .cmd / .bat wrapping
+# ---------------------------------------------------------------------------
+
+
+def test_windows_cmd_shim_wrapped_with_cmd_exe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = r"C:\Users\user\AppData\Roaming\npm\claude.cmd"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("claude", "-p", "hello")
+    assert result == ["cmd.exe", "/c", resolved, "-p", "hello"]
+
+
+def test_windows_bat_shim_wrapped_with_cmd_exe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = r"C:\tools\run.bat"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("run", "--flag")
+    assert result == ["cmd.exe", "/c", resolved, "--flag"]
+
+
+def test_windows_ps1_wrapped_with_powershell(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = r"C:\tools\deploy.ps1"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("deploy", "--env", "prod")
+    assert result == [
+        "powershell",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        resolved,
+        "--env",
+        "prod",
+    ]
+
+
+def test_windows_exe_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = r"C:\Program Files\GitHub CLI\gh.exe"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("gh", "auth", "token")
+    assert result == [resolved, "auth", "token"]
+
+
+def test_windows_which_none_falls_back_to_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    with patch("kagan.core._subprocess.shutil.which", return_value=None):
+        result = resolve_spawn_command("missing-tool", "--flag")
+    assert result == ["missing-tool", "--flag"]
+
+
+# ---------------------------------------------------------------------------
+# Absolute path — skip which(), inspect suffix
+# ---------------------------------------------------------------------------
+# Note: these tests use POSIX-style absolute paths (/...) so that
+# Path.is_absolute() returns True when the test suite runs on macOS/Linux.
+# On a real Windows host the same logic handles C:\... paths correctly.
+
+
+def test_absolute_cmd_path_wraps_without_calling_which(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    abs_path = "/tools/claude.cmd"
+    with patch("kagan.core._subprocess.shutil.which") as mock_which:
+        result = resolve_spawn_command(abs_path, "--flag")
+    mock_which.assert_not_called()
+    assert result == ["cmd.exe", "/c", abs_path, "--flag"]
+
+
+def test_absolute_exe_path_passes_through_without_calling_which(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    abs_path = "/usr/local/bin/git.exe"
+    with patch("kagan.core._subprocess.shutil.which") as mock_which:
+        result = resolve_spawn_command(abs_path, "status")
+    mock_which.assert_not_called()
+    assert result == [abs_path, "status"]
+
+
+# ---------------------------------------------------------------------------
+# Mixed-case suffix (.CMD / .BAT)
+# ---------------------------------------------------------------------------
+
+
+def test_windows_mixed_case_cmd_suffix_triggers_wrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = "/tools/claude.CMD"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("claude")
+    assert result == ["cmd.exe", "/c", resolved]
+
+
+def test_windows_mixed_case_bat_suffix_triggers_wrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = "/tools/run.BAT"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("run")
+    assert result == ["cmd.exe", "/c", resolved]
+
+
+def test_windows_mixed_case_ps1_suffix_triggers_wrap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    resolved = "/tools/script.PS1"
+    with patch("kagan.core._subprocess.shutil.which", return_value=resolved):
+        result = resolve_spawn_command("script")
+    assert result == [
+        "powershell",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        resolved,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Absolute .cmd path — no args edge case
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_cmd_no_extra_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    abs_path = "/tools/cursor.cmd"
+    # absolute path: which() must not be called
+    with patch("kagan.core._subprocess.shutil.which") as mock_which:
+        result = resolve_spawn_command(abs_path)
+    mock_which.assert_not_called()
+    assert result == ["cmd.exe", "/c", abs_path]

--- a/tests/server/test_fs_browse.py
+++ b/tests/server/test_fs_browse.py
@@ -1,0 +1,252 @@
+"""Tests for GET /api/fs/browse — Windows-safe filesystem browser endpoint."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlencode
+
+import pytest
+from starlette.requests import Request
+
+if TYPE_CHECKING:
+    from starlette.responses import JSONResponse
+
+import kagan.server._helpers as server_helpers
+from kagan.server.mcp.server import ServerOptions
+from tests.helpers.server import get_http_endpoint, json_body
+from tests.helpers.server_ws import make_api_server
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_ctx() -> SimpleNamespace:
+    async def _get_settings() -> dict[str, str]:
+        return {}
+
+    async def _no_repo_path(**_kwargs: Any) -> None:
+        return None
+
+    return SimpleNamespace(
+        client=SimpleNamespace(
+            settings=SimpleNamespace(get=_get_settings),
+            projects=SimpleNamespace(resolve_repo_path=_no_repo_path),
+        ),
+        opts=ServerOptions(),
+    )
+
+
+def _make_browse_request(path: str | None = None) -> Request:
+    """Build a Starlette Request for the browse endpoint with an optional path param."""
+    qs = urlencode({"path": path}).encode() if path is not None else b""
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "path": "/api/fs/browse",
+        "raw_path": b"/api/fs/browse",
+        "headers": [],
+        "query_string": qs,
+        "scheme": "http",
+        "server": ("127.0.0.1", 8765),
+        "client": ("127.0.0.1", 12345),
+        "path_params": {},
+    }
+    return Request(scope)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def browse_endpoint(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Return the browse endpoint with a real ctx stub."""
+    mcp = make_api_server()
+    monkeypatch.setattr(server_helpers, "get_server_context", lambda _mcp: _make_ctx())
+    return get_http_endpoint(mcp, "/api/fs/browse", "GET")
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+async def test_browse_home_returns_entries(browse_endpoint: Any) -> None:
+    response = await browse_endpoint(_make_browse_request("~"))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    data = body["data"]
+    assert data["path"] == str(Path.home())
+    assert isinstance(data["entries"], list)
+    assert isinstance(data["separator"], str)
+    assert len(data["separator"]) == 1
+    assert isinstance(data["roots"], list)
+    assert len(data["roots"]) >= 1
+
+
+async def test_browse_default_path_is_home(browse_endpoint: Any) -> None:
+    """Omitting path param should default to '~'."""
+    response = await browse_endpoint(_make_browse_request())
+    body = json_body(response)
+
+    assert body["ok"] is True
+    assert body["data"]["path"] == str(Path.home())
+
+
+async def test_browse_separator_matches_os_sep(browse_endpoint: Any) -> None:
+    response = await browse_endpoint(_make_browse_request("~"))
+    body = json_body(response)
+
+    assert body["data"]["separator"] == os.sep
+
+
+async def test_browse_roots_contains_posix_root_on_posix(browse_endpoint: Any) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX-only test")
+    response = await browse_endpoint(_make_browse_request("~"))
+    body = json_body(response)
+
+    assert "/" in body["data"]["roots"]
+
+
+async def test_browse_parent_correct_for_nested_dir(browse_endpoint: Any, tmp_path: Path) -> None:
+    child = tmp_path / "subdir"
+    child.mkdir()
+
+    response = await browse_endpoint(_make_browse_request(str(child)))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    assert body["data"]["parent"] == str(tmp_path)
+
+
+async def test_browse_parent_is_null_at_root(browse_endpoint: Any) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX-only root null test")
+    response = await browse_endpoint(_make_browse_request("/"))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    assert body["data"]["parent"] is None
+
+
+async def test_browse_nonexistent_path_returns_400(browse_endpoint: Any) -> None:
+    response = await browse_endpoint(_make_browse_request("/definitely/does/not/exist/xyz123"))
+    assert cast("JSONResponse", response).status_code == 400
+    body = json_body(response)
+    assert body["ok"] is False
+
+
+async def test_browse_file_path_returns_400(browse_endpoint: Any, tmp_path: Path) -> None:
+    file_path = tmp_path / "afile.txt"
+    file_path.write_text("hello")
+
+    response = await browse_endpoint(_make_browse_request(str(file_path)))
+    assert cast("JSONResponse", response).status_code == 400
+    body = json_body(response)
+    assert body["ok"] is False
+
+
+async def test_browse_git_repo_dir_is_flagged(browse_endpoint: Any, tmp_path: Path) -> None:
+    git_dir = tmp_path / "myrepo"
+    git_dir.mkdir()
+    (git_dir / ".git").mkdir()
+
+    response = await browse_endpoint(_make_browse_request(str(tmp_path)))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    entries = {e["name"]: e for e in body["data"]["entries"]}
+    assert "myrepo" in entries
+    assert entries["myrepo"]["is_git_repo"] is True
+
+
+async def test_browse_dot_prefixed_entries_filtered(browse_endpoint: Any, tmp_path: Path) -> None:
+    (tmp_path / ".hidden_dir").mkdir()
+    (tmp_path / "visible_dir").mkdir()
+
+    response = await browse_endpoint(_make_browse_request(str(tmp_path)))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    names = [e["name"] for e in body["data"]["entries"]]
+    assert ".hidden_dir" not in names
+    assert "visible_dir" in names
+
+
+async def test_browse_symlink_to_dir_included_and_flagged(
+    browse_endpoint: Any, tmp_path: Path
+) -> None:
+    if sys.platform == "win32":
+        pytest.skip("Symlink creation requires elevated privileges on Windows")
+
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link = tmp_path / "linked"
+    link.symlink_to(real_dir)
+
+    response = await browse_endpoint(_make_browse_request(str(tmp_path)))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    entries = {e["name"]: e for e in body["data"]["entries"]}
+    assert "linked" in entries, f"symlink not in entries; got: {list(entries)}"
+    assert entries["linked"]["is_link"] is True
+    assert entries["linked"]["is_dir"] is True
+
+
+async def test_browse_entry_shape_has_required_fields(browse_endpoint: Any, tmp_path: Path) -> None:
+    (tmp_path / "a_dir").mkdir()
+    response = await browse_endpoint(_make_browse_request(str(tmp_path)))
+    body = json_body(response)
+
+    entry = next(e for e in body["data"]["entries"] if e["name"] == "a_dir")
+    for field in ("name", "path", "is_dir", "is_git_repo", "is_link"):
+        assert field in entry, f"missing field {field!r}"
+
+
+# ── Windows-specific tests ─────────────────────────────────────────────────────
+
+_WINDOWS_ONLY = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+
+
+@pytest.mark.windows_ci
+@_WINDOWS_ONLY
+async def test_windows_roots_include_c_drive(browse_endpoint: Any) -> None:
+    response = await browse_endpoint(_make_browse_request("~"))
+    body = json_body(response)
+
+    roots = body["data"]["roots"]
+    # The test runner's drive (usually C:\) must be in the list.
+    cwd_drive = Path.cwd().drive + "\\"
+    assert cwd_drive in roots, f"Expected {cwd_drive!r} in roots; got {roots}"
+
+
+@pytest.mark.windows_ci
+@_WINDOWS_ONLY
+async def test_windows_parent_of_users_is_drive(browse_endpoint: Any) -> None:
+    users = Path("C:\\Users")
+    if not users.exists():
+        pytest.skip("C:\\Users does not exist on this runner")
+
+    response = await browse_endpoint(_make_browse_request(str(users)))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    assert body["data"]["parent"] == "C:\\"
+
+
+@pytest.mark.windows_ci
+@_WINDOWS_ONLY
+async def test_windows_parent_of_c_root_is_null(browse_endpoint: Any) -> None:
+    c_root = Path("C:\\")
+    if not c_root.exists():
+        pytest.skip("C:\\ does not exist on this runner")
+
+    response = await browse_endpoint(_make_browse_request(str(c_root)))
+    body = json_body(response)
+
+    assert body["ok"] is True
+    assert body["data"]["parent"] is None

--- a/tests/unit/core/test_runtime_env.py
+++ b/tests/unit/core/test_runtime_env.py
@@ -8,15 +8,23 @@ Tests for src/kagan/runtime_env.py covering:
 - Platform-specific noisy env var handling
 """
 
+from __future__ import annotations
+
 import os
 import sys
-from collections.abc import MutableMapping
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
 
 import pytest
 
 from kagan.runtime_env import (
     _ESSENTIAL_ENV,
+    _ESSENTIAL_ENV_POSIX,
+    _ESSENTIAL_ENV_WINDOWS,
+    _essential_env,
     _is_python_key,
     _is_sensitive_key,
     build_sanitized_subprocess_environment,
@@ -632,3 +640,110 @@ class TestIntegrationScenarios:
         allow_extra = {"GITHUB_TOKEN": "new_token"}  # But added back via allow_extra
         result = build_sanitized_subprocess_environment(base_env, allow_extra=allow_extra)
         assert result["GITHUB_TOKEN"] == "new_token"
+
+
+class TestEssentialEnvSelector:
+    """Tests for the _essential_env() platform-selection helper."""
+
+    def test_posix_set_returned_for_linux(self) -> None:
+        """Linux platform should return the POSIX frozenset."""
+        assert _essential_env("linux") is _ESSENTIAL_ENV_POSIX
+
+    def test_posix_set_returned_for_darwin(self) -> None:
+        """Darwin platform should return the POSIX frozenset."""
+        assert _essential_env("darwin") is _ESSENTIAL_ENV_POSIX
+
+    def test_windows_set_returned_for_win32(self) -> None:
+        """win32 platform should return the Windows frozenset."""
+        assert _essential_env("win32") is _ESSENTIAL_ENV_WINDOWS
+
+    def test_essential_env_alias_is_posix(self) -> None:
+        """The backwards-compat _ESSENTIAL_ENV alias must equal the POSIX set."""
+        assert _ESSENTIAL_ENV is _ESSENTIAL_ENV_POSIX
+
+    def test_windows_set_contains_critical_vars(self) -> None:
+        """Windows set must include the vars that prevent DLL/config failures."""
+        required = {
+            "SYSTEMROOT",
+            "TEMP",
+            "TMP",
+            "APPDATA",
+            "LOCALAPPDATA",
+            "USERPROFILE",
+            "PATHEXT",
+            "COMSPEC",
+        }
+        assert required <= _ESSENTIAL_ENV_WINDOWS
+
+    def test_defaults_to_sys_platform(self) -> None:
+        """Without an argument, _essential_env() consults sys.platform."""
+        with patch.object(sys, "platform", "win32"):
+            assert _essential_env() is _ESSENTIAL_ENV_WINDOWS
+
+        with patch.object(sys, "platform", "linux"):
+            assert _essential_env() is _ESSENTIAL_ENV_POSIX
+
+
+class TestBuildSanitizedWindowsPlatform:
+    """Tests for build_sanitized_subprocess_environment on Windows platform."""
+
+    def _windows_env(self) -> dict[str, str]:
+        """Return a representative Windows environment dict."""
+        return {
+            "PATH": "C:\\Windows\\System32;C:\\Windows",
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+            "SYSTEMROOT": "C:\\Windows",
+            "WINDIR": "C:\\Windows",
+            "COMSPEC": "C:\\Windows\\System32\\cmd.exe",
+            "TEMP": "C:\\Users\\User\\AppData\\Local\\Temp",
+            "TMP": "C:\\Users\\User\\AppData\\Local\\Temp",
+            "USERPROFILE": "C:\\Users\\User",
+            "HOMEDRIVE": "C:",
+            "HOMEPATH": "\\Users\\User",
+            "APPDATA": "C:\\Users\\User\\AppData\\Roaming",
+            "LOCALAPPDATA": "C:\\Users\\User\\AppData\\Local",
+            "PROGRAMFILES": "C:\\Program Files",
+            "PROGRAMFILES(X86)": "C:\\Program Files (x86)",
+            "PROGRAMDATA": "C:\\ProgramData",
+            "USERNAME": "User",
+            "COMPUTERNAME": "MYPC",
+            "USERDOMAIN": "MYPC",
+            "LANG": "en_US.UTF-8",
+            "ANTHROPIC_API_KEY": "sk-ant-xxx",
+        }
+
+    def test_windows_essential_vars_preserved(self) -> None:
+        """All Windows essential vars present in the env must be kept."""
+        base_env = self._windows_env()
+        result = build_sanitized_subprocess_environment(base_env, platform_name="win32")
+        for key in _ESSENTIAL_ENV_WINDOWS:
+            if key in base_env:
+                assert key in result, f"Expected Windows essential var {key!r} in result"
+                assert result[key] == base_env[key]
+
+    def test_sensitive_var_stripped_on_windows(self) -> None:
+        """Sensitive credentials must still be stripped even on Windows platform."""
+        base_env = self._windows_env()
+        result = build_sanitized_subprocess_environment(base_env, platform_name="win32")
+        assert "ANTHROPIC_API_KEY" not in result
+
+    def test_linux_platform_drops_windows_vars(self) -> None:
+        """When platform_name='linux', Windows-specific vars are not carried over."""
+        base_env = self._windows_env()
+        result = build_sanitized_subprocess_environment(base_env, platform_name="linux")
+        # Windows-only vars must be absent
+        for win_var in ("SYSTEMROOT", "APPDATA", "LOCALAPPDATA", "COMSPEC", "WINDIR"):
+            assert win_var not in result, f"Windows var {win_var!r} leaked into POSIX result"
+        # PATH is in both sets and must be present
+        assert "PATH" in result
+
+    def test_allow_extra_works_on_windows_platform(self) -> None:
+        """allow_extra must be present alongside Windows essentials."""
+        base_env = self._windows_env()
+        allow_extra = {"CUSTOM_VAR": "hello"}
+        result = build_sanitized_subprocess_environment(
+            base_env, allow_extra=allow_extra, platform_name="win32"
+        )
+        assert result["CUSTOM_VAR"] == "hello"
+        assert "SYSTEMROOT" in result
+        assert "APPDATA" in result

--- a/tests/unit/test_agent_kill.py
+++ b/tests/unit/test_agent_kill.py
@@ -1,0 +1,272 @@
+"""Tests for _kill_agent / _force_kill process-handle timeout path.
+
+Covers:
+- timeout fires → process is terminated via proc.terminate()/kill(), not os.kill()
+- process already gone → no crash, timeout entry cleaned up
+- unregister_spawned_process cancels the pending timer
+- no signal.SIGKILL reference in the kill path (cross-platform safety)
+"""
+
+import asyncio
+import sys
+
+import pytest
+
+from kagan.core._agent import (
+    _AGENT_TIMEOUT_GRACE_SECONDS,
+    _AGENT_TIMEOUTS,
+    _AgentTimeout,
+    _force_kill,
+    _kill_agent,
+    _spawned_processes,
+    register_spawned_process,
+    unregister_spawned_process,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Fake asyncio subprocess Process
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """Minimal stand-in for asyncio.subprocess.Process."""
+
+    def __init__(self, *, pid: int = 9999, already_dead: bool = False) -> None:
+        self.pid: int = pid
+        self.returncode: int | None = 0 if already_dead else None
+        self.terminate_calls: int = 0
+        self.kill_calls: int = 0
+
+    def terminate(self) -> None:
+        if self.returncode is not None:
+            raise ProcessLookupError("process already exited")
+        self.terminate_calls += 1
+        # Simulate OS-level termination
+        self.returncode = -15
+
+    def kill(self) -> None:
+        if self.returncode is not None:
+            raise ProcessLookupError("process already exited")
+        self.kill_calls += 1
+        self.returncode = -9
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_timer_handle() -> asyncio.TimerHandle:
+    """Return a cancelled TimerHandle (avoids scheduling real callbacks)."""
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    handle = loop.call_later(9999, lambda: None)
+    handle.cancel()
+    return handle
+
+
+# ---------------------------------------------------------------------------
+# _kill_agent
+# ---------------------------------------------------------------------------
+
+
+async def test_kill_agent_calls_terminate_not_os_kill() -> None:
+    """_kill_agent must use proc.terminate(), never os.kill with signal constants."""
+    proc = _FakeProcess(pid=1001)
+
+    # Seed _AGENT_TIMEOUTS so _kill_agent can overwrite the entry
+    loop = asyncio.get_event_loop()
+    dummy = loop.call_later(9999, lambda: None)
+    dummy.cancel()
+    _AGENT_TIMEOUTS[proc.pid] = _AgentTimeout(proc=proc, handle=dummy)
+
+    try:
+        _kill_agent(proc)
+        assert proc.terminate_calls == 1, "proc.terminate() should have been called once"
+    finally:
+        # Clean up any timer _kill_agent may have scheduled
+        entry = _AGENT_TIMEOUTS.pop(proc.pid, None)
+        if entry is not None:
+            entry.handle.cancel()
+
+
+async def test_kill_agent_process_already_dead_no_crash() -> None:
+    """_kill_agent must not raise when proc.terminate() raises ProcessLookupError."""
+    proc = _FakeProcess(pid=1002, already_dead=True)
+
+    loop = asyncio.get_event_loop()
+    dummy = loop.call_later(9999, lambda: None)
+    dummy.cancel()
+    _AGENT_TIMEOUTS[proc.pid] = _AgentTimeout(proc=proc, handle=dummy)
+
+    try:
+        # Should not raise even though terminate() raises ProcessLookupError
+        _kill_agent(proc)
+    finally:
+        entry = _AGENT_TIMEOUTS.pop(proc.pid, None)
+        if entry is not None:
+            entry.handle.cancel()
+
+
+async def test_kill_agent_schedules_force_kill_timer() -> None:
+    """After _kill_agent, a grace-period timer entry must be present in _AGENT_TIMEOUTS."""
+    proc = _FakeProcess(pid=1003)
+
+    try:
+        _kill_agent(proc)
+        assert proc.pid in _AGENT_TIMEOUTS, "_AGENT_TIMEOUTS must contain the force-kill timer"
+        entry = _AGENT_TIMEOUTS[proc.pid]
+        assert entry.proc is proc
+        assert not entry.handle.cancelled()
+    finally:
+        entry = _AGENT_TIMEOUTS.pop(proc.pid, None)
+        if entry is not None:
+            entry.handle.cancel()
+
+
+# ---------------------------------------------------------------------------
+# _force_kill
+# ---------------------------------------------------------------------------
+
+
+async def test_force_kill_kills_live_process() -> None:
+    """_force_kill calls proc.kill() when process is still running."""
+    proc = _FakeProcess(pid=2001)
+    loop = asyncio.get_event_loop()
+    dummy = loop.call_later(9999, lambda: None)
+    dummy.cancel()
+    _AGENT_TIMEOUTS[proc.pid] = _AgentTimeout(proc=proc, handle=dummy)
+
+    _force_kill(proc)
+
+    assert proc.kill_calls == 1
+    assert proc.pid not in _AGENT_TIMEOUTS, "_AGENT_TIMEOUTS entry should be cleaned up"
+
+
+async def test_force_kill_skips_already_dead_process() -> None:
+    """_force_kill must not raise and must clean up when process is already gone."""
+    proc = _FakeProcess(pid=2002, already_dead=True)
+    loop = asyncio.get_event_loop()
+    dummy = loop.call_later(9999, lambda: None)
+    dummy.cancel()
+    _AGENT_TIMEOUTS[proc.pid] = _AgentTimeout(proc=proc, handle=dummy)
+
+    _force_kill(proc)  # Should not raise
+
+    assert proc.kill_calls == 0, "kill() must not be called on an already-dead process"
+    assert proc.pid not in _AGENT_TIMEOUTS
+
+
+# ---------------------------------------------------------------------------
+# unregister_spawned_process cancels the timer
+# ---------------------------------------------------------------------------
+
+
+async def test_unregister_cancels_pending_timer() -> None:
+    """unregister_spawned_process must cancel any pending timeout timer."""
+    session_id = "session-cancel-test"
+    proc = _FakeProcess(pid=3001)
+
+    await register_spawned_process(session_id, proc)
+
+    loop = asyncio.get_event_loop()
+    handle = loop.call_later(9999, _kill_agent, proc)
+    _AGENT_TIMEOUTS[proc.pid] = _AgentTimeout(proc=proc, handle=handle)
+
+    assert not handle.cancelled()
+    await unregister_spawned_process(session_id)
+
+    assert handle.cancelled(), "Timer handle must be cancelled after unregister"
+    assert proc.pid not in _AGENT_TIMEOUTS
+    assert session_id not in _spawned_processes
+
+
+async def test_unregister_without_timer_does_not_crash() -> None:
+    """unregister_spawned_process is safe even if no timeout was registered."""
+    session_id = "session-no-timer"
+    proc = _FakeProcess(pid=3002)
+
+    await register_spawned_process(session_id, proc)
+    await unregister_spawned_process(session_id)  # No timer registered — must not raise
+
+    assert session_id not in _spawned_processes
+
+
+async def test_unregister_unknown_session_is_noop() -> None:
+    """unregister_spawned_process on an unknown session_id must not crash."""
+    await unregister_spawned_process("does-not-exist")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Integration: full timeout cycle with a real subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="real subprocess spawn skipped on Windows CI")
+async def test_timeout_kills_real_subprocess() -> None:
+    """Spawn a real long-running process, register a short timeout, verify it exits."""
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(30)",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    assert proc.pid is not None
+
+    pid = proc.pid
+    session_id = f"integration-{pid}"
+    await register_spawned_process(session_id, proc)
+
+    # Schedule a very short timeout
+    loop = asyncio.get_event_loop()
+    handle = loop.call_later(0.05, _kill_agent, proc)
+    _AGENT_TIMEOUTS[pid] = _AgentTimeout(proc=proc, handle=handle)
+
+    # Wait long enough for terminate + grace period + force kill
+    total_wait = 0.05 + _AGENT_TIMEOUT_GRACE_SECONDS + 1.0
+    await asyncio.sleep(total_wait)
+
+    assert proc.returncode is not None, "Process must have been terminated by the timeout"
+
+    # Clean up tracking state
+    _spawned_processes.pop(session_id, None)
+    entry = _AGENT_TIMEOUTS.pop(pid, None)
+    if entry is not None:
+        entry.handle.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Windows-specific: no signal.SIGKILL in the kill path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only guard")
+def test_no_sigkill_reference_on_windows() -> None:
+    """On Windows, signal.SIGKILL must not exist and the kill path must not reference it."""
+    import signal as _signal
+
+    assert not hasattr(_signal, "SIGKILL"), (
+        "signal.SIGKILL must not exist on Windows — the kill path would raise AttributeError"
+    )
+
+
+def test_kill_agent_uses_proc_handle_not_os_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch os.kill to raise — _kill_agent must succeed without calling it."""
+    import os
+
+    def _bad_os_kill(pid: int, sig: int) -> None:
+        raise AssertionError(f"os.kill({pid}, {sig}) must not be called by _kill_agent")
+
+    monkeypatch.setattr(os, "kill", _bad_os_kill)
+
+    proc = _FakeProcess(pid=4001)
+
+    try:
+        _kill_agent(proc)  # Must not call os.kill
+    finally:
+        entry = _AGENT_TIMEOUTS.pop(proc.pid, None)
+        if entry is not None:
+            entry.handle.cancel()

--- a/tests/unit/test_agent_kill.py
+++ b/tests/unit/test_agent_kill.py
@@ -229,7 +229,9 @@ async def test_timeout_kills_real_subprocess() -> None:
     total_wait = 0.05 + _AGENT_TIMEOUT_GRACE_SECONDS + 1.0
     await asyncio.sleep(total_wait)
 
-    assert proc.returncode is not None, "Process must have been terminated by the timeout"
+    rc = proc.returncode
+    assert isinstance(rc, int), "Process must have been terminated by the timeout"
+    assert rc != 0, f"Killed process must have non-zero exit code, got {rc}"
 
     # Clean up tracking state
     _spawned_processes.pop(session_id, None)

--- a/tests/unit/test_agent_spawn_acp.py
+++ b/tests/unit/test_agent_spawn_acp.py
@@ -46,6 +46,9 @@ async def _spawn_and_capture_command(
         _fake_create_subprocess_exec,
     )
     monkeypatch.setattr("kagan.core._acp.run_acp_session", _fake_run_acp_session)
+    # resolve_spawn_command calls shutil.which; return the bare name unchanged so
+    # assertions on the captured command remain stable across environments.
+    monkeypatch.setattr("kagan.core._subprocess.shutil.which", lambda exe: exe)
 
     _, reader_task = await spawn_agent_via_acp(
         backend_name,
@@ -142,7 +145,8 @@ async def test_spawn_agent_acp_uses_typed_capability_over_legacy_supports_flag(
 
     monkeypatch.setattr("kagan.core._agent.get_backend_spec", lambda _name: spec)
     monkeypatch.setattr("kagan.core._agent.get_backend", lambda _name: legacy_entry)
-    monkeypatch.setattr("kagan.core._agent.shutil.which", lambda _exe: "/usr/bin/typed-acp")
+    # resolve_spawn_command uses shutil.which from _subprocess, not _agent.
+    monkeypatch.setattr("kagan.core._subprocess.shutil.which", lambda exe: exe)
 
     captured: dict[str, list[str]] = {}
 

--- a/tests/unit/test_chat_acp_backend_contract.py
+++ b/tests/unit/test_chat_acp_backend_contract.py
@@ -110,7 +110,9 @@ async def test_run_orchestrator_turn_uses_backend_spec_env_vars(
     )
 
     assert result == ""
-    assert captured["exe"] == "typed-backend"
+    # resolve_spawn_command resolves the executable via shutil.which; on POSIX the
+    # resolved path is passed directly, so accept any value ending in "typed-backend".
+    assert str(captured["exe"]).endswith("typed-backend")
     assert captured["exe_args"] == ["acp"]
     assert captured["cwd"] == str(tmp_path)
     env = captured["env"]

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "kagan"
-version = "0.19.0b4"
+version = "0.19.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

Five Windows-specific bugs fixed across the server, web client, and core spawn/runtime code. All pre-existing tests still pass (1295 non-snapshot); adds 4 Windows-gated tests (skipped on POSIX) and 142 new non-gated tests.

## Commits

| Commit | Fix |
|---|---|
| `a09e5ac` | **fix(server):** windows-safe `/api/fs/browse`. Drop `Path.home()` boundary; return `parent`/`separator`/`roots`/`is_link` so clients don't parse paths. Use `FILE_ATTRIBUTE_HIDDEN` on Windows; include junctions/symlinks. Mirror fix in plugin GitHub repo detection. |
| `fc262e5` | **fix(web):** windows-safe `PathPicker`. Consume server-provided fields instead of splitting on `/`. Home breadcrumb → `~` (server-expanded). Drive-root picker when multiple roots. `Link2` badge for junctions. |
| `64e1e4f` | **fix(core):** resolve `.cmd`/`.bat`/`.ps1` shims via `cmd.exe`/`powershell` at spawn time. Windows `CreateProcess` doesn't honour `PATHEXT` and can't exec batch files directly — this is why `claude`, `codex`, `copilot`, `code`, `cursor` etc. fail to invoke despite `shutil.which` finding them. New helper `kagan.core._subprocess.resolve_spawn_command`; all agent/IDE/ACP spawn sites routed through it. |
| `0004779` | **fix(runtime_env):** platform-aware essential env for Windows. Adds `SYSTEMROOT`, `TEMP`, `TMP`, `APPDATA`, `LOCALAPPDATA`, `USERPROFILE`, `PATHEXT`, `COMSPEC`, `WINDIR`, `HOMEDRIVE`/`HOMEPATH`, `PROGRAMFILES(X86)`, `PROGRAMDATA`, `USERNAME`, `COMPUTERNAME`, `USERDOMAIN` to the subprocess env on Windows. POSIX unchanged. |
| `0deeb68` | **fix(core):** terminate agent processes via `Process` handle, not `os.kill(SIGKILL)`. `signal.SIGKILL` doesn't exist on Windows (`AttributeError` at timeout); `os.kill(SIGTERM)` is a no-op for detached processes. Now stores `Process` alongside the timer and calls `proc.terminate()`/`proc.kill()`. |

## Why stacked

The three backend fixes interact on Windows:
- Shim resolution lets us *invoke* `claude.cmd`.
- Essential-env lets the spawned `claude` *start* (needs `APPDATA`/`SYSTEMROOT`).
- Process-handle termination lets the timeout path *work* when an agent hangs.

Shipping any one without the others leaves a different symptom on Windows.

## Test plan

- [x] `uv run poe typecheck` — 0 errors
- [x] `uv run pytest tests/ -m "not snapshot"` — 1295 passed, 4 skipped (Windows-gated)
- [x] `packages/web`: `pnpm exec vitest run path-picker` — 14/14; `pnpm exec tsc --noEmit` clean; `pnpm run build` clean
- [ ] CI Windows matrix (`test-windows` job) — needs a real Windows runner to exercise the `windows_ci`-marked tests
- [ ] Manual smoke: spawn a claude-code task from kagan web on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)