### PR TITLE
feat(chat): polish kg chat REPL UX (Rich approval panel, arrow-key nav, /approvals, grouped tools)

### DIFF
--- a/src/kagan/cli/chat/_approval_batch.py
+++ b/src/kagan/cli/chat/_approval_batch.py
@@ -1,0 +1,604 @@
+"""Batched approval queue for concurrent tool-permission requests in kg chat.
+
+When multiple ``request_permission`` calls arrive within the debounce window
+(default 100 ms), they are collected into a single combined panel.  Each caller
+receives an ``asyncio.Future``; the batch responder resolves all of them once
+the user has worked through the panel.
+
+N=1 path: if only one item arrives before the debounce fires, the caller's
+Future is resolved with the raw (options, tool_call) tuple — the upstream
+``request_permission`` implementation falls through to the existing
+single-approval panel unchanged.
+
+Batch path (N>=2): a single combined panel lists all pending items with
+per-item options 1-4 and bulk options 5 (approve all) / 6 (reject all).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import shutil
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+from prompt_toolkit.application.run_in_terminal import run_in_terminal
+
+# ---------------------------------------------------------------------------
+# Environment-configurable debounce + cap
+# ---------------------------------------------------------------------------
+
+_DEFAULT_DEBOUNCE_MS = 100
+_DEFAULT_BATCH_CAP = 20
+
+
+def _debounce_seconds() -> float:
+    raw = os.environ.get("KAGAN_BATCH_APPROVAL_DEBOUNCE_MS", "")
+    try:
+        return max(0.0, float(raw)) / 1000.0
+    except ValueError:
+        return _DEFAULT_DEBOUNCE_MS / 1000.0
+
+
+def _batch_cap() -> int:
+    return _DEFAULT_BATCH_CAP
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PendingItem:
+    """One pending approval request waiting in the batch queue."""
+
+    options: list[Any]
+    tool_call: Any
+    future: asyncio.Future[Any]  # resolved with an ACP response object
+
+
+# ---------------------------------------------------------------------------
+# Batch panel rendering helpers
+# ---------------------------------------------------------------------------
+
+# Options 1-4 come from the existing single-approval panel.
+# Options 5-6 are batch-only bulk actions.
+_BATCH_OPTION_LABELS: list[tuple[str, str]] = [
+    ("Approve once", "allow_once"),
+    ("Approve for this session", "allow_always"),
+    ("Reject", "reject_once"),
+    ("Reject — tell the model what to do", "reject_feedback"),
+    ("Approve all remaining", "approve_all"),
+    ("Reject all remaining", "reject_all"),
+]
+
+
+def _build_batch_panel_ansi(
+    items: list[_PendingItem],
+    *,
+    focused_item: int,
+    selected_option: int,
+    feedback_draft: str,
+) -> str:
+    """Render the combined batch approval panel to an ANSI string."""
+    from rich.console import Console, Group
+    from rich.markup import escape as _rich_escape
+    from rich.panel import Panel
+    from rich.text import Text
+
+    buf = io.StringIO()
+    cols = shutil.get_terminal_size((80, 24)).columns
+    tmp = Console(file=buf, highlight=False, width=cols, force_terminal=True)
+
+    n = len(items)
+    lines: list[Any] = []
+
+    # Item list header
+    lines.append(Text(f"[yellow]{n} tool calls pending:[/yellow]", justify="left"))
+    lines.append(Text(""))
+
+    for i, item in enumerate(items):
+        raw = (
+            getattr(item.tool_call, "title", None)
+            or getattr(item.tool_call, "name", None)
+            or "tool call"
+        )
+        name = _strip_mcp_prefix(str(raw))
+        if i == focused_item:
+            lines.append(Text.from_markup(f"[cyan bold]→ {name}[/cyan bold]"))
+        else:
+            lines.append(Text.from_markup(f"[dim]  {_rich_escape(name)}[/dim]"))
+
+    lines.append(Text(""))
+
+    # Option menu for focused item
+    for idx, (label, _kind) in enumerate(_BATCH_OPTION_LABELS):
+        num = idx + 1
+        is_selected = idx == selected_option
+        is_feedback_slot = idx == 3
+        if is_selected:
+            if is_feedback_slot and feedback_draft:
+                cursor_display = f"→ [{num}] Reject: {feedback_draft}█"
+                lines.append(Text(cursor_display, style="cyan"))
+            else:
+                lines.append(Text(f"→ [{num}] {label}", style="cyan bold"))
+        else:
+            lines.append(Text(f"  [{num}] {label}", style="dim"))
+
+    lines.append(Text(""))
+
+    # Footer hint
+    if selected_option == 3 and feedback_draft:
+        hint = "  Type feedback  Enter submit  Esc cancel"
+    else:
+        hint = "  ▲/▼ option  Tab/S-Tab item  1-6 choose  ↵ confirm  Esc reject all"
+    lines.append(Text(hint, style="dim"))
+
+    title = f"[bold]approval ({n} tools)[/bold]"
+    panel = Panel(
+        Group(*lines),
+        border_style="yellow",
+        title=title,
+        title_align="left",
+        padding=(0, 1),
+    )
+    tmp.print(panel)
+    return buf.getvalue()
+
+
+def _strip_mcp_prefix(name: str) -> str:
+    for prefix in ("mcp__kagan__", "mcp__"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+    return name.replace("_", " ").strip()
+
+
+# ---------------------------------------------------------------------------
+# Interactive batch modal
+# ---------------------------------------------------------------------------
+
+
+async def _run_batch_modal_async(
+    items: list[_PendingItem],
+    *,
+    _resolve_item: Any,
+    _resolve_all: Any,
+    _reject_all: Any,
+) -> None:
+    """Run the interactive batch-approval prompt_toolkit Application.
+
+    Calls _resolve_item(index, option_idx, feedback) for per-item decisions,
+    _resolve_all(option_idx) for approve-all / reject-all.
+    Falls back to legacy_batch_input on any failure.
+    """
+    try:
+        await _run_batch_interactive(
+            items,
+            resolve_item=_resolve_item,
+            resolve_all=_resolve_all,
+            reject_all=_reject_all,
+        )
+    except Exception:
+        logger.debug("Batch interactive modal failed; falling back to legacy batch input")
+        _run_legacy_batch_input(
+            items,
+            resolve_item=_resolve_item,
+            reject_all=_reject_all,
+        )
+
+
+def _find_next_unresolved(
+    current: int, n: int, resolved: set[int], direction: int = 1
+) -> int | None:
+    """Return the next unresolved item index (wrapping), or None if all done."""
+    for i in range(1, n + 1):
+        candidate = (current + direction * i) % n
+        if candidate not in resolved:
+            return candidate
+    return None
+
+
+def _reset_item_focus(state: dict[str, Any], new_idx: int, fb_buf: Any) -> None:
+    """Move focus to a new item and reset option state."""
+    from prompt_toolkit.document import Document
+
+    state["focused_item"] = new_idx
+    state["selected_option"] = 0
+    state["feedback_mode"] = False
+    state["feedback"] = ""
+    fb_buf.set_document(Document(), bypass_readonly=True)
+
+
+def _handle_num_key(
+    idx: int,
+    *,
+    state: dict[str, Any],
+    fb_buf: Any,
+    app: Any,
+    resolve_all: Any,
+    reject_all: Any,
+    confirm_fn: Any,
+) -> None:
+    """Handle a digit key press (0-based idx) in the batch modal."""
+    state["selected_option"] = idx
+    if idx == 3:
+        state["feedback_mode"] = True
+    elif idx == 4:
+        resolve_all("allow_once")
+        app.exit(result=None)
+    elif idx == 5:
+        reject_all()
+        app.exit(result=None)
+    else:
+        state["feedback_mode"] = False
+        confirm_fn(app)
+
+
+async def _run_batch_interactive(
+    items: list[_PendingItem],
+    *,
+    resolve_item: Any,
+    resolve_all: Any,
+    reject_all: Any,
+) -> None:
+    """Build and run a transient prompt_toolkit Application for batch approval."""
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.buffer import Buffer
+    from prompt_toolkit.document import Document
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import HSplit, Window
+    from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+
+    n = len(items)
+    state: dict[str, Any] = {
+        "focused_item": 0,
+        "selected_option": 0,
+        "feedback": "",
+        "feedback_mode": False,
+        "resolved": [],
+    }
+
+    feedback_buffer = Buffer(name="batch_approval_feedback", multiline=False)
+
+    def _panel_text() -> ANSI:
+        draft = feedback_buffer.text if state["feedback_mode"] else state["feedback"]
+        ansi = _build_batch_panel_ansi(
+            items,
+            focused_item=state["focused_item"],
+            selected_option=state["selected_option"],
+            feedback_draft=draft,
+        )
+        return ANSI(ansi)
+
+    panel_window = Window(
+        content=FormattedTextControl(text=_panel_text),
+        dont_extend_height=True,
+    )
+    feedback_window = Window(
+        content=BufferControl(buffer=feedback_buffer, focusable=True),
+        height=0,
+    )
+    layout = Layout(HSplit([panel_window, feedback_window]))
+    kb = KeyBindings()
+
+    def _move_option(direction: int) -> None:
+        if state["feedback_mode"]:
+            state["feedback"] = feedback_buffer.text
+            feedback_buffer.set_document(Document(), bypass_readonly=True)
+        state["selected_option"] = (state["selected_option"] + direction) % 6
+        state["feedback_mode"] = state["selected_option"] == 3
+
+    def _confirm_current(app: Any) -> None:
+        opt = state["selected_option"]
+        item_idx = state["focused_item"]
+        fb = feedback_buffer.text.strip() if state["feedback_mode"] else state["feedback"]
+        if opt == 4:
+            resolve_all("allow_once")
+            app.exit(result=None)
+            return
+        if opt == 5:
+            reject_all()
+            app.exit(result=None)
+            return
+        resolve_item(item_idx, opt, fb)
+        state["resolved"].append(item_idx)
+        state["feedback"] = ""
+        feedback_buffer.set_document(Document(), bypass_readonly=True)
+        resolved_set = set(state["resolved"])
+        next_idx = _find_next_unresolved(item_idx, n, resolved_set)
+        if next_idx is None:
+            app.exit(result=None)
+        else:
+            _reset_item_focus(state, next_idx, feedback_buffer)
+
+    def _move_item(direction: int) -> None:
+        resolved_set = set(state["resolved"])
+        next_idx = _find_next_unresolved(state["focused_item"], n, resolved_set, direction)
+        if next_idx is not None:
+            _reset_item_focus(state, next_idx, feedback_buffer)
+
+    @kb.add("up", eager=True)
+    def _up(event) -> None:
+        _move_option(-1)
+
+    @kb.add("down", eager=True)
+    def _down(event) -> None:
+        _move_option(1)
+
+    @kb.add("tab", eager=True)
+    def _tab(event) -> None:
+        _move_item(1)
+
+    @kb.add("s-tab", eager=True)
+    def _stab(event) -> None:
+        _move_item(-1)
+
+    @kb.add("enter", eager=True)
+    def _enter(event) -> None:
+        if state["feedback_mode"] and not feedback_buffer.text.strip():
+            return
+        _confirm_current(event.app)
+
+    @kb.add("escape", eager=True)
+    @kb.add("c-c", eager=True)
+    @kb.add("c-d", eager=True)
+    def _cancel(event) -> None:
+        reject_all()
+        event.app.exit(result=None)
+
+    def _make_num_handler(num: int) -> None:
+        @kb.add(str(num), eager=True)
+        def _num(event) -> None:
+            _handle_num_key(
+                num - 1,
+                state=state,
+                fb_buf=feedback_buffer,
+                app=event.app,
+                resolve_all=resolve_all,
+                reject_all=reject_all,
+                confirm_fn=_confirm_current,
+            )
+
+    for n_key in range(1, 7):
+        _make_num_handler(n_key)
+
+    app: Application[None] = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        mouse_support=False,
+    )
+    await app.run_async()
+
+
+def _run_legacy_batch_input(
+    items: list[_PendingItem],
+    *,
+    resolve_item: Any,
+    reject_all: Any,
+) -> None:
+    """Sync fallback: iterate items one by one via input()."""
+    from kagan.cli.chat.repl import _console
+
+    for i, item in enumerate(items):
+        _console.print(
+            f"[bold yellow]approval ({i+1}/{len(items)})[/bold yellow]: "
+            f"{_strip_mcp_prefix(getattr(item.tool_call, 'title', None) or 'tool')}"
+        )
+        try:
+            raw = input("  [1] approve  [3] reject  > ").strip()
+            if raw in {"1", "2"}:
+                resolve_item(i, 0, "")
+            elif raw in {"5", "a"}:
+                # approve all remaining
+                for j in range(i, len(items)):
+                    resolve_item(j, 0, "")
+                return
+            elif raw in {"6", "d"}:
+                reject_all()
+                return
+            else:
+                resolve_item(i, 2, "")
+        except (EOFError, KeyboardInterrupt):
+            reject_all()
+            return
+
+
+# ---------------------------------------------------------------------------
+# Batch queue
+# ---------------------------------------------------------------------------
+
+
+class _BatchApprovalQueue:
+    """Collect concurrent request_permission calls and present them as one panel.
+
+    Usage::
+
+        queue = _BatchApprovalQueue(acp_client)
+        # In _OrchestratorACPClient.request_permission:
+        future = await queue.enqueue(options, tool_call)
+        response = await future   # blocks until batch resolves
+
+    The queue arms a debounce timer on the first enqueue.  When the timer fires
+    (or the cap is reached) it calls ``_flush()`` which renders the batch panel
+    and resolves all pending Futures.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self._client = client  # _OrchestratorACPClient reference (for helpers)
+        self._pending: list[_PendingItem] = []
+        self._debounce_task: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+
+    def reset(self) -> None:
+        """Clear queue state at turn start (called from start_turn)."""
+        if self._debounce_task is not None and not self._debounce_task.done():
+            self._debounce_task.cancel()
+        self._debounce_task = None
+        # Resolve any lingering futures as cancelled
+        for item in self._pending:
+            if not item.future.done():
+                from kagan.cli.chat._chat_acp import _cancelled_permission_response
+
+                item.future.set_result(_cancelled_permission_response())
+        self._pending.clear()
+
+    def cancel_all(self) -> None:
+        """Cancel all pending futures (SIGINT handler)."""
+        if self._debounce_task is not None and not self._debounce_task.done():
+            self._debounce_task.cancel()
+        self._debounce_task = None
+        from kagan.cli.chat._chat_acp import _cancelled_permission_response
+
+        for item in self._pending:
+            if not item.future.done():
+                item.future.set_result(_cancelled_permission_response())
+        self._pending.clear()
+
+    async def enqueue(self, options: list[Any], tool_call: Any) -> asyncio.Future[Any]:
+        """Add one permission request to the queue; return a Future for the response."""
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[Any] = loop.create_future()
+        item = _PendingItem(options=options, tool_call=tool_call, future=fut)
+
+        async with self._lock:
+            self._pending.append(item)
+            cap = _batch_cap()
+            if len(self._pending) >= cap:
+                # Cancel debounce timer and flush immediately
+                if self._debounce_task is not None and not self._debounce_task.done():
+                    self._debounce_task.cancel()
+                self._debounce_task = None
+                asyncio.ensure_future(self._flush())
+            elif self._debounce_task is None or self._debounce_task.done():
+                # Arm new debounce timer
+                self._debounce_task = asyncio.create_task(
+                    self._debounce_then_flush(), name="batch-approval-debounce"
+                )
+
+        return fut
+
+    async def _debounce_then_flush(self) -> None:
+        await asyncio.sleep(_debounce_seconds())
+        await self._flush()
+
+    async def _flush(self) -> None:
+        """Take snapshot of pending items and render panel; resolve all Futures."""
+        async with self._lock:
+            items = list(self._pending)
+            self._pending.clear()
+            self._debounce_task = None
+
+        if not items:
+            return
+
+        if len(items) == 1:
+            # N=1: fall through to the single-approval panel unchanged.
+            await self._flush_single(items[0])
+            return
+
+        await self._flush_batch(items)
+
+    async def _flush_single(self, item: _PendingItem) -> None:
+        """Resolve one item via the existing single-approval panel."""
+        from kagan.cli.chat._chat_acp import (
+            _map_approval_result,
+            _rejected_permission_response,
+            _run_approval_panel_async,
+            _selected_permission_response,
+            _session_approvals,
+            _tool_action_key,
+        )
+
+        action_key = _tool_action_key(item.tool_call)
+        if _session_approvals.is_allowed(action_key):
+            for o in item.options:
+                if getattr(o, "kind", None) == "allow_once":
+                    item.future.set_result(_selected_permission_response(o))
+                    return
+            item.future.set_result(_selected_permission_response(item.options[0]))
+            return
+
+        selected_index, feedback = await _run_approval_panel_async(
+            item.tool_call,
+            permission_options=item.options,
+            queue_position=1,
+            queue_depth=1,
+        )
+        option = _map_approval_result(
+            selected_index,
+            feedback,
+            action_key=action_key,
+            permission_options=item.options,
+        )
+        if option is None:
+            item.future.set_result(_rejected_permission_response())
+        else:
+            item.future.set_result(_selected_permission_response(option))
+
+    async def _flush_batch(self, items: list[_PendingItem]) -> None:
+        """Render combined batch panel and resolve all item Futures."""
+        from kagan.cli.chat._chat_acp import (
+            _map_approval_result,
+            _rejected_permission_response,
+            _selected_permission_response,
+            _tool_action_key,
+        )
+
+        # We'll collect resolutions here then apply after the modal closes
+        resolutions: dict[int, Any] = {}  # index -> ACP response
+
+        def _resolve_item(item_idx: int, opt_idx: int, feedback: str) -> None:
+            item = items[item_idx]
+            action_key = _tool_action_key(item.tool_call)
+            option = _map_approval_result(
+                opt_idx,
+                feedback,
+                action_key=action_key,
+                permission_options=item.options,
+            )
+            if option is None:
+                resolutions[item_idx] = _rejected_permission_response()
+            else:
+                resolutions[item_idx] = _selected_permission_response(option)
+
+        def _resolve_all(kind: str) -> None:
+            for i, item in enumerate(items):
+                if i not in resolutions:
+                    for o in item.options:
+                        if getattr(o, "kind", None) == kind:
+                            resolutions[i] = _selected_permission_response(o)
+                            break
+                    else:
+                        # fall back to first option
+                        if item.options:
+                            resolutions[i] = _selected_permission_response(item.options[0])
+                        else:
+                            resolutions[i] = _rejected_permission_response()
+
+        def _reject_all_fn() -> None:
+            for i, _item in enumerate(items):
+                if i not in resolutions:
+                    resolutions[i] = _rejected_permission_response()
+
+        run_in_terminal(lambda: None)  # flush any pending terminal output
+
+        await _run_batch_modal_async(
+            items,
+            _resolve_item=_resolve_item,
+            _resolve_all=_resolve_all,
+            _reject_all=_reject_all_fn,
+        )
+
+        # Apply resolutions; any still-missing items get rejected
+        for i, item in enumerate(items):
+            response = resolutions.get(i)
+            if response is None:
+                response = _rejected_permission_response()
+            if not item.future.done():
+                item.future.set_result(response)

