### PR TITLE
style: apply formatter pass across chat/server/core/tui/tests

### DIFF
--- a/src/kagan/cli/chat/acp.py
+++ b/src/kagan/cli/chat/acp.py
@@ -67,11 +67,7 @@ _friendly_acp_error_message = friendly_acp_error_message
 
 def _is_mcp_server_unsupported_error(error: object) -> bool:
     raw = str(error).lower()
-    return (
-        "mcp" in raw
-        and "server" in raw
-        and ("not implemented" in raw or "unsupported" in raw)
-    )
+    return "mcp" in raw and "server" in raw and ("not implemented" in raw or "unsupported" in raw)
 
 
 async def _new_session_with_mcp_fallback(

--- a/src/kagan/cli/chat/sessions.py
+++ b/src/kagan/cli/chat/sessions.py
@@ -103,9 +103,7 @@ def _session_to_dict(row: ChatSession, messages: list[ChatMessage]) -> dict[str,
     """Convert a ChatSession ORM row + messages list to the legacy dict shape."""
     history = [[m.role, m.content] for m in messages]
     updated_at = (
-        row.updated_at.isoformat()
-        if isinstance(row.updated_at, datetime)
-        else str(row.updated_at)
+        row.updated_at.isoformat() if isinstance(row.updated_at, datetime) else str(row.updated_at)
     )
     return {
         "id": row.id,
@@ -147,13 +145,11 @@ async def list_chat_sessions(
             sessions = db.exec(stmt).all()
             result: list[dict[str, Any]] = []
             for row in sessions:
-                msgs = (
-                    db.exec(
-                        select(ChatMessage)
-                        .where(ChatMessage.session_id == row.id)  # type: ignore[arg-type]
-                        .order_by(ChatMessage.id)  # type: ignore[attr-defined]
-                    ).all()
-                )
+                msgs = db.exec(
+                    select(ChatMessage)
+                    .where(ChatMessage.session_id == row.id)  # type: ignore[arg-type]
+                    .order_by(ChatMessage.id)  # type: ignore[attr-defined]
+                ).all()
                 result.append(_session_to_dict(row, list(msgs)))
             return result
 
@@ -280,7 +276,7 @@ async def save_chat_session(client: Any, session: dict[str, Any]) -> None:
         project_id = None
 
     history: list[list[str]] = []
-    for pair in (session.get("orchestrator_history") or []):
+    for pair in session.get("orchestrator_history") or []:
         if isinstance(pair, (list, tuple)) and len(pair) == 2:
             role = str(pair[0]).strip()
             content = str(pair[1]).strip()

--- a/src/kagan/core/_reviews.py
+++ b/src/kagan/core/_reviews.py
@@ -440,8 +440,13 @@ def _make_reviews_ns(engine: Engine, client: "KaganCore") -> Any:
         session_id: str | None = None,
     ) -> Task:
         return await set_criterion_verdict(
-            engine, task_id, criterion_index, verdict, reason,
-            client=client, session_id=session_id,
+            engine,
+            task_id,
+            criterion_index,
+            verdict,
+            reason,
+            client=client,
+            session_id=session_id,
         )
 
     async def _clear_verdicts(task_id: str) -> Task:

--- a/src/kagan/core/_tasks.py
+++ b/src/kagan/core/_tasks.py
@@ -210,9 +210,7 @@ class Tasks:
         # Try the specified repo_id first, then all project repos
         repos_to_try = []
         if repo_id is not None:
-            repo = await _db_async(
-                self._engine, lambda s: s.get(Repository, repo_id)
-            )
+            repo = await _db_async(self._engine, lambda s: s.get(Repository, repo_id))
             if repo:
                 repos_to_try.append(repo)
 
@@ -340,9 +338,7 @@ class Tasks:
 
                 await _push_task_change(self._client, task, fields=fields)  # type: ignore[arg-type]
             except Exception as exc:
-                logger.warning(
-                    "GitHub push fire-and-forget failed for task {}: {}", task.id, exc
-                )
+                logger.warning("GitHub push fire-and-forget failed for task {}: {}", task.id, exc)
 
         try:
             loop = asyncio.get_running_loop()
@@ -707,10 +703,9 @@ class Tasks:
         def _search_with_criteria(s) -> builtins.list[Task]:
             tasks = list(s.exec(stmt).all())
             matched = [
-                t for t in tasks
-                if q in t.title.lower()
-                or q in t.id[:8].lower()
-                or q in t.description.lower()
+                t
+                for t in tasks
+                if q in t.title.lower() or q in t.id[:8].lower() or q in t.description.lower()
             ][:limit]
             for t in matched:
                 _ = list(t.criteria)

--- a/src/kagan/core/integrations/mentions.py
+++ b/src/kagan/core/integrations/mentions.py
@@ -26,7 +26,7 @@ class Mention:
     """A single mention result from the dual-source typeahead backend."""
 
     source: Literal["kagan", "github"]
-    id: str          # insert form: "kagan#abc12345" or "#42"
+    id: str  # insert form: "kagan#abc12345" or "#42"
     title: str
     state: str | None = None  # task status for kagan, issue state for github
 
@@ -85,8 +85,8 @@ async def search_mentions(
         merged.append(k)
         merged.append(g)
 
-    remaining_k = scored_kagan[len(scored_github):]
-    remaining_g = scored_github[len(scored_kagan):]
+    remaining_k = scored_kagan[len(scored_github) :]
+    remaining_g = scored_github[len(scored_kagan) :]
     merged.extend(remaining_k)
     merged.extend(remaining_g)
 

--- a/src/kagan/core/models.py
+++ b/src/kagan/core/models.py
@@ -211,9 +211,7 @@ class AuditEntry(SQLModel, table=True):
 
 class ChatSession(SQLModel, table=True):
     __tablename__ = "chat_sessions"  # type: ignore[assignment]
-    __table_args__ = (
-        Index("ix_chat_sessions_project_id_updated_at", "project_id", "updated_at"),
-    )
+    __table_args__ = (Index("ix_chat_sessions_project_id_updated_at", "project_id", "updated_at"),)
 
     id: str = Field(default_factory=_new_id, primary_key=True)
     label: str
@@ -235,9 +233,7 @@ class ChatSession(SQLModel, table=True):
 
 class ChatMessage(SQLModel, table=True):
     __tablename__ = "chat_messages"  # type: ignore[assignment]
-    __table_args__ = (
-        Index("ix_chat_messages_session_id_id", "session_id", "id"),
-    )
+    __table_args__ = (Index("ix_chat_messages_session_id_id", "session_id", "id"),)
 
     id: int | None = Field(default=None, primary_key=True)  # autoincrement
     session_id: str = Field(foreign_key="chat_sessions.id", index=True)

--- a/src/kagan/server/_access.py
+++ b/src/kagan/server/_access.py
@@ -35,5 +35,3 @@ def http_forbidden(*, operation: str, minimum_tier: AccessTier) -> JSONResponse:
     ).model_dump()
     payload["error_code"] = "ACCESS_TIER_FORBIDDEN"
     return JSONResponse(payload, status_code=403)
-
-

--- a/src/kagan/server/_chat_routes.py
+++ b/src/kagan/server/_chat_routes.py
@@ -102,9 +102,7 @@ async def _claim_turn_slot(
             return _err("Session not found", status=404)
         settings = await client.settings.get()
         backend = (
-            agent_backend
-            or session.get("agent_backend")
-            or resolve_default_agent_backend(settings)
+            agent_backend or session.get("agent_backend") or resolve_default_agent_backend(settings)
         )
         return (session, backend)
     except BaseException:

--- a/src/kagan/server/_integration_routes.py
+++ b/src/kagan/server/_integration_routes.py
@@ -76,14 +76,7 @@ def register_integration_routes(mcp: FastMCP) -> None:
         from kagan.core.integrations import all_enabled
 
         integrations = all_enabled()
-        return _ok(
-            {
-                "integrations": [
-                    {"id": i.id, "name": i.id}
-                    for i in integrations
-                ]
-            }
-        )
+        return _ok({"integrations": [{"id": i.id, "name": i.id} for i in integrations]})
 
     @mcp.custom_route("/api/integrations/{id}/preflight", methods=["GET"])
     @require_context(mcp)
@@ -166,9 +159,7 @@ def register_integration_routes(mcp: FastMCP) -> None:
             return _err(f"Integration {integration_id!r} not found", status=404)
 
         if integration_id != "github":
-            return _err(
-                f"Integration {integration_id!r} does not support preview", status=400
-            )
+            return _err(f"Integration {integration_id!r} does not support preview", status=400)
 
         project_id = ctx.client.active_project_id
         if not project_id:
@@ -238,9 +229,7 @@ def register_integration_routes(mcp: FastMCP) -> None:
             state = normalize_github_state(str(body.get("state", "open")))
             labels_raw = body.get("labels")
             labels = (
-                tuple(str(s).strip() for s in labels_raw)
-                if isinstance(labels_raw, list)
-                else ()
+                tuple(str(s).strip() for s in labels_raw) if isinstance(labels_raw, list) else ()
             )
             limit = min(max(int(body.get("limit", 100)), 1), 500)
             issue_numbers_raw = body.get("issue_numbers")

--- a/src/kagan/server/_task_routes.py
+++ b/src/kagan/server/_task_routes.py
@@ -414,10 +414,7 @@ def register_task_routes(mcp: FastMCP) -> None:
         task_id = cast("str", request.path_params["task_id"])
         sessions = await ctx.client.tasks.sessions.list_for_task(task_id)
         return _ok(
-            [
-                TaskSessionResponse.model_validate(s).model_dump(mode="json")
-                for s in sessions
-            ]
+            [TaskSessionResponse.model_validate(s).model_dump(mode="json") for s in sessions]
         )
 
     @mcp.custom_route("/api/tasks/{task_id}/review", methods=["GET"])

--- a/src/kagan/server/responses.py
+++ b/src/kagan/server/responses.py
@@ -391,7 +391,7 @@ class MentionResponse(BaseModel):
     """A single result from the dual-source mention autocomplete endpoint."""
 
     source: str  # "kagan" or "github"
-    id: str      # insert form: "kagan#<short_id>" or "#<number>"
+    id: str  # insert form: "kagan#<short_id>" or "#<number>"
     title: str
     state: str | None = None
 

--- a/src/kagan/tui/screens/github_import_modal.py
+++ b/src/kagan/tui/screens/github_import_modal.py
@@ -304,8 +304,7 @@ class GitHubImportModal(ModalScreen[GitHubImportSummary | None]):
         count = len(issues)
         selected_count = sum(not issue.already_synced for issue in issues)
         self._set_status(
-            f"{count} issue{'s' if count != 1 else ''} found. "
-            f"{selected_count} selected for import."
+            f"{count} issue{'s' if count != 1 else ''} found. {selected_count} selected for import."
         )
 
     async def _do_import(self) -> None:

--- a/src/kagan/tui/screens/kanban_commands.py
+++ b/src/kagan/tui/screens/kanban_commands.py
@@ -23,9 +23,7 @@ KANBAN_COMMANDS: tuple[KanbanCommandSpec, ...] = (
     KanbanCommandSpec(
         "task.details", "View selected task details", "open_session", requires_task=True
     ),
-    KanbanCommandSpec(
-        "task.delete", "Delete selected task", "delete_task", requires_task=True
-    ),
+    KanbanCommandSpec("task.delete", "Delete selected task", "delete_task", requires_task=True),
     KanbanCommandSpec(
         "task.duplicate", "Duplicate selected task", "duplicate_task", requires_task=True
     ),

--- a/src/kagan/tui/screens/session_resume_modal.py
+++ b/src/kagan/tui/screens/session_resume_modal.py
@@ -113,9 +113,7 @@ class SessionResumeModal(ModalScreen[RecentSessionSelection | None]):
     ) -> str:
         backend = f" · {agent_backend}" if agent_backend else ""
         updated = f" · {updated_relative}" if updated_relative else ""
-        source_badge = (
-            f" [$secondary][{source}][/]" if source else ""
-        )
+        source_badge = f" [$secondary][{source}][/]" if source else ""
         return f"{project_name} · {session_label}{backend}{updated}{source_badge}"
 
     def _selected_session(self) -> RecentSessionSelection | None:

--- a/src/kagan/tui/widgets/_mention_typeahead.py
+++ b/src/kagan/tui/widgets/_mention_typeahead.py
@@ -125,8 +125,8 @@ class MentionTypeahead(Vertical):
         self._project_id = project_id
         self._client = client
         self._debounce_seconds = debounce_seconds
-        self._active = False          # True while user has typed a ``#``
-        self._hash_position: int = -1 # cursor index just after ``#``
+        self._active = False  # True while user has typed a ``#``
+        self._hash_position: int = -1  # cursor index just after ``#``
         self._current_query = ""
         self._results: list[Mention] = []
         self._debounce_task: asyncio.Task[None] | None = None
@@ -163,7 +163,7 @@ class MentionTypeahead(Vertical):
             self._deactivate()
             return
 
-        query = text[self._hash_position + 1:cursor_position]
+        query = text[self._hash_position + 1 : cursor_position]
         # If there's whitespace in the query the ``#``-mention span ended
         if " " in query or "\n" in query:
             self._deactivate()
@@ -237,9 +237,7 @@ class MentionTypeahead(Vertical):
         option_list = self.query_one(f"#mention-list-{self._host_id}", OptionList)
         option_list.clear_options()
         for mention in self._results:
-            option_list.add_option(
-                Option(_render_mention_option(mention), id=mention.id)
-            )
+            option_list.add_option(Option(_render_mention_option(mention), id=mention.id))
         if self._results:
             option_list.highlighted = 0
             self.display = True

--- a/src/kagan/tui/widgets/chat.py
+++ b/src/kagan/tui/widgets/chat.py
@@ -338,9 +338,7 @@ class ChatPanel(Vertical):
         with contextlib.suppress(NoMatches):
             self.query_one("#chat-overlay-session-select", Select).disabled = True
         with contextlib.suppress(NoMatches):
-            self.query_one("#chat-overlay-empty-heading", Static).update(
-                self._DOCKED_EMPTY_HEADING
-            )
+            self.query_one("#chat-overlay-empty-heading", Static).update(self._DOCKED_EMPTY_HEADING)
         self._sync_input_enabled_state()
         self._render_current_session()
         self._refresh_status()

--- a/tests/core/test_projects_and_repos.py
+++ b/tests/core/test_projects_and_repos.py
@@ -185,9 +185,7 @@ async def test_inspect_project_folder_resolves_git_root_and_existing_project(
     assert resolution.existing_repo_id == repo_id
 
 
-async def test_inspect_project_folder_describes_empty_folder(
-    board: KaganDriver, tmp_path
-) -> None:
+async def test_inspect_project_folder_describes_empty_folder(board: KaganDriver, tmp_path) -> None:
     folder = tmp_path / "empty-folder"
     folder.mkdir()
 

--- a/tests/integrations/test_mentions.py
+++ b/tests/integrations/test_mentions.py
@@ -78,9 +78,7 @@ async def test_mentions_merges_kagan_and_github_results(client) -> None:
     await client.tasks.create("Auth task")
     project_id = client.active_project_id
 
-    github_results = [
-        Mention(source="github", id="#5", title="Auth GitHub issue", state="open")
-    ]
+    github_results = [Mention(source="github", id="#5", title="Auth GitHub issue", state="open")]
     with patch(
         "kagan.core.integrations.mentions._fetch_github_mentions",
         new_callable=AsyncMock,
@@ -99,8 +97,7 @@ async def test_mentions_returns_at_most_limit(client) -> None:
         await client.tasks.create(f"Task {i} matching query")
 
     github_results = [
-        Mention(source="github", id=f"#{i}", title=f"Issue {i}", state="open")
-        for i in range(8)
+        Mention(source="github", id=f"#{i}", title=f"Issue {i}", state="open") for i in range(8)
     ]
     project_id = client.active_project_id
     with patch(

--- a/tests/server/test_analytics_routes.py
+++ b/tests/server/test_analytics_routes.py
@@ -21,9 +21,7 @@ class _FakeAnalytics:
         self.calls.append(("backend_stats", project_id, days))
         return [{"agent_backend": "alpha", "count": 1}]
 
-    async def session_timeline(
-        self, project_id: str, days: int = 30
-    ) -> list[dict[str, Any]]:
+    async def session_timeline(self, project_id: str, days: int = 30) -> list[dict[str, Any]]:
         self.calls.append(("session_timeline", project_id, days))
         return [{"date": "2026-04-28", "total": 1}]
 

--- a/tests/tui/test_chat_turn_interrupted.py
+++ b/tests/tui/test_chat_turn_interrupted.py
@@ -221,8 +221,7 @@ async def test_watch_chat_session_notifies_on_takeover() -> None:
             pass
 
         assert any(
-            "taken over" in msg.lower() or "interrupted" in msg.lower()
-            for msg in app.notifications
+            "taken over" in msg.lower() or "interrupted" in msg.lower() for msg in app.notifications
         ), f"Expected takeover notification, got: {app.notifications}"
 
 

--- a/tests/tui/test_task_editor_github_issue.py
+++ b/tests/tui/test_task_editor_github_issue.py
@@ -1,6 +1,5 @@
 """Tests for the github_issue field on the TaskEditor widget."""
 
-
 import pytest
 from tests.helpers.driver import KaganDriver
 from textual.widgets import Input

--- a/tests/unit/core/test_chat_blob_migration.py
+++ b/tests/unit/core/test_chat_blob_migration.py
@@ -96,9 +96,7 @@ def test_migration_drops_legacy_blob_not_migrates(tmp_path: Path) -> None:
     conn = sqlite3.connect(db_path)
     try:
         # Legacy setting must be gone
-        row = conn.execute(
-            "SELECT value FROM settings WHERE key = ?", (_SETTINGS_KEY,)
-        ).fetchone()
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", (_SETTINGS_KEY,)).fetchone()
         assert row is None, "chat_sessions_v1 must be deleted by migration"
 
         # New tables exist but contain no rows (data NOT migrated)
@@ -119,9 +117,7 @@ def test_migration_creates_tables_on_fresh_db(tmp_path: Path) -> None:
     try:
         tables = {
             row[0]
-            for row in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
         }
         assert "chat_sessions" in tables
         assert "chat_messages" in tables

--- a/tests/unit/core/test_chat_migration_crash_safety.py
+++ b/tests/unit/core/test_chat_migration_crash_safety.py
@@ -64,9 +64,7 @@ def test_migration_runs_on_fresh_db(tmp_path: Path) -> None:
     try:
         tables = {
             row[0]
-            for row in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
         }
         assert "chat_sessions" in tables
         assert "chat_messages" in tables
@@ -116,9 +114,7 @@ def test_migration_runs_when_chat_sessions_v1_setting_exists(tmp_path: Path) -> 
     try:
         tables = {
             row[0]
-            for row in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
         }
         assert "chat_sessions" in tables
         assert "chat_messages" in tables

--- a/tests/unit/core/test_chat_schema.py
+++ b/tests/unit/core/test_chat_schema.py
@@ -64,10 +64,7 @@ def test_session_indexes_support_recency_listing(tmp_path: Path) -> None:
     db_path = _make_db(tmp_path)
     conn = sqlite3.connect(db_path)
     try:
-        indexes = {
-            row[1]
-            for row in conn.execute("PRAGMA index_list(chat_sessions)").fetchall()
-        }
+        indexes = {row[1] for row in conn.execute("PRAGMA index_list(chat_sessions)").fetchall()}
         # SQLModel create_all creates individual indexes from Field(index=True)
         # The migration additionally creates a composite index; on fresh DBs only
         # the individual ones exist.
@@ -75,8 +72,7 @@ def test_session_indexes_support_recency_listing(tmp_path: Path) -> None:
         assert "ix_chat_sessions_updated_at" in indexes
         # Check the session_id cursor index on messages exists
         msg_indexes = {
-            row[1]
-            for row in conn.execute("PRAGMA index_list(chat_messages)").fetchall()
+            row[1] for row in conn.execute("PRAGMA index_list(chat_messages)").fetchall()
         }
         assert "ix_chat_messages_session_id" in msg_indexes
     finally:
@@ -99,8 +95,7 @@ def test_terminated_at_user_request_defaults_false(tmp_path: Path) -> None:
         )
         conn.commit()
         row = conn.execute(
-            "SELECT terminated_at_user_request FROM chat_messages "
-            "WHERE session_id = 'sess02'"
+            "SELECT terminated_at_user_request FROM chat_messages WHERE session_id = 'sess02'"
         ).fetchone()
         assert row is not None
         assert row[0] == 0  # SQLite stores False as 0

--- a/tests/unit/core/test_task_classification.py
+++ b/tests/unit/core/test_task_classification.py
@@ -179,7 +179,6 @@ class TestClassifyTaskIndividual:
         assert task_type == TaskType.INVESTIGATION
 
 
-
 class TestClassificationEdgeCases:
     """Test edge cases and unusual inputs."""
 


### PR DESCRIPTION
## Summary

Mechanical formatter pass — single-line collapses of multi-line statements + whitespace tweaks. No behavioral change. Likely fallout from a `ruff format` run after a config tweak (line-length or similar).

Two Explore agents independently confirmed: no new APIs, schemas, types, TODO markers, or new tests. Pure style normalization.

## Test plan

- [x] `uv run poe lint` — all checks passed
- [x] No `src/` test files modified — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)