--- a/src/kagan/cli/chat/_approval_panel.py
+++ b/src/kagan/cli/chat/_approval_panel.py
@@ -1,0 +1,239 @@
+"""Rich approval panel for chat REPL permission requests.
+
+Renders a bordered yellow panel with:
+- Human-readable action header (strips mcp__kagan__ prefix)
+- Typed body preview (bash syntax-highlight for shell commands, pretty-print for MCP args)
+- 4-option menu with arrow-key nav and number hotkeys
+- Inline feedback capture for option 4 (Reject + tell model)
+- Footer hint line
+- Agent identity metadata if available
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from rich.console import Group
+from rich.markup import escape as _rich_escape
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.text import Text
+
+# Maximum lines to show in approval preview body
+_MAX_PREVIEW_LINES = 4
+
+_APPROVAL_OPTIONS: list[tuple[str, str]] = [
+    ("Approve once", "allow_once"),
+    ("Approve for this session", "allow_always"),
+    ("Reject", "reject_once"),
+    ("Reject — tell the model what to do", "reject_feedback"),
+]
+
+
+def _use_ascii_spinner() -> bool:
+    """Return True when the terminal cannot render Unicode spinners."""
+    return bool(os.environ.get("NO_COLOR")) or os.environ.get("TERM", "") == "dumb"
+
+
+def _strip_tool_prefix(name: str) -> str:
+    """Remove mcp__kagan__ prefix and convert underscores to spaces for display."""
+    for prefix in ("mcp__kagan__", "mcp__"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+    return name.replace("_", " ").strip()
+
+
+def _tool_display_name(tool_call: Any) -> str:
+    """Return a human-readable tool name from an ACP tool_call object."""
+    raw = getattr(tool_call, "title", None) or getattr(tool_call, "name", None) or "tool call"
+    return _strip_tool_prefix(str(raw))
+
+
+def _is_shell_command(tool_call: Any) -> bool:
+    raw = getattr(tool_call, "title", None) or getattr(tool_call, "name", None) or ""
+    lower = str(raw).casefold()
+    return any(kw in lower for kw in ("shell", "bash", "exec", "run", "command"))
+
+
+def _extract_shell_command(tool_call: Any) -> str | None:
+    """Try to pull the shell command string out of tool args."""
+    for attr in ("raw_input", "rawInput", "arguments", "args"):
+        val = getattr(tool_call, attr, None)
+        if not val:
+            continue
+        if isinstance(val, str):
+            import json
+            try:
+                obj = json.loads(val)
+                if isinstance(obj, dict):
+                    for key in ("command", "cmd", "shell", "script"):
+                        if key in obj:
+                            return str(obj[key])
+                    # first string value
+                    for v in obj.values():
+                        if isinstance(v, str):
+                            return v
+            except (json.JSONDecodeError, ValueError):
+                return val.strip()
+        elif isinstance(val, dict):
+            for key in ("command", "cmd", "shell", "script"):
+                if key in val:
+                    return str(val[key])
+    return None
+
+
+def _extract_key_args_preview(tool_call: Any) -> str | None:
+    """Extract up to _MAX_PREVIEW_LINES lines of key arguments for display."""
+    import json
+    for attr in ("raw_input", "rawInput", "arguments", "args"):
+        val = getattr(tool_call, attr, None)
+        if not val:
+            continue
+        parsed: dict[str, object] | None = None
+        if isinstance(val, dict):
+            parsed = {str(k): v for k, v in val.items()}
+        elif isinstance(val, str):
+            try:
+                obj = json.loads(val)
+                if isinstance(obj, dict):
+                    parsed = {str(k): v for k, v in obj.items()}
+            except (json.JSONDecodeError, ValueError):
+                pass
+        if parsed is None:
+            continue
+        lines = []
+        for k, v in list(parsed.items())[:_MAX_PREVIEW_LINES]:
+            vstr = str(v)
+            if len(vstr) > 80:
+                vstr = vstr[:77] + "..."
+            lines.append(f"  {k}: {vstr}")
+        if len(parsed) > _MAX_PREVIEW_LINES:
+            lines.append(f"  ... ({len(parsed) - _MAX_PREVIEW_LINES} more args)")
+        return "\n".join(lines)
+    return None
+
+
+def build_approval_panel(
+    tool_call: Any,
+    *,
+    options: list[Any],
+    selected_index: int = 0,
+    feedback_draft: str = "",
+    queue_depth: int = 0,
+    queue_position: int = 0,
+) -> Panel:
+    """Build a Rich Panel for an ACP permission request.
+
+    Args:
+        tool_call: ACP tool_call object from request_permission.
+        options: Filtered list of ACP permission option objects.
+        selected_index: Currently highlighted menu row (0-based).
+        feedback_draft: Text typed so far for option-4 rejection feedback.
+        queue_depth: Total pending approvals (0 = single, shown as queue N of M).
+        queue_position: 1-based position in queue.
+    """
+    display_name = _tool_display_name(tool_call)
+    lines: list[object] = []
+
+    # Header
+    header_text = f"Kagan wants to run [bold]{_rich_escape(display_name)}[/bold]"
+    lines.append(Text.from_markup(f"[yellow]{header_text}[/yellow]"))
+
+    # Agent metadata (subagent / source task)
+    agent_id = getattr(tool_call, "agent_id", None)
+    subagent_type = getattr(tool_call, "subagent_type", None)
+    source_desc = getattr(tool_call, "source_description", None)
+    if agent_id or subagent_type:
+        parts = [p for p in (subagent_type, agent_id) if p]
+        lines.append(Text(f"Agent: {' / '.join(parts)}", style="dim grey50"))
+    if source_desc:
+        lines.append(Text(f"Task: {source_desc}", style="dim grey50"))
+
+    lines.append(Text(""))
+
+    # Body: shell command or MCP args preview
+    if _is_shell_command(tool_call):
+        cmd = _extract_shell_command(tool_call)
+        if cmd:
+            truncated = "\n".join(cmd.splitlines()[:_MAX_PREVIEW_LINES])
+            if len(cmd.splitlines()) > _MAX_PREVIEW_LINES:
+                truncated += "\n... (truncated)"
+            lines.append(Syntax(truncated, "bash", theme="ansi_dark", word_wrap=False))
+        else:
+            lines.append(Text("(shell command)", style="dim"))
+    else:
+        preview = _extract_key_args_preview(tool_call)
+        if preview:
+            lines.append(Text(preview, style="dim"))
+        else:
+            raw = getattr(tool_call, "title", None) or getattr(tool_call, "name", None) or ""
+            lines.append(Text(_strip_tool_prefix(str(raw)), style="dim"))
+
+    lines.append(Text(""))
+
+    # Menu options
+    panel_options = _build_display_options(options)
+    for i, (label, _kind) in enumerate(panel_options):
+        num = i + 1
+        is_feedback = i == 3
+        if i == selected_index:
+            if is_feedback and feedback_draft:
+                cursor_display = f"→ [{num}] Reject: {feedback_draft}█"
+                lines.append(Text(cursor_display, style="cyan"))
+            else:
+                lines.append(Text(f"→ [{num}] {label}", style="cyan bold"))
+        else:
+            lines.append(Text(f"  [{num}] {label}", style="dim"))
+
+    # Keyboard hint footer
+    lines.append(Text(""))
+    if selected_index == 3 and feedback_draft:
+        hint = "  Type feedback  Enter submit  Esc cancel"
+    else:
+        hint = "  ▲/▼ select  1/2/3/4 choose  ↵ confirm"
+    lines.append(Text(hint, style="dim"))
+
+    # Queue depth indicator
+    title = "[bold]approval[/bold]"
+    if queue_depth > 1:
+        title = f"[bold]approval[/bold]  [dim]{queue_position}/{queue_depth}[/dim]"
+
+    return Panel(
+        Group(*lines),
+        border_style="yellow",
+        title=title,
+        title_align="left",
+        padding=(0, 1),
+    )
+
+
+def _build_display_options(acp_options: list[Any]) -> list[tuple[str, str]]:
+    """Map ACP option kinds to our 4-slot display list.
+
+    Always returns exactly 4 rows regardless of what ACP provides.
+    """
+    _KIND_LABEL = {
+        "allow_once": "Approve once",
+        "allow_always": "Approve for this session",
+        "reject_once": "Reject",
+        "reject_always": "Reject",
+    }
+    found = {str(getattr(o, "kind", "")): o for o in acp_options}
+    result: list[tuple[str, str]] = []
+    for kind, label in [
+        ("allow_once", "Approve once"),
+        ("allow_always", "Approve for this session"),
+        ("reject_once", "Reject"),
+    ]:
+        if kind in found:
+            result.append((label, kind))
+        else:
+            result.append((label, kind))
+    result.append(("Reject — tell the model what to do", "reject_feedback"))
+    return result
+
+
+def get_rich_spinner_name() -> str:
+    """Return Rich spinner name appropriate for the terminal."""
+    return "line" if _use_ascii_spinner() else "dots"

--- a/src/kagan/cli/chat/_chat_acp.py
+++ b/src/kagan/cli/chat/_chat_acp.py
@@ -440,11 +440,12 @@ async def _run_interactive_modal(
     @kb.add("c-e", eager=True)
     def _expand(event) -> None:
         async def _pager() -> None:
-            await asyncio.to_thread(
-                _show_panel_in_pager,
-                tool_call,
-                permission_options=permission_options,
-                selected_index=state["selected"],
+            await run_in_terminal(
+                lambda: _show_panel_in_pager(
+                    tool_call,
+                    permission_options=permission_options,
+                    selected_index=state["selected"],
+                )
             )
 
         event.app.create_background_task(_pager())

--- a/src/kagan/cli/chat/_chat_acp.py
+++ b/src/kagan/cli/chat/_chat_acp.py
@@ -1,12 +1,16 @@
 """ACP client for orchestrator mode — streaming output, tool tracking, animation."""
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
+import io
+import shutil
 import sys
 import time
-from collections.abc import AsyncIterator, Callable
+from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from acp.schema import (
     AgentMessageChunk,
@@ -15,10 +19,16 @@ from acp.schema import (
     ToolCallStart,
     UsageUpdate,
 )
+from loguru import logger
+from prompt_toolkit.application.run_in_terminal import run_in_terminal
 from rich.markup import escape as _rich_escape
 from rich.measure import Measurement
 from rich.text import Text
 
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+from kagan.cli.chat._approval_panel import build_approval_panel, get_rich_spinner_name
 from kagan.cli.chat._streaming import OutputFlushManager, ResponseChunkBuffer
 from kagan.cli.chat.repl import WAVE_FRAMES, _console, _env_flag_enabled
 from kagan.cli.chat.tool_runs import ToolRunTracker
@@ -136,6 +146,12 @@ def _selected_permission_response(option: Any) -> Any:
     )
 
 
+def _rejected_permission_response() -> Any:
+    from acp.schema import DeniedOutcome, RequestPermissionResponse
+
+    return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
+
+
 def _permission_choice_matches(value: str, option: Any, index: int) -> bool:
     normalized = value.casefold().strip()
     kind = str(getattr(option, "kind", "")).casefold()
@@ -159,28 +175,458 @@ def _format_permission_tool(tool_call: Any) -> str:
     return "tool call"
 
 
-def _prompt_for_permission_option(options: list[Any], tool_call: Any) -> Any | None:
-    _console.print()
-    _console.print("[bold yellow]Permission requested[/bold yellow]")
-    _console.print(f"[dim]{_rich_escape(_format_permission_tool(tool_call))}[/dim]")
-    for index, option in enumerate(options, start=1):
-        kind = str(getattr(option, "kind", ""))
-        label = _PERMISSION_KIND_LABELS.get(kind, kind.replace("_", " "))
-        name = str(getattr(option, "name", "") or label)
-        _console.print(f"  {index}. {name} [dim]({label})[/dim]")
+def _tool_action_key(tool_call: Any) -> str:
+    """Return a stable string that identifies the tool action for session-allow tracking."""
+    title = getattr(tool_call, "title", None) or getattr(tool_call, "name", None) or "tool"
+    return str(title).strip().casefold()
+
+
+# ---------------------------------------------------------------------------
+# Grouped tool-call display
+# ---------------------------------------------------------------------------
+
+
+class _GroupedToolDisplay:
+    """Accumulate parallel tool calls and render them as grouped status lines.
+
+    Groups calls by tool name.  Shows: ``tool_name x N -- done D/N . Xs``.
+    """
+
+    def __init__(self) -> None:
+        # tool_name -> list of (status, started_at, ended_at)
+        self._calls: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        self._key_to_name: dict[str, str] = {}
+
+    def start(self, tool_key: str, tool_name: str, started_at: float) -> None:
+        self._key_to_name[tool_key] = tool_name
+        self._calls[tool_name].append(
+            {"key": tool_key, "status": "running", "started": started_at, "ended": None}
+        )
+
+    def complete(self, tool_key: str, status: str, ended_at: float) -> None:
+        name = self._key_to_name.get(tool_key)
+        if name is None:
+            return
+        for entry in self._calls.get(name, []):
+            if entry["key"] == tool_key and entry["status"] == "running":
+                entry["status"] = status
+                entry["ended"] = ended_at
+                break
+
+    def render_lines(self) -> list[str]:
+        """Return one display line per tool name."""
+        lines = []
+        now = time.monotonic()
+        for name, entries in self._calls.items():
+            total = len(entries)
+            done = sum(1 for e in entries if e["status"] in ("completed", "failed"))
+            error = sum(1 for e in entries if e["status"] == "failed")
+            elapsed = max(
+                (now - e["started"]) for e in entries if e["started"] is not None
+            )
+            elapsed_text = f"{elapsed:.1f}s"
+
+            if total == 1:
+                entry = entries[0]
+                if entry["status"] == "running":
+                    icon = "●"
+                    style = "dim"
+                elif entry["status"] == "completed":
+                    icon = "✓"
+                    style = "green"
+                else:
+                    icon = "✗"
+                    style = "red"
+                line = f"  [{style}]{icon} {_rich_escape(name)} · {elapsed_text}[/{style}]"
+            else:
+                if error > 0:
+                    status_text = f"done {done}/{total} · {error} err · {elapsed_text}"
+                    style = "red"
+                elif done == total:
+                    status_text = f"done {total}/{total} · {elapsed_text}"
+                    style = "green"
+                else:
+                    status_text = f"done {done}/{total} · {elapsed_text}"
+                    style = "dim"
+                icon = "✓" if done == total and error == 0 else "●"
+                line = (
+                    f"  [{style}]{icon} {_rich_escape(name)} x{total}"
+                    f" -- {status_text}[/{style}]"
+                )
+            lines.append(line)
+        return lines
+
+    def clear(self) -> None:
+        self._calls.clear()
+        self._key_to_name.clear()
+
+
+# ---------------------------------------------------------------------------
+# Arrow-key approval panel — prompt_toolkit Application
+# ---------------------------------------------------------------------------
+
+
+def _render_panel_ansi(
+    tool_call: Any,
+    *,
+    permission_options: list[Any],
+    selected_index: int,
+    feedback_draft: str,
+    queue_position: int,
+    queue_depth: int,
+) -> str:
+    """Render the Rich approval panel to an ANSI escape-code string."""
+    from rich.console import Console
+
+    buf = io.StringIO()
+    cols = shutil.get_terminal_size((80, 24)).columns
+    tmp = Console(file=buf, highlight=False, width=cols, force_terminal=True)
+    tmp.print(
+        build_approval_panel(
+            tool_call,
+            options=permission_options,
+            selected_index=selected_index,
+            feedback_draft=feedback_draft,
+            queue_depth=queue_depth,
+            queue_position=queue_position,
+        )
+    )
+    return buf.getvalue()
+
+
+def _show_panel_in_pager(
+    tool_call: Any,
+    *,
+    permission_options: list[Any],
+    selected_index: int,
+) -> None:
+    """Show a full pager with the approval panel content (Ctrl-E handler)."""
+    from rich.console import Console
+
+    cols = shutil.get_terminal_size((80, 24)).columns
+    buf = io.StringIO()
+    tmp = Console(file=buf, highlight=False, width=cols, force_terminal=True)
+    tmp.print(
+        build_approval_panel(
+            tool_call,
+            options=permission_options,
+            selected_index=selected_index,
+            feedback_draft="",
+            queue_depth=1,
+            queue_position=1,
+        )
+    )
+    with _console.pager(styles=True):
+        _console.print(buf.getvalue(), end="")
+
+
+async def _run_approval_panel_async(
+    tool_call: Any,
+    *,
+    permission_options: list[Any],
+    queue_position: int = 1,
+    queue_depth: int = 1,
+) -> tuple[int, str]:
+    """Show an interactive arrow-key approval panel.
+
+    Returns (selected_index, feedback_draft).
+    Falls back to the legacy input() loop on any failure (e.g. dumb TTY).
+    """
+    try:
+        return await _run_interactive_modal(
+            tool_call,
+            permission_options=permission_options,
+            queue_position=queue_position,
+            queue_depth=queue_depth,
+        )
+    except Exception:
+        logger.debug("Arrow-key approval modal failed; falling back to legacy input loop")
+        return _run_legacy_input(
+            tool_call,
+            permission_options=permission_options,
+            queue_position=queue_position,
+            queue_depth=queue_depth,
+        )
+
+
+async def _run_interactive_modal(
+    tool_call: Any,
+    *,
+    permission_options: list[Any],
+    queue_position: int,
+    queue_depth: int,
+) -> tuple[int, str]:
+    """Build and run a transient prompt_toolkit Application for the approval panel.
+
+    The Application renders the Rich panel as ANSI text and handles key events.
+    It does not interfere with the outer PromptSession — it runs as a separate
+    event-loop Application that the outer session is not aware of.
+    """
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.buffer import Buffer
+    from prompt_toolkit.document import Document
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import HSplit, Window
+    from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+
+    # Mutable state captured by the closures below.
+    state: dict[str, Any] = {
+        "selected": 0,
+        "feedback": "",
+        "feedback_mode": False,
+    }
+
+    # Buffer for option-4 inline feedback text.
+    feedback_buffer = Buffer(name="approval_feedback", multiline=False)
+
+    def _panel_text() -> ANSI:
+        draft = feedback_buffer.text if state["feedback_mode"] else state["feedback"]
+        ansi = _render_panel_ansi(
+            tool_call,
+            permission_options=permission_options,
+            selected_index=state["selected"],
+            feedback_draft=draft,
+            queue_position=queue_position,
+            queue_depth=queue_depth,
+        )
+        return ANSI(ansi)
+
+    panel_window = Window(
+        content=FormattedTextControl(text=_panel_text),
+        dont_extend_height=True,
+    )
+    # Height-0 Window keeps the feedback buffer alive without taking screen space.
+    feedback_window = Window(
+        content=BufferControl(buffer=feedback_buffer, focusable=True),
+        height=0,
+    )
+
+    layout = Layout(HSplit([panel_window, feedback_window]))
+    kb = KeyBindings()
+
+    def _exit_with(app: Any, idx: int, fb: str) -> None:
+        app.exit(result=(idx, fb))
+
+    def _move(direction: int) -> None:
+        if state["feedback_mode"]:
+            state["feedback"] = feedback_buffer.text
+            feedback_buffer.set_document(Document(), bypass_readonly=True)
+        state["selected"] = (state["selected"] + direction) % 4
+        state["feedback_mode"] = state["selected"] == 3
+
+    @kb.add("up", eager=True)
+    def _up(event) -> None:
+        _move(-1)
+
+    @kb.add("down", eager=True)
+    def _down(event) -> None:
+        _move(1)
+
+    @kb.add("enter", eager=True)
+    def _enter(event) -> None:
+        if state["feedback_mode"] and not feedback_buffer.text.strip():
+            return  # keep editing — empty Enter in feedback mode is a no-op
+        fb = feedback_buffer.text.strip() if state["feedback_mode"] else state["feedback"]
+        _exit_with(event.app, state["selected"], fb)
+
+    @kb.add("escape", eager=True)
+    @kb.add("c-c", eager=True)
+    @kb.add("c-d", eager=True)
+    def _cancel(event) -> None:
+        _exit_with(event.app, 2, "")  # slot 2 = reject_once
+
+    @kb.add("c-e", eager=True)
+    def _expand(event) -> None:
+        async def _pager() -> None:
+            await asyncio.to_thread(
+                _show_panel_in_pager,
+                tool_call,
+                permission_options=permission_options,
+                selected_index=state["selected"],
+            )
+
+        event.app.create_background_task(_pager())
+
+    def _make_num_handler(num: int) -> None:
+        @kb.add(str(num), eager=True)
+        def _num(event) -> None:
+            idx = num - 1
+            state["selected"] = idx
+            if idx == 3:
+                state["feedback_mode"] = True
+                # option 4 selected — stay open for feedback input
+            else:
+                state["feedback_mode"] = False
+                _exit_with(event.app, idx, "")
+
+    for n in range(1, 5):
+        _make_num_handler(n)
+
+    app: Application[tuple[int, str]] = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        mouse_support=False,
+    )
+
+    result = await app.run_async()
+    if result is None:
+        return 2, ""
+    return result
+
+
+def _run_legacy_input(
+    tool_call: Any,
+    *,
+    permission_options: list[Any],
+    queue_position: int,
+    queue_depth: int,
+) -> tuple[int, str]:
+    """Sync fallback: render panel then read choice via input()."""
+    selected_index = 0
+    feedback_draft = ""
+
+    _console.print(
+        build_approval_panel(
+            tool_call,
+            options=permission_options,
+            selected_index=selected_index,
+            feedback_draft=feedback_draft,
+            queue_depth=queue_depth,
+            queue_position=queue_position,
+        )
+    )
 
     try:
-        value = input("Select permission option [deny]: ").strip()
+        while True:
+            raw = input().strip()
+            if not raw:
+                break
+            if raw in {"1", "2", "3", "4"}:
+                selected_index = int(raw) - 1
+                if selected_index == 3:
+                    _console.print(
+                        "[dim]Type rejection reason (Enter confirm, empty cancel):[/dim]"
+                    )
+                    try:
+                        feedback_draft = input().strip()
+                    except (EOFError, KeyboardInterrupt):
+                        feedback_draft = ""
+                break
+            if raw in {"q", "n", "reject", "deny"}:
+                selected_index = 2
+                break
+            if raw in {"y", "a", "approve"}:
+                selected_index = 0
+                break
     except (EOFError, KeyboardInterrupt):
-        _console.print("[yellow]Permission denied.[/yellow]")
+        selected_index = 2
+
+    return selected_index, feedback_draft
+
+
+class _SessionApprovals:
+    """Track tool actions approved for the lifetime of this REPL session."""
+
+    def __init__(self) -> None:
+        self._allowed: set[str] = set()
+
+    def is_allowed(self, action_key: str) -> bool:
+        return action_key in self._allowed
+
+    def grant(self, action_key: str) -> None:
+        self._allowed.add(action_key)
+
+    def revoke(self, action_key: str) -> None:
+        self._allowed.discard(action_key)
+
+    def list_granted(self) -> list[str]:
+        return sorted(self._allowed)
+
+
+_session_approvals = _SessionApprovals()
+
+
+def get_session_approvals() -> _SessionApprovals:
+    """Return the module-level session approval tracker."""
+    return _session_approvals
+
+
+async def _prompt_for_permission_option_async(
+    options: list[Any],
+    tool_call: Any,
+    *,
+    queue_position: int = 1,
+    queue_depth: int = 1,
+) -> Any | None:
+    """Show Rich panel approval prompt with arrow-key navigation.
+
+    Returns selected ACP option or None (reject / cancel).
+    """
+    _allowed_kinds = {"allow_once", "allow_always", "reject_once", "reject_always"}
+    permission_options = [o for o in options if getattr(o, "kind", None) in _allowed_kinds]
+    if not permission_options:
         return None
 
-    if not value:
-        return None
-    for index, option in enumerate(options, start=1):
-        if _permission_choice_matches(value, option, index):
-            return option
-    _console.print("[yellow]Unrecognized permission choice; denying.[/yellow]")
+    action_key = _tool_action_key(tool_call)
+    if _session_approvals.is_allowed(action_key):
+        for o in permission_options:
+            if getattr(o, "kind", None) == "allow_once":
+                return o
+        return permission_options[0]
+
+    selected_index, feedback = await _run_approval_panel_async(
+        tool_call,
+        permission_options=permission_options,
+        queue_position=queue_position,
+        queue_depth=queue_depth,
+    )
+
+    return _map_approval_result(
+        selected_index,
+        feedback,
+        action_key=action_key,
+        permission_options=permission_options,
+    )
+
+
+def _map_approval_result(
+    selected_index: int,
+    feedback: str,
+    *,
+    action_key: str,
+    permission_options: list[Any],
+) -> Any | None:
+    """Convert (selected_index, feedback) into an ACP option or None (reject)."""
+    _SLOT_KINDS = ["allow_once", "allow_always", "reject_once", "reject_feedback"]
+    slot_kind = _SLOT_KINDS[min(selected_index, 3)]
+
+    if slot_kind == "allow_always":
+        _session_approvals.grant(action_key)
+        msg = (
+            f"[dim green]✓ approved · will not ask again for"
+            f" [bold]{_rich_escape(action_key)}[/bold] this session[/dim green]"
+        )
+        _console.print(msg)
+        for o in permission_options:
+            if getattr(o, "kind", None) == "allow_always":
+                return o
+        for o in permission_options:
+            if getattr(o, "kind", None) == "allow_once":
+                return o
+        return permission_options[0]
+
+    if slot_kind == "allow_once":
+        for o in permission_options:
+            if getattr(o, "kind", None) == "allow_once":
+                return o
+        return permission_options[0]
+
+    if slot_kind == "reject_feedback" and feedback:
+        logger.info("Rejection feedback from user: {}", feedback)
+
     return None
 
 
@@ -191,17 +637,20 @@ class _OrchestratorACPClient(ACPClientBase):
         self._yolo = yolo
         self._show_thoughts = _env_flag_enabled("KAGAN_CHAT_SHOW_THOUGHTS", default=False)
         self._tool_runs = ToolRunTracker()
+        self._grouped_tools = _GroupedToolDisplay()
         self._response_chunks = ResponseChunkBuffer()
         self._output_flusher = OutputFlushManager(_console)
         self._first_update_notified = False
         self._on_first_update: Callable[[], None] | None = None
         self.last_usage: Any = None
+        self._spinner_name = get_rich_spinner_name()
 
     def start_turn(self, *, on_first_update: Callable[[], None] | None = None) -> None:
         self._output_flusher.shutdown()
         self._response_chunks.clear()
         self._output_flusher.clear()
         self._tool_runs.start_turn()
+        self._grouped_tools.clear()
         self._first_update_notified = False
         self._on_first_update = on_first_update
         self.last_usage = None
@@ -222,6 +671,71 @@ class _OrchestratorACPClient(ACPClientBase):
     def tool_report(self, query: str | None) -> tuple[str, bool]:
         return self._tool_runs.tool_report(query)
 
+    def _print_via_terminal(self, fn: Callable[[], None]) -> None:
+        """Print safely, using run_in_terminal when a real prompt_toolkit app is active."""
+        try:
+            from prompt_toolkit.application.current import get_app
+            from prompt_toolkit.application.dummy import DummyApplication
+
+            app = get_app()
+            if app is not None and not isinstance(app, DummyApplication):
+                run_in_terminal(fn)
+                return
+        except Exception:
+            pass
+        fn()
+
+    def _handle_tool_progress(self, update: ToolCallProgress) -> None:
+        """Handle ToolCallProgress events: update run record and print status."""
+        status = getattr(update, "status", None)
+        title = getattr(update, "title", None) or "tool"
+        tool_key = self._tool_runs.tool_key(update)
+        if status and self._tool_runs.status_for(tool_key) == status:
+            return
+        key_arg = self._tool_runs.extract_tool_key_arg(update)
+        run = self._tool_runs.ensure_tool_run(update=update, title=title, key_arg=key_arg)
+        if status:
+            run.status = str(status)
+        args = self._tool_runs.serialize_payload(self._tool_runs.extract_tool_args(update))
+        if args:
+            run.args = args
+        result = self._tool_runs.serialize_payload(self._tool_runs.extract_tool_result(update))
+        if result:
+            run.result = result
+        if status not in ("completed", "failed"):
+            return
+        self._tool_runs.set_status(tool_key, status)
+        run.ended_at = run.ended_at or time.monotonic()
+        self._grouped_tools.complete(tool_key, status, run.ended_at)
+        self._print_via_terminal(
+            self._make_done_printer(title, key_arg, status, run.started_at, run.ended_at)
+        )
+
+    @staticmethod
+    def _make_done_printer(
+        title: str,
+        key_arg: str | None,
+        status: str,
+        started_at: float,
+        ended_at: float,
+    ) -> Callable[[], None]:
+        def _print() -> None:
+            arg_suffix = f"({key_arg})" if key_arg else ""
+            elapsed = max(0.0, ended_at - started_at)
+            duration = f" [dim]{elapsed:.1f}s[/dim]" if elapsed >= 0.1 else ""
+            if status == "completed":
+                _console.print(
+                    f"  [green]● {title}{arg_suffix}[/green]{duration}",
+                    highlight=False,
+                )
+            else:
+                _console.print(
+                    f"  [red]● {title}{arg_suffix} failed[/red]",
+                    highlight=False,
+                )
+
+        return _print
+
     async def session_update(self, session_id: str, update: Any, **kwargs: Any) -> None:
         if isinstance(update, AgentMessageChunk):
             content = getattr(update, "content", None)
@@ -241,8 +755,14 @@ class _OrchestratorACPClient(ACPClientBase):
                     if text:
                         self._notify_first_update()
                         self._output_flusher.flush(force=True)
-                        _console.print(f"[dim]{_rich_escape(text)}[/dim]", end="", highlight=False)
-                        _console.file.flush()
+
+                        def _print_thought() -> None:
+                            _console.print(
+                                f"[dim]{_rich_escape(text)}[/dim]", end="", highlight=False
+                            )
+                            _console.file.flush()
+
+                        self._print_via_terminal(_print_thought)
         elif isinstance(update, ToolCallStart):
             self._notify_first_update()
             self._output_flusher.flush(force=True)
@@ -256,39 +776,17 @@ class _OrchestratorACPClient(ACPClientBase):
                 run.args = self._tool_runs.serialize_payload(
                     self._tool_runs.extract_tool_args(update)
                 )
-                arg_suffix = f"({key_arg})" if key_arg else ""
-                _console.print(f"\n  [dim]● {title}{arg_suffix}[/dim]", highlight=False)
+                self._grouped_tools.start(tool_key, title, run.started_at)
+
+                def _print_start() -> None:
+                    arg_suffix = f"({key_arg})" if key_arg else ""
+                    _console.print(f"\n  [dim]● {title}{arg_suffix}[/dim]", highlight=False)
+
+                self._print_via_terminal(_print_start)
         elif isinstance(update, ToolCallProgress):
             self._notify_first_update()
             self._output_flusher.flush(force=True)
-            status = getattr(update, "status", None)
-            title = getattr(update, "title", None) or "tool"
-            tool_key = self._tool_runs.tool_key(update)
-            if status and self._tool_runs.status_for(tool_key) == status:
-                return
-            key_arg = self._tool_runs.extract_tool_key_arg(update)
-            run = self._tool_runs.ensure_tool_run(update=update, title=title, key_arg=key_arg)
-            if status:
-                run.status = str(status)
-            args = self._tool_runs.serialize_payload(self._tool_runs.extract_tool_args(update))
-            if args:
-                run.args = args
-            result = self._tool_runs.serialize_payload(self._tool_runs.extract_tool_result(update))
-            if result:
-                run.result = result
-            arg_suffix = f"({key_arg})" if key_arg else ""
-            if status == "completed":
-                self._tool_runs.set_status(tool_key, status)
-                run.ended_at = run.ended_at or time.monotonic()
-                duration = ""
-                if run.started_at and run.ended_at:
-                    elapsed = run.ended_at - run.started_at
-                    duration = f" [dim]{elapsed:.1f}s[/dim]" if elapsed >= 0.1 else ""
-                _console.print(f"  [green]● {title}{arg_suffix}[/green]{duration}", highlight=False)
-            elif status == "failed":
-                self._tool_runs.set_status(tool_key, status)
-                run.ended_at = run.ended_at or time.monotonic()
-                _console.print(f"  [red]● {title}{arg_suffix} failed[/red]", highlight=False)
+            self._handle_tool_progress(update)
         elif isinstance(update, UsageUpdate):
             self._notify_first_update()
             self.last_usage = update
@@ -309,18 +807,29 @@ class _OrchestratorACPClient(ACPClientBase):
         if self._yolo:
             for option in permission_options:
                 if getattr(option, "kind", None) == "allow_once":
-                    title = _format_permission_tool(tool_call)
-                    _console.print(
-                        f"  [red]● yolo auto-approve:[/red] [dim]{_rich_escape(title)}[/dim]",
-                        highlight=False,
-                    )
+                    _yolo_title = _format_permission_tool(tool_call)
+
+                    def _print_yolo(_t: str = _yolo_title) -> None:
+                        _console.print(
+                            f"  [red]● yolo auto-approve:[/red]"
+                            f" [dim]{_rich_escape(_t)}[/dim]",
+                            highlight=False,
+                        )
+
+                    self._print_via_terminal(_print_yolo)
                     return _selected_permission_response(option)
 
         if not _stdio_is_interactive():
-            _console.print("[yellow]Permission request denied in non-interactive mode.[/yellow]")
+
+            def _print_denied() -> None:
+                _console.print(
+                    "[yellow]Permission request denied in non-interactive mode.[/yellow]"
+                )
+
+            self._print_via_terminal(_print_denied)
             return _cancelled_permission_response()
 
-        selected = _prompt_for_permission_option(permission_options, tool_call)
+        selected = await _prompt_for_permission_option_async(permission_options, tool_call)
         if selected is None:
-            return _cancelled_permission_response()
+            return _rejected_permission_response()
         return _selected_permission_response(selected)

--- a/src/kagan/cli/chat/_chat_acp.py
+++ b/src/kagan/cli/chat/_chat_acp.py
@@ -633,6 +633,8 @@ def _map_approval_result(
 
 class _OrchestratorACPClient(ACPClientBase):
     def __init__(self, *, yolo: bool = False) -> None:
+        from kagan.cli.chat._approval_batch import _BatchApprovalQueue
+
         self._conn: Any = None
         self._streaming = False
         self._yolo = yolo
@@ -645,6 +647,7 @@ class _OrchestratorACPClient(ACPClientBase):
         self._on_first_update: Callable[[], None] | None = None
         self.last_usage: Any = None
         self._spinner_name = get_rich_spinner_name()
+        self._batch_queue = _BatchApprovalQueue(self)
 
     def start_turn(self, *, on_first_update: Callable[[], None] | None = None) -> None:
         self._output_flusher.shutdown()
@@ -655,6 +658,7 @@ class _OrchestratorACPClient(ACPClientBase):
         self._first_update_notified = False
         self._on_first_update = on_first_update
         self.last_usage = None
+        self._batch_queue.reset()
 
     def _notify_first_update(self) -> None:
         if self._first_update_notified:
@@ -805,6 +809,7 @@ class _OrchestratorACPClient(ACPClientBase):
 
         self._output_flusher.flush(force=True)
 
+        # --yolo: short-circuit before the batch queue is armed.
         if self._yolo:
             for option in permission_options:
                 if getattr(option, "kind", None) == "allow_once":
@@ -830,7 +835,10 @@ class _OrchestratorACPClient(ACPClientBase):
             self._print_via_terminal(_print_denied)
             return _cancelled_permission_response()
 
-        selected = await _prompt_for_permission_option_async(permission_options, tool_call)
-        if selected is None:
-            return _rejected_permission_response()
-        return _selected_permission_response(selected)
+        # Enqueue into the batch queue; await the resolved Future.
+        future = await self._batch_queue.enqueue(permission_options, tool_call)
+        return await future
+
+    def cancel_batch_queue(self) -> None:
+        """Cancel all pending batch approval futures (called from SIGINT handler)."""
+        self._batch_queue.cancel_all()

--- a/src/kagan/cli/chat/commands.py
+++ b/src/kagan/cli/chat/commands.py
@@ -57,6 +57,7 @@ class SlashAction(Enum):
     SHOW_INFO = "show_info"
     SWITCH_REPO = "switch_repo"
     SHOW_REPO = "show_repo"
+    SHOW_APPROVALS = "show_approvals"
 
 
 @dataclass(frozen=True, slots=True)
@@ -312,6 +313,20 @@ def _handle_analytics(
     return SlashCommandOutcome(handled=True, action=SlashAction.SHOW_ANALYTICS)
 
 
+def _handle_approvals(
+    invocation: SlashCommandInvocation, _ctx: _SlashCommandContext
+) -> SlashCommandOutcome:
+    arg = invocation.arg.strip().casefold()
+    if arg.startswith("revoke ") or arg.startswith("revoke\t"):
+        target = arg.split(None, 1)[1].strip()
+        return SlashCommandOutcome(
+            handled=True,
+            action=SlashAction.SHOW_APPROVALS,
+            data=f"revoke:{target}",
+        )
+    return SlashCommandOutcome(handled=True, action=SlashAction.SHOW_APPROVALS)
+
+
 def _handle_flow(
     invocation: SlashCommandInvocation, ctx: _SlashCommandContext
 ) -> SlashCommandOutcome:
@@ -398,6 +413,11 @@ def _build_slash_command_registry() -> SlashCommandRegistry:
         name="analytics",
         description="Show stats or export: /analytics [export [path]]",
         handler=_handle_analytics,
+    )
+    registry.register(
+        name="approvals",
+        description="List session-granted approvals: /approvals [revoke <name>]",
+        handler=_handle_approvals,
     )
     registry.register(
         name="flow",

--- a/src/kagan/cli/chat/controller.py
+++ b/src/kagan/cli/chat/controller.py
@@ -14,6 +14,7 @@ import click
 from loguru import logger
 from rich.live import Live
 
+from kagan.cli.chat._approval_panel import _strip_tool_prefix
 from kagan.cli.chat._chat_acp import (
     _OrchestratorACPClient,
     _SendResult,
@@ -101,6 +102,19 @@ __all__ = [
     "_WaveIndicator",
     "_turn_wave_animation",
 ]
+
+
+def _reply_has_markdown(text: str) -> bool:
+    """Return True if the text contains Markdown tables, fences, or headers."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("|") and "|" in stripped[1:]:
+            return True
+        if stripped.startswith("```"):
+            return True
+        if stripped.startswith("#"):
+            return True
+    return False
 
 
 def _settings_flag_enabled(settings: dict[str, str], key: str, *, default: bool) -> bool:
@@ -856,6 +870,12 @@ class ChatController:
             return _SendResult(was_cancelled=True)
 
         _console.print()  # newline after streamed output
+        # If the response contains Markdown tables/headers/fences, re-render
+        # using Rich Markdown so pipes display as proper tables.
+        if assistant_reply and _reply_has_markdown(assistant_reply):
+            from rich.markdown import Markdown as _RichMarkdown
+
+            _console.print(_RichMarkdown(assistant_reply))
         self._turn_count += 1
         _TOOLBAR_STATE.turn_count = self._turn_count
 
@@ -1022,11 +1042,7 @@ class ChatController:
                     turn_count=self._turn_count,
                 )
             case SlashAction.SHOW_ANALYTICS:
-                if result.data and result.data.startswith("export:"):
-                    path = result.data[len("export:") :] or None
-                    await export_analytics_json(self.client, path)
-                else:
-                    await print_analytics_panel(self.client)
+                await self._handle_analytics(result.data)
             case SlashAction.SHOW_PROJECT:
                 print_project_info(
                     project_name=self._project_name,
@@ -1041,12 +1057,44 @@ class ChatController:
                     repo_name=self._selected_repo_name,
                     repo_id=self._selected_repo_id,
                 )
+            case SlashAction.SHOW_APPROVALS:
+                self._show_approvals(result.data or "")
             case SlashAction.CLOSE:
                 return True
             case _:
                 pass
 
         return False
+
+    async def _handle_analytics(self, data: str | None) -> None:
+        if data and data.startswith("export:"):
+            path = data[len("export:"):] or None
+            await export_analytics_json(self.client, path)
+        else:
+            await print_analytics_panel(self.client)
+
+    def _show_approvals(self, data: str) -> None:
+        from kagan.cli.chat._chat_acp import get_session_approvals
+
+        approvals = get_session_approvals()
+
+        if data.startswith("revoke:"):
+            target = data[len("revoke:"):]
+            if target:
+                approvals.revoke(target)
+                _console.print(f"[green]Revoked approval:[/green] {target}")
+            else:
+                _console.print("[red]Usage: /approvals revoke <name>[/red]")
+            return
+
+        granted = approvals.list_granted()
+        if not granted:
+            _console.print("[dim]No session approvals granted yet.[/dim]")
+            return
+        _console.print("[bold]Session-granted approvals:[/bold]")
+        for name in granted:
+            display = _strip_tool_prefix(name)
+            _console.print(f"  [green]✓[/green] {display}  [dim](/approvals revoke {name})[/dim]")
 
     async def _switch_project(self, name: str) -> None:
         projects = await self.client.projects.list()

--- a/src/kagan/cli/chat/repl.py
+++ b/src/kagan/cli/chat/repl.py
@@ -69,6 +69,9 @@ class ToolbarState:
     workspace_label: str = ""
     is_streaming: bool = False
     yolo: bool = False
+    pending_approvals: int = 0
+    current_tool: str = ""
+    token_used_k: float | None = None
 
 
 _TOOLBAR_STATE = ToolbarState()
@@ -505,11 +508,16 @@ def _bottom_toolbar() -> FormattedText:
         status_right_parts.append("YOLO")
     if _TOOLBAR_STATE.agent_backend:
         status_right_parts.append(_TOOLBAR_STATE.agent_backend)
-    if _TOOLBAR_STATE.context_pct is not None:
+    if _TOOLBAR_STATE.pending_approvals > 0:
+        status_right_parts.append(f"⚠ {_TOOLBAR_STATE.pending_approvals} approval(s) pending")
+    if _TOOLBAR_STATE.current_tool:
+        status_right_parts.append(f"tool: {_TOOLBAR_STATE.current_tool}")
+    if _TOOLBAR_STATE.token_used_k is not None:
+        status_right_parts.append(f"~{_TOOLBAR_STATE.token_used_k:.0f}k tok")
+    elif _TOOLBAR_STATE.context_pct is not None:
         status_right_parts.append(f"ctx {_TOOLBAR_STATE.context_pct:.0%}")
-    status_right_parts.append(f"{_TOOLBAR_STATE.turn_count} msg")
-    if _TOOLBAR_STATE.turn_count != 1:
-        status_right_parts[-1] = f"{_TOOLBAR_STATE.turn_count} msgs"
+    msg_word = "msg" if _TOOLBAR_STATE.turn_count == 1 else "msgs"
+    status_right_parts.append(f"{_TOOLBAR_STATE.turn_count} {msg_word}")
     status_right = " · ".join(status_right_parts)
 
     shortcut_left = _SHORTCUT_HINT_STREAMING if _TOOLBAR_STATE.is_streaming else _SHORTCUT_HINT_IDLE
@@ -599,16 +607,25 @@ def _get_prompt_session() -> PromptSession[str]:
     return _prompt_session
 
 
-WAVE_FRAMES = (
-    "ᘚᘚᘚᘚ",
-    "ᘛᘚᘚᘚ",
-    "ᘛᘛᘚᘚ",
-    "ᘛᘛᘛᘚ",
-    "ᘛᘛᘛᘛ",
-    "ᘚᘛᘛᘛ",
-    "ᘚᘚᘛᘛ",
-    "ᘚᘚᘚᘛ",
+def _ascii_spinner_active() -> bool:
+    """Return True when terminal cannot handle Unicode spinners."""
+    return bool(os.environ.get("NO_COLOR")) or os.environ.get("TERM", "") == "dumb"
+
+
+# Unicode frames (Canadian Syllabics) replaced with dots-style ASCII-safe fallback
+WAVE_FRAMES_UNICODE: tuple[str, ...] = (
+    "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
 )
+WAVE_FRAMES_ASCII: tuple[str, ...] = ("|", "/", "-", "\\")
+
+
+def _get_wave_frames() -> tuple[str, ...]:
+    return WAVE_FRAMES_ASCII if _ascii_spinner_active() else WAVE_FRAMES_UNICODE
+
+
+# WAVE_FRAMES is computed once at import time; callers that cache it will use
+# the resolved value.  Dynamic terminal detection happens in _get_wave_frames().
+WAVE_FRAMES = _get_wave_frames()
 
 
 def _write_boot_banner(

--- a/tests/unit/test_chat_approval_panel.py
+++ b/tests/unit/test_chat_approval_panel.py
@@ -1,0 +1,362 @@
+"""Unit tests for the chat approval panel and arrow-key navigation logic."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import kagan.cli.chat._chat_acp as chat_acp_module
+from kagan.cli.chat._approval_panel import (
+    _build_display_options,
+    _extract_key_args_preview,
+    _is_shell_command,
+    _strip_tool_prefix,
+    _tool_display_name,
+    build_approval_panel,
+)
+from kagan.cli.chat._chat_acp import (
+    _map_approval_result,
+    _run_legacy_input,
+    _session_approvals,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# _approval_panel helpers
+# ---------------------------------------------------------------------------
+
+
+def test_strip_tool_prefix_removes_mcp_kagan_prefix() -> None:
+    assert _strip_tool_prefix("mcp__kagan__task_get") == "task get"
+
+
+def test_strip_tool_prefix_removes_mcp_prefix() -> None:
+    assert _strip_tool_prefix("mcp__bash") == "bash"
+
+
+def test_strip_tool_prefix_leaves_plain_names_unchanged() -> None:
+    assert _strip_tool_prefix("read_file") == "read file"
+
+
+def test_tool_display_name_uses_title_attr() -> None:
+    class _FakeCall:
+        title = "mcp__kagan__run_get"
+        name = None
+
+    assert _tool_display_name(_FakeCall()) == "run get"
+
+
+def test_tool_display_name_falls_back_to_name_attr() -> None:
+    class _FakeCall:
+        title = None
+        name = "bash"
+
+    assert _tool_display_name(_FakeCall()) == "bash"
+
+
+def test_is_shell_command_detects_bash_keyword() -> None:
+    class _FakeCall:
+        title = "mcp__bash"
+        name = None
+
+    assert _is_shell_command(_FakeCall())
+
+
+def test_is_shell_command_false_for_non_shell() -> None:
+    class _FakeCall:
+        title = "task_get"
+        name = None
+
+    assert not _is_shell_command(_FakeCall())
+
+
+def test_extract_key_args_preview_returns_dict_lines() -> None:
+    import json
+
+    class _FakeCall:
+        title = None
+        name = None
+        raw_input = json.dumps({"command": "ls -la", "cwd": "/tmp"})
+        rawInput = None
+        arguments = None
+        args = None
+
+    result = _extract_key_args_preview(_FakeCall())
+    assert result is not None
+    assert "command" in result
+    assert "ls -la" in result
+
+
+def test_extract_key_args_preview_truncates_long_values() -> None:
+    import json
+
+    class _FakeCall:
+        title = None
+        name = None
+        raw_input = json.dumps({"long_key": "x" * 200})
+        rawInput = None
+        arguments = None
+        args = None
+
+    result = _extract_key_args_preview(_FakeCall())
+    assert result is not None
+    assert "..." in result
+
+
+def test_build_display_options_always_returns_four_slots() -> None:
+    class _Opt:
+        def __init__(self, kind: str) -> None:
+            self.kind = kind
+
+    options = [_Opt("allow_once"), _Opt("reject_once")]
+    result = _build_display_options(options)
+    assert len(result) == 4
+    assert result[3][0] == "Reject — tell the model what to do"
+
+
+def test_build_approval_panel_highlights_selected_index() -> None:
+    from rich.console import Console
+    import io
+
+    class _FakeCall:
+        title = "mcp__kagan__task_get"
+        name = None
+        raw_input = None
+        rawInput = None
+        arguments = None
+        args = None
+        agent_id = None
+        subagent_type = None
+        source_description = None
+
+    class _Opt:
+        def __init__(self, kind: str) -> None:
+            self.kind = kind
+
+    panel = build_approval_panel(
+        _FakeCall(),
+        options=[_Opt("allow_once"), _Opt("allow_always"), _Opt("reject_once")],
+        selected_index=1,
+        feedback_draft="",
+        queue_depth=1,
+        queue_position=1,
+    )
+
+    buf = io.StringIO()
+    console = Console(file=buf, highlight=False, width=80, no_color=True)
+    console.print(panel)
+    output = buf.getvalue()
+
+    # Selected index 1 should show arrow
+    assert "→ [2]" in output
+    # Non-selected should not have arrow prefix on first option
+    assert "  [1]" in output
+
+
+# ---------------------------------------------------------------------------
+# _map_approval_result logic
+# ---------------------------------------------------------------------------
+
+
+class _FakeOption:
+    def __init__(self, kind: str, option_id: str) -> None:
+        self.kind = kind
+        self.option_id = option_id
+
+
+def test_map_approval_result_allow_once_returns_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    opts = [
+        _FakeOption("allow_once", "allow-1"),
+        _FakeOption("allow_always", "allow-all"),
+        _FakeOption("reject_once", "deny-1"),
+    ]
+    result = _map_approval_result(0, "", action_key="test_tool", permission_options=opts)
+    assert result is not None
+    assert result.option_id == "allow-1"
+
+
+def test_map_approval_result_allow_always_grants_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_console = type("_FC", (), {"print": lambda *a, **kw: None})()
+    monkeypatch.setattr(chat_acp_module, "_console", fake_console)
+
+    opts = [
+        _FakeOption("allow_once", "allow-1"),
+        _FakeOption("allow_always", "allow-all"),
+    ]
+    result = _map_approval_result(1, "", action_key="my_tool", permission_options=opts)
+    assert result is not None
+    assert result.option_id == "allow-all"
+    assert _session_approvals.is_allowed("my_tool")
+    _session_approvals.revoke("my_tool")
+
+
+def test_map_approval_result_reject_once_returns_none() -> None:
+    opts = [_FakeOption("allow_once", "allow-1"), _FakeOption("reject_once", "deny-1")]
+    result = _map_approval_result(2, "", action_key="test_tool", permission_options=opts)
+    assert result is None
+
+
+def test_map_approval_result_reject_feedback_logs_and_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: list[str] = []
+    monkeypatch.setattr(
+        chat_acp_module.logger,
+        "info",
+        lambda msg, *args, **kw: logged.append(str(args[0]) if args else msg),
+    )
+    opts = [_FakeOption("allow_once", "allow-1")]
+    result = _map_approval_result(
+        3, "please use a different file", action_key="test_tool", permission_options=opts
+    )
+    assert result is None
+    assert any("please use a different file" in entry for entry in logged)
+
+
+# ---------------------------------------------------------------------------
+# _run_legacy_input fallback
+# ---------------------------------------------------------------------------
+
+
+def test_run_legacy_input_enter_confirms_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty Enter with no prior selection confirms index 0."""
+    inputs = iter([""])
+    monkeypatch.setattr("builtins.input", lambda: next(inputs))
+
+    class _FakeCall:
+        title = "mcp__task_get"
+        name = None
+        raw_input = None
+        rawInput = None
+        arguments = None
+        args = None
+        agent_id = None
+        subagent_type = None
+        source_description = None
+
+    class _Opt:
+        kind = "allow_once"
+
+    fake_console = type("_FC", (), {"print": lambda *a, **kw: None})()
+    monkeypatch.setattr(chat_acp_module, "_console", fake_console)
+
+    idx, fb = _run_legacy_input(
+        _FakeCall(),
+        permission_options=[_Opt()],
+        queue_position=1,
+        queue_depth=1,
+    )
+    assert idx == 0
+    assert fb == ""
+
+
+def test_run_legacy_input_number_selects_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    inputs = iter(["2"])
+    monkeypatch.setattr("builtins.input", lambda: next(inputs))
+
+    class _FakeCall:
+        title = "task"
+        name = None
+        raw_input = None
+        rawInput = None
+        arguments = None
+        args = None
+        agent_id = None
+        subagent_type = None
+        source_description = None
+
+    class _Opt:
+        kind = "allow_once"
+
+    fake_console = type("_FC", (), {"print": lambda *a, **kw: None})()
+    monkeypatch.setattr(chat_acp_module, "_console", fake_console)
+
+    idx, fb = _run_legacy_input(
+        _FakeCall(),
+        permission_options=[_Opt()],
+        queue_position=1,
+        queue_depth=1,
+    )
+    assert idx == 1
+
+
+def test_run_legacy_input_eof_defaults_to_reject(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise():
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise)
+
+    class _FakeCall:
+        title = "task"
+        name = None
+        raw_input = None
+        rawInput = None
+        arguments = None
+        args = None
+        agent_id = None
+        subagent_type = None
+        source_description = None
+
+    class _Opt:
+        kind = "allow_once"
+
+    fake_console = type("_FC", (), {"print": lambda *a, **kw: None})()
+    monkeypatch.setattr(chat_acp_module, "_console", fake_console)
+
+    idx, fb = _run_legacy_input(
+        _FakeCall(),
+        permission_options=[_Opt()],
+        queue_position=1,
+        queue_depth=1,
+    )
+    assert idx == 2  # reject
+
+
+# ---------------------------------------------------------------------------
+# _run_approval_panel_async — fallback to legacy on modal failure
+# ---------------------------------------------------------------------------
+
+
+async def test_run_approval_panel_falls_back_to_legacy_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the interactive modal raises, the legacy input() path is used."""
+
+    async def _fail(*_a: Any, **_kw: Any) -> tuple[int, str]:
+        raise RuntimeError("no terminal")
+
+    monkeypatch.setattr(chat_acp_module, "_run_interactive_modal", _fail)
+
+    inputs = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda: next(inputs))
+
+    class _FakeCall:
+        title = "test_tool"
+        name = None
+        raw_input = None
+        rawInput = None
+        arguments = None
+        args = None
+        agent_id = None
+        subagent_type = None
+        source_description = None
+
+    class _Opt:
+        kind = "allow_once"
+
+    fake_console = type("_FC", (), {"print": lambda *a, **kw: None})()
+    monkeypatch.setattr(chat_acp_module, "_console", fake_console)
+
+    idx, fb = await chat_acp_module._run_approval_panel_async(
+        _FakeCall(),
+        permission_options=[_Opt()],
+        queue_position=1,
+        queue_depth=1,
+    )
+    assert idx == 0
+    assert fb == ""

--- a/tests/unit/test_chat_batched_approvals.py
+++ b/tests/unit/test_chat_batched_approvals.py
@@ -1,0 +1,396 @@
+"""Unit tests for batched approval queue in kg chat.
+
+All tests are pure-unit: no real terminal, no prompt_toolkit Application
+launched.  ``_run_approval_panel_async`` and ``_run_batch_modal_async`` are
+monkeypatched to simulate user responses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from acp.schema import PermissionOption, ToolCallStart
+
+import kagan.cli.chat._approval_batch as batch_module
+import kagan.cli.chat._chat_acp as chat_acp_module
+import kagan.cli.chat.controller as chat_controller
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_call(title: str = "task_get") -> ToolCallStart:
+    return ToolCallStart(title=title, tool_call_id=f"tc-{title}", session_update="tool_call")
+
+
+def _make_options() -> list[PermissionOption]:
+    return [
+        PermissionOption(kind="allow_once", name="Allow once", option_id="allow-1"),
+        PermissionOption(kind="allow_always", name="Allow always", option_id="allow-all"),
+        PermissionOption(kind="reject_once", name="Reject", option_id="deny-1"),
+    ]
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def print(self, *args: object, **kwargs: object) -> None:
+        self.calls.append((args, kwargs))
+
+
+def _make_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    yolo: bool = False,
+) -> chat_controller._OrchestratorACPClient:
+    """Build an _OrchestratorACPClient with console patched."""
+    fake_console = _FakeConsole()
+    monkeypatch.setattr(chat_acp_module, "_console", fake_console)
+    monkeypatch.setattr(chat_acp_module, "_stdio_is_interactive", lambda: True)
+    client = chat_controller._OrchestratorACPClient(yolo=yolo)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# test_single_approval_unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_single_approval_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """N=1: existing single-approval panel is used; batch panel is never rendered."""
+    client = _make_client(monkeypatch)
+    # Patch _run_approval_panel_async to return allow_once (index 0)
+    async def _fake_single(*_a: Any, **_kw: Any) -> tuple[int, str]:
+        return (0, "")
+
+    monkeypatch.setattr(chat_acp_module, "_run_approval_panel_async", _fake_single)
+    # Ensure batch modal is NOT called
+    batch_called: list[bool] = []
+
+    async def _fake_batch(*_a: Any, **_kw: Any) -> None:
+        batch_called.append(True)
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+
+    # Override debounce to fire immediately
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.0)
+
+    opts = _make_options()
+    tool = _make_tool_call("read_file")
+
+    response = await client.request_permission(opts, "session-1", tool)
+
+    assert response.outcome.outcome == "selected"
+    assert response.outcome.option_id == "allow-1"
+    assert batch_called == [], "batch modal must not be invoked for N=1"
+
+
+# ---------------------------------------------------------------------------
+# test_batch_debounce_groups_concurrent_calls
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_debounce_groups_concurrent_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """5 concurrent calls within the debounce window → one combined panel, all resolved."""
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.005)
+
+    panel_render_count: list[int] = [0]
+
+    async def _fake_batch(
+        items: Any,
+        *,
+        _resolve_item: Any,
+        _resolve_all: Any,
+        _reject_all: Any,
+    ) -> None:
+        panel_render_count[0] += 1
+        # Approve all remaining (simulate option 5)
+        _resolve_all("allow_once")
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+    # Also patch run_in_terminal to be a no-op so we don't need a real event loop
+    monkeypatch.setattr(batch_module, "run_in_terminal", lambda fn: fn() if callable(fn) else None)  # type: ignore[attr-defined]
+
+    opts = _make_options()
+    tools = [_make_tool_call(f"tool_{i}") for i in range(5)]
+
+    # Fire all 5 concurrently — they should all land in the same debounce window
+    responses = await asyncio.gather(
+        *[client.request_permission(opts, "session-1", t) for t in tools]
+    )
+
+    assert panel_render_count[0] == 1, "batch panel must render exactly once"
+    assert len(responses) == 5
+    for r in responses:
+        assert r.outcome.outcome == "selected"
+
+
+# ---------------------------------------------------------------------------
+# test_batch_approve_all_option (option 5 / digit 5)
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_approve_all_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting option 5 resolves all pending items as allow_once."""
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.005)
+
+    async def _fake_batch(
+        items: Any,
+        *,
+        _resolve_item: Any,
+        _resolve_all: Any,
+        _reject_all: Any,
+    ) -> None:
+        _resolve_all("allow_once")
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+    monkeypatch.setattr(batch_module, "run_in_terminal", lambda fn: fn() if callable(fn) else None)  # type: ignore[attr-defined]
+
+    opts = _make_options()
+    tools = [_make_tool_call(f"bulk_{i}") for i in range(3)]
+
+    responses = await asyncio.gather(
+        *[client.request_permission(opts, "session-1", t) for t in tools]
+    )
+
+    assert len(responses) == 3
+    for r in responses:
+        assert r.outcome.outcome == "selected"
+        assert r.outcome.option_id == "allow-1"
+
+
+# ---------------------------------------------------------------------------
+# test_batch_deny_all_option (option 6 / digit 6)
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_deny_all_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Selecting option 6 resolves all pending items as reject_once (cancelled)."""
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.005)
+
+    async def _fake_batch(
+        items: Any,
+        *,
+        _resolve_item: Any,
+        _resolve_all: Any,
+        _reject_all: Any,
+    ) -> None:
+        _reject_all()
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+    monkeypatch.setattr(batch_module, "run_in_terminal", lambda fn: fn() if callable(fn) else None)  # type: ignore[attr-defined]
+
+    opts = _make_options()
+    tools = [_make_tool_call(f"deny_{i}") for i in range(3)]
+
+    responses = await asyncio.gather(
+        *[client.request_permission(opts, "session-1", t) for t in tools]
+    )
+
+    assert len(responses) == 3
+    for r in responses:
+        assert r.outcome.outcome == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# test_batch_does_not_group_sequential_calls
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_does_not_group_sequential_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two calls >debounce apart → two separate panel renders."""
+    client = _make_client(monkeypatch)
+    # Debounce is 20 ms; we'll sleep 30 ms between calls
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.020)
+
+    panel_render_count: list[int] = [0]
+
+    async def _fake_batch(
+        items: Any,
+        *,
+        _resolve_item: Any,
+        _resolve_all: Any,
+        _reject_all: Any,
+    ) -> None:
+        panel_render_count[0] += 1
+        _resolve_all("allow_once")
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+
+    async def _fake_single_panel(*_a: Any, **_kw: Any) -> tuple[int, str]:
+        return (0, "")
+
+    monkeypatch.setattr(chat_acp_module, "_run_approval_panel_async", _fake_single_panel)
+    monkeypatch.setattr(batch_module, "run_in_terminal", lambda fn: fn() if callable(fn) else None)  # type: ignore[attr-defined]
+
+    opts = _make_options()
+
+    # First call — arms debounce, flushes after 20 ms
+    r1 = asyncio.create_task(client.request_permission(opts, "s-1", _make_tool_call("seq_1")))
+    await asyncio.sleep(0.040)  # wait for first debounce to expire
+    assert r1.done(), "first call must have resolved"
+
+    # Second call — new debounce window
+    r2 = asyncio.create_task(client.request_permission(opts, "s-1", _make_tool_call("seq_2")))
+    await asyncio.sleep(0.040)
+
+    await r1
+    await r2
+
+    # N=1 for each → single-approval path; batch modal not called
+    # (but single-approval path is used via _flush_single → _run_approval_panel_async)
+    assert panel_render_count[0] == 0, "batch panel must not fire for N=1 debounce windows"
+
+
+# ---------------------------------------------------------------------------
+# test_yolo_bypasses_batch
+# ---------------------------------------------------------------------------
+
+
+async def test_yolo_bypasses_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--yolo flag: auto-approves immediately, no batch queue involved."""
+    client = _make_client(monkeypatch, yolo=True)
+
+    batch_enqueue_called: list[bool] = []
+    original_enqueue = client._batch_queue.enqueue
+
+    async def _spy_enqueue(*args: Any, **kwargs: Any) -> Any:
+        batch_enqueue_called.append(True)
+        return await original_enqueue(*args, **kwargs)
+
+    client._batch_queue.enqueue = _spy_enqueue  # type: ignore[method-assign]
+
+    opts = _make_options()
+    tool = _make_tool_call("yolo_tool")
+
+    response = await client.request_permission(opts, "session-1", tool)
+
+    assert response.outcome.outcome == "selected"
+    assert batch_enqueue_called == [], "batch queue must not be invoked in --yolo mode"
+
+
+# ---------------------------------------------------------------------------
+# test_batch_feedback_option_on_focused_item
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_feedback_option_on_focused_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deny+feedback on item 1 of 3; items 0 and 2 get approved."""
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.005)
+
+    async def _fake_batch(
+        items: Any,
+        *,
+        _resolve_item: Any,
+        _resolve_all: Any,
+        _reject_all: Any,
+    ) -> None:
+        # item 0: approve once (option 0)
+        _resolve_item(0, 0, "")
+        # item 1: reject+feedback (option 3)
+        _resolve_item(1, 3, "use a safer approach")
+        # item 2: approve once (option 0)
+        _resolve_item(2, 0, "")
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+    monkeypatch.setattr(batch_module, "run_in_terminal", lambda fn: fn() if callable(fn) else None)  # type: ignore[attr-defined]
+
+    opts = _make_options()
+    tools = [_make_tool_call(f"fb_tool_{i}") for i in range(3)]
+
+    responses = await asyncio.gather(
+        *[client.request_permission(opts, "session-1", t) for t in tools]
+    )
+
+    assert len(responses) == 3
+    # item 0: allowed
+    assert responses[0].outcome.outcome == "selected"
+    # item 1: rejected (feedback path returns None → cancelled)
+    assert responses[1].outcome.outcome == "cancelled"
+    # item 2: allowed
+    assert responses[2].outcome.outcome == "selected"
+
+
+# ---------------------------------------------------------------------------
+# test_tab_moves_between_items
+# ---------------------------------------------------------------------------
+
+
+async def test_tab_moves_between_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify Tab/Shift-Tab item navigation doesn't break resolution.
+
+    We simulate a user who Tabs to item 1 then approves both items.
+    """
+    client = _make_client(monkeypatch)
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 0.005)
+
+    # We simulate a user who resolves item 1 first (via Tab) then item 0
+    async def _fake_batch(
+        items: Any,
+        *,
+        _resolve_item: Any,
+        _resolve_all: Any,
+        _reject_all: Any,
+    ) -> None:
+        # Tab moved focus to item 1 first
+        _resolve_item(1, 0, "")  # approve
+        _resolve_item(0, 0, "")  # approve
+
+    monkeypatch.setattr(batch_module, "_run_batch_modal_async", _fake_batch)
+    monkeypatch.setattr(batch_module, "run_in_terminal", lambda fn: fn() if callable(fn) else None)  # type: ignore[attr-defined]
+
+    opts = _make_options()
+    tools = [_make_tool_call("tab_tool_a"), _make_tool_call("tab_tool_b")]
+
+    responses = await asyncio.gather(
+        *[client.request_permission(opts, "session-1", t) for t in tools]
+    )
+
+    assert len(responses) == 2
+    for r in responses:
+        assert r.outcome.outcome == "selected"
+
+
+# ---------------------------------------------------------------------------
+# test_sigint_cancels_pending_futures
+# ---------------------------------------------------------------------------
+
+
+async def test_sigint_cancels_pending_futures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cancel_all() resolves all pending Futures as cancelled without hang."""
+    client = _make_client(monkeypatch)
+    # Set a long debounce so items stay pending when we call cancel_all
+    monkeypatch.setattr(batch_module, "_debounce_seconds", lambda: 10.0)
+
+    opts = _make_options()
+    # Enqueue items but don't await the futures yet
+    fut1 = await client._batch_queue.enqueue(opts, _make_tool_call("sigint_tool_1"))
+    fut2 = await client._batch_queue.enqueue(opts, _make_tool_call("sigint_tool_2"))
+
+    assert not fut1.done()
+    assert not fut2.done()
+
+    # Simulate SIGINT
+    client.cancel_batch_queue()
+
+    assert fut1.done()
+    assert fut2.done()
+    assert fut1.result().outcome.outcome == "cancelled"
+    assert fut2.result().outcome.outcome == "cancelled"

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -158,6 +158,7 @@ def test_slash_command_registry_is_canonical() -> None:
     assert names == [
         "agents",
         "analytics",
+        "approvals",
         "clear",
         "delete",
         "exit",

--- a/tests/unit/test_chat_controller_streaming.py
+++ b/tests/unit/test_chat_controller_streaming.py
@@ -175,7 +175,12 @@ async def test_permission_request_selects_interactive_allow_option(
     fake_console = _FakeConsole()
     monkeypatch.setattr(chat_acp_module, "_console", fake_console)
     monkeypatch.setattr(chat_acp_module, "_stdio_is_interactive", lambda: True)
-    monkeypatch.setattr("builtins.input", lambda _prompt: "2")
+    # Mock the async panel to return index 1 = allow_always without launching a real terminal.
+    async def _fake_panel(*_a, **_kw):  # noqa: RUF006
+        return (1, "")
+    monkeypatch.setattr(chat_acp_module, "_run_approval_panel_async", _fake_panel)
+    # Ensure no residual session approval bleeds into this test.
+    chat_acp_module._session_approvals.revoke("run command")
 
     client = chat_controller._OrchestratorACPClient()
     response = await client.request_permission(
@@ -202,7 +207,12 @@ async def test_permission_request_can_select_deny_option_from_acp_options(
     fake_console = _FakeConsole()
     monkeypatch.setattr(chat_acp_module, "_console", fake_console)
     monkeypatch.setattr(chat_acp_module, "_stdio_is_interactive", lambda: True)
-    monkeypatch.setattr("builtins.input", lambda _prompt: "deny")
+    # Mock the async panel to return index 2 = reject_once.
+    async def _fake_panel(*_a, **_kw):  # noqa: RUF006
+        return (2, "")
+    monkeypatch.setattr(chat_acp_module, "_run_approval_panel_async", _fake_panel)
+    # Clear any session-level grant that may bleed from allow_always tests.
+    chat_acp_module._session_approvals.revoke("run command")
 
     client = chat_controller._OrchestratorACPClient()
     response = await client.request_permission(
@@ -218,5 +228,4 @@ async def test_permission_request_can_select_deny_option_from_acp_options(
         ),
     )
 
-    assert response.outcome.outcome == "selected"
-    assert response.outcome.option_id == "deny-1"
+    assert response.outcome.outcome == "cancelled"


### PR DESCRIPTION
## Summary

Polish the `kg chat` REPL based on a UX critique vs `references/kimi-cli`. Four commits:

1. **`eadf7136`** — Rich `Panel` approval prompt with arrow-key navigation, syntax-highlighted previews, 4 options (Approve once / for session / Reject / Reject + tell the model with inline feedback), queue-depth indicator, Esc/Ctrl-C cancel, Ctrl-E pager. New `_approval_panel.py` module + 19 unit tests. Fallback to legacy `input()` for dumb TTYs.
2. **`949a4055`** — Tooling around the panel: `/approvals` slash command (list + revoke session scopes), bottom toolbar shows pending approvals / current tool / token usage.
3. **`7a95c315`** — Ctrl-E pager fix: swap `asyncio.to_thread` for `await run_in_terminal(...)` so the pager cleanly suspends and resumes the modal.
4. **`82ed909c`** — Batched approval panel for concurrent tool calls. Client-side 100 ms debounce (env: `KAGAN_BATCH_APPROVAL_DEBOUNCE_MS`) collects N concurrent `request_permission` calls into a single combined panel. Same arrow-key input model as the single panel; bulk actions are options 5 (approve all) and 6 (reject all) — no dedicated single-letter hotkeys, kept consistent with future TUI/web/VS Code surfaces. New `_approval_batch.py` (604 LOC) + 9 unit tests. N=1 path is byte-for-byte the existing single-panel flow.

Also lands inside the panel rewrite of `_chat_acp.py`:
- Output interleaving fix via `prompt_toolkit.run_in_terminal`
- Markdown post-render so `|`-tables render as Rich tables
- Grouped tool display (`task_delete × 9 — done 7/9 · 6.7s`) instead of N orphan lines
- Braille spinner replacing the `ᘛᘛᘛᘚ` mojibake; ASCII fallback under `NO_COLOR`/`TERM=dumb`

## Test plan

- [x] `uv run poe lint`
- [x] `uv run poe check-guardrails` (LOC, complexity, wire drift, test quality)
- [x] `uv run pytest tests/unit/test_chat_commands.py tests/unit/test_chat_approval_panel.py tests/unit/test_chat_controller_streaming.py tests/unit/test_chat_batched_approvals.py` — 74 passed
- [ ] Manual: `kg chat`, trigger 2+ approvals, navigate with arrows, exercise option 4 (feedback), Esc-cancel, Ctrl-E pager, run `/approvals` and `/approvals revoke <name>`, trigger N≥2 concurrent approvals to exercise the batch panel.

## Known limitations

- ACP delivers approvals serially; this PR debounces client-side. A protocol-level `request_permission_batch` is tracked as a future upstream proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)