### PR TITLE
refactor(R4): enforce package boundaries — promote privates + import-linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ exclude = ["src/kagan/server/_web_static/**"]
 "src/kagan/server/_web_static" = "kagan/server/_web_static"
 [dependency-groups]
 dev = [
-  "import-linter>=2.1",
+  "import-linter>=2.11",
   "poethepoet>=0.40.0",
   "pre-commit>=4.5.1",
   "pytest>=9.0.2",
@@ -99,7 +99,6 @@ dev = [
   "pytest-sugar>=1.1.1",
   "playwright>=1.58.0",
   "pytest-playwright>=0.7.2",
-  "import-linter>=2.11",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,7 +412,7 @@ root_package = "kagan"
 name = "kagan.tui must not import kagan.core private modules"
 type = "forbidden"
 source_modules = ["kagan.tui"]
-allow_indirect_imports = "true"
+allow_indirect_imports = true
 forbidden_modules = [
     "kagan.core._acp",
     "kagan.core._agent",
@@ -461,7 +461,7 @@ forbidden_modules = [
 name = "kagan.cli must not import kagan.core private modules"
 type = "forbidden"
 source_modules = ["kagan.cli"]
-allow_indirect_imports = "true"
+allow_indirect_imports = true
 forbidden_modules = [
     "kagan.core._acp",
     "kagan.core._agent",
@@ -510,7 +510,7 @@ forbidden_modules = [
 name = "kagan.server must not import kagan.core private modules"
 type = "forbidden"
 source_modules = ["kagan.server"]
-allow_indirect_imports = "true"
+allow_indirect_imports = true
 forbidden_modules = [
     "kagan.core._acp",
     "kagan.core._agent",
@@ -561,7 +561,7 @@ forbidden_modules = [
 name = "kagan.tui and kagan.cli must not import kagan.server private modules"
 type = "forbidden"
 source_modules = ["kagan.tui", "kagan.cli"]
-allow_indirect_imports = "true"
+allow_indirect_imports = true
 forbidden_modules = [
     "kagan.server._access",
     "kagan.server._analytics_routes",
@@ -585,7 +585,7 @@ forbidden_modules = [
 name = "kagan.server and kagan.tui must not import kagan.cli private modules"
 type = "forbidden"
 source_modules = ["kagan.server", "kagan.tui"]
-allow_indirect_imports = "true"
+allow_indirect_imports = true
 forbidden_modules = [
     "kagan.cli._bootstrap",
     "kagan.cli._doctor_output",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ exclude = ["src/kagan/server/_web_static/**"]
 "src/kagan/server/_web_static" = "kagan/server/_web_static"
 [dependency-groups]
 dev = [
+  "import-linter>=2.1",
   "poethepoet>=0.40.0",
   "pre-commit>=4.5.1",
   "pytest>=9.0.2",
@@ -98,6 +99,7 @@ dev = [
   "pytest-sugar>=1.1.1",
   "playwright>=1.58.0",
   "pytest-playwright>=0.7.2",
+  "import-linter>=2.11",
 ]
 
 [tool.ruff]
@@ -208,11 +210,12 @@ check-loc = "python scripts/check_python_loc_budget.py --max-lines 2500"
 check-complexity = "ruff check src/ --select C90"
 check-wire-drift = "python scripts/check_wire_drift.py"
 check-test-quality = { help = "Lint test files for tautological patterns", cmd = "python scripts/check_test_quality.py" }
+check-boundaries = { cmd = "lint-imports", help = "Verify package boundaries (no cross-package _* imports)" }
 check-guardrails = ["check-loc", "check-complexity", "check-wire-drift", "check-test-quality"]
 format = "ruff format src/ tests/"
 typecheck = "pyrefly check --project-excludes src/kagan/core/adapters/db/migrations/versions src/"
 deadcode = "vulture"
-check = ["lint", "typecheck", "deadcode", "test"]
+check = ["lint", "typecheck", "deadcode", "check-boundaries", "test"]
 db-migrations-check = "pytest tests/core/test_db_migrations.py -n 0 -v"
 docs-dev = "mkdocs serve -f mkdocs.local.yml"
 docs-build = "mkdocs build"
@@ -396,6 +399,212 @@ upload_to_vcs_release = true
 
 [tool.semantic_release.remote.token]
 env = "GITHUB_TOKEN"
+
+[tool.importlinter]
+root_package = "kagan"
+
+# --- kagan.core private modules (kagan.core._*) ---
+# Nothing outside kagan.core may import from a private submodule directly.
+# Consumers must go through kagan.core (the public __init__) or a public
+# subpackage like kagan.core.chat, kagan.core.git, kagan.core.models, etc.
+# Each _*.py file is listed explicitly because import-linter's wildcard syntax
+# (mypackage.*) cannot filter by name prefix.
+[[tool.importlinter.contracts]]
+name = "kagan.tui must not import kagan.core private modules"
+type = "forbidden"
+source_modules = ["kagan.tui"]
+allow_indirect_imports = "true"
+forbidden_modules = [
+    "kagan.core._acp",
+    "kagan.core._agent",
+    "kagan.core._agent_monitor",
+    "kagan.core._analytics",
+    "kagan.core._asyncio_compat",
+    "kagan.core._attached_backends",
+    "kagan.core._audit",
+    "kagan.core._backend_selector",
+    "kagan.core._checkpoints",
+    "kagan.core._compaction",
+    "kagan.core._config",
+    "kagan.core._db",
+    "kagan.core._db_helpers",
+    "kagan.core._environment_checks",
+    "kagan.core._event_rendering",
+    "kagan.core._events",
+    "kagan.core._formatting",
+    "kagan.core._hooks",
+    "kagan.core._insights",
+    "kagan.core._io",
+    "kagan.core._launchers",
+    "kagan.core._logging",
+    "kagan.core._orphan_reap",
+    "kagan.core._persona",
+    "kagan.core._preflight",
+    "kagan.core._projects",
+    "kagan.core._prompt_export",
+    "kagan.core._prompts",
+    "kagan.core._reviews",
+    "kagan.core._security",
+    "kagan.core._session_helpers",
+    "kagan.core._sessions",
+    "kagan.core._settings",
+    "kagan.core._subprocess",
+    "kagan.core._task_classification",
+    "kagan.core._tasks",
+    "kagan.core._transitions",
+    "kagan.core._utils",
+    "kagan.core._verification",
+    "kagan.core._watcher",
+    "kagan.core._worktrees",
+]
+
+[[tool.importlinter.contracts]]
+name = "kagan.cli must not import kagan.core private modules"
+type = "forbidden"
+source_modules = ["kagan.cli"]
+allow_indirect_imports = "true"
+forbidden_modules = [
+    "kagan.core._acp",
+    "kagan.core._agent",
+    "kagan.core._agent_monitor",
+    "kagan.core._analytics",
+    "kagan.core._asyncio_compat",
+    "kagan.core._attached_backends",
+    "kagan.core._audit",
+    "kagan.core._backend_selector",
+    "kagan.core._checkpoints",
+    "kagan.core._compaction",
+    "kagan.core._config",
+    "kagan.core._db",
+    "kagan.core._db_helpers",
+    "kagan.core._environment_checks",
+    "kagan.core._event_rendering",
+    "kagan.core._events",
+    "kagan.core._formatting",
+    "kagan.core._hooks",
+    "kagan.core._insights",
+    "kagan.core._io",
+    "kagan.core._launchers",
+    "kagan.core._logging",
+    "kagan.core._orphan_reap",
+    "kagan.core._persona",
+    "kagan.core._preflight",
+    "kagan.core._projects",
+    "kagan.core._prompt_export",
+    "kagan.core._prompts",
+    "kagan.core._reviews",
+    "kagan.core._security",
+    "kagan.core._session_helpers",
+    "kagan.core._sessions",
+    "kagan.core._settings",
+    "kagan.core._subprocess",
+    "kagan.core._task_classification",
+    "kagan.core._tasks",
+    "kagan.core._transitions",
+    "kagan.core._utils",
+    "kagan.core._verification",
+    "kagan.core._watcher",
+    "kagan.core._worktrees",
+]
+
+[[tool.importlinter.contracts]]
+name = "kagan.server must not import kagan.core private modules"
+type = "forbidden"
+source_modules = ["kagan.server"]
+allow_indirect_imports = "true"
+forbidden_modules = [
+    "kagan.core._acp",
+    "kagan.core._agent",
+    "kagan.core._agent_monitor",
+    "kagan.core._analytics",
+    "kagan.core._asyncio_compat",
+    "kagan.core._attached_backends",
+    "kagan.core._audit",
+    "kagan.core._backend_selector",
+    "kagan.core._checkpoints",
+    "kagan.core._compaction",
+    "kagan.core._config",
+    "kagan.core._db",
+    "kagan.core._db_helpers",
+    "kagan.core._environment_checks",
+    "kagan.core._event_rendering",
+    "kagan.core._events",
+    "kagan.core._formatting",
+    "kagan.core._hooks",
+    "kagan.core._insights",
+    "kagan.core._io",
+    "kagan.core._launchers",
+    "kagan.core._logging",
+    "kagan.core._orphan_reap",
+    "kagan.core._persona",
+    "kagan.core._preflight",
+    "kagan.core._projects",
+    "kagan.core._prompt_export",
+    "kagan.core._prompts",
+    "kagan.core._reviews",
+    "kagan.core._security",
+    "kagan.core._session_helpers",
+    "kagan.core._sessions",
+    "kagan.core._settings",
+    "kagan.core._subprocess",
+    "kagan.core._task_classification",
+    "kagan.core._tasks",
+    "kagan.core._transitions",
+    "kagan.core._utils",
+    "kagan.core._verification",
+    "kagan.core._watcher",
+    "kagan.core._worktrees",
+]
+
+# --- Cross-package private module imports ---
+# kagan.server._* must not be imported from kagan.tui or kagan.cli.
+[[tool.importlinter.contracts]]
+name = "kagan.tui and kagan.cli must not import kagan.server private modules"
+type = "forbidden"
+source_modules = ["kagan.tui", "kagan.cli"]
+allow_indirect_imports = "true"
+forbidden_modules = [
+    "kagan.server._access",
+    "kagan.server._analytics_routes",
+    "kagan.server._chat_routes",
+    "kagan.server._envelope",
+    "kagan.server._helpers",
+    "kagan.server._integration_routes",
+    "kagan.server._middleware",
+    "kagan.server._presence",
+    "kagan.server._project_routes",
+    "kagan.server._sse",
+    "kagan.server._system_routes",
+    "kagan.server._task_routes",
+    "kagan.server._web_ui",
+    "kagan.server.mcp._policy",
+]
+
+# kagan.cli._* must not be imported from kagan.server or kagan.tui.
+# Note: kagan.cli.chat (public package) is allowed; only kagan.cli.chat._* is forbidden.
+[[tool.importlinter.contracts]]
+name = "kagan.server and kagan.tui must not import kagan.cli private modules"
+type = "forbidden"
+source_modules = ["kagan.server", "kagan.tui"]
+allow_indirect_imports = "true"
+forbidden_modules = [
+    "kagan.cli._bootstrap",
+    "kagan.cli._doctor_output",
+    "kagan.cli._env",
+    "kagan.cli.chat._approval_batch",
+    "kagan.cli.chat._approval_panel",
+    "kagan.cli.chat._chat_ui",
+    "kagan.cli.chat._completion",
+    "kagan.cli.chat._handshake",
+    "kagan.cli.chat._permission_ui",
+    "kagan.cli.chat._renderer",
+    "kagan.cli.chat._session_picker",
+    "kagan.cli.chat._signals",
+    "kagan.cli.chat._streaming",
+    "kagan.cli.chat._theme",
+    "kagan.cli.chat._title",
+    "kagan.cli.chat._yolo",
+]
 
 [tool.vulture]
 paths = ["src/"]

--- a/src/kagan/cli/chat/__init__.py
+++ b/src/kagan/cli/chat/__init__.py
@@ -4,6 +4,12 @@ Public API re-exported from private sub-modules.
 """
 
 from kagan.cli.chat._completion import fuzzy_match
+from kagan.cli.chat._session_picker import (
+    ChatSessionListItem,
+    build_chat_session_list_items,
+    chat_session_to_legacy_dict,
+    resolve_chat_session_selector,
+)
 from kagan.cli.chat._title import ensure_session_title, generate_session_title, is_default_title
 from kagan.cli.chat.acp import run_orchestrator_turn, warm_orchestrator_backend
 from kagan.cli.chat.agents import (
@@ -49,15 +55,18 @@ __all__ = [
     "CHAT_SCOPE_PREFIX",
     "SLASH_COMMAND_REGISTRY",
     "ChatController",
+    "ChatSessionListItem",
     "SlashAction",
     "SlashCommandInvocation",
     "SlashCommandOutcome",
     "SlashCommandRegistry",
     "SlashCommandSpec",
     "SlashPresentationLine",
+    "build_chat_session_list_items",
     "build_chat_status_line",
     "build_orchestrator_prompt",
     "build_slash_presentation_lines",
+    "chat_session_to_legacy_dict",
     "ensure_session_title",
     "format_agent_backend_list",
     "format_agent_usage",
@@ -72,6 +81,7 @@ __all__ = [
     "parse_slash_invocation",
     "resolve_agent_backend_selection",
     "resolve_agent_command_argument",
+    "resolve_chat_session_selector",
     "resolve_default_agent_backend",
     "resolve_slash_command",
     "resolve_slash_input",

--- a/src/kagan/cli/chat/_chat_ui.py
+++ b/src/kagan/cli/chat/_chat_ui.py
@@ -13,7 +13,7 @@ from rich.text import Text
 from kagan.cli.chat._renderer import CLIRenderer
 from kagan.cli.chat.commands import SLASH_COMMAND_REGISTRY
 from kagan.cli.chat.repl import SearchPickerOption, _console
-from kagan.core._formatting import format_duration, format_percentage
+from kagan.core import format_duration, format_percentage
 
 
 def print_help_documentation() -> None:

--- a/src/kagan/cli/chat/_session_picker.py
+++ b/src/kagan/cli/chat/_session_picker.py
@@ -15,13 +15,12 @@ formatting, VS Code tree view).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from kagan.core.chat.sessions import format_relative_time
-
-if TYPE_CHECKING:
-    from kagan.core.models import ChatMessage, ChatSession
+from kagan.core.chat.sessions import (
+    chat_session_to_legacy_dict,
+    format_relative_time,
+)
 
 __all__ = [
     "ChatSessionListItem",
@@ -42,35 +41,6 @@ class ChatSessionListItem:
     updated_at: str
     updated_relative: str
     is_current: bool
-
-
-def chat_session_to_legacy_dict(
-    row: ChatSession,
-    messages: list[ChatMessage],
-) -> dict[str, Any]:
-    """Convert a ``(ChatSession, list[ChatMessage])`` pair into the legacy dict shape.
-
-    Several call sites (TUI orchestrator store, server SSE wire mapping, server
-    REST shape) consume the dict shape that the deleted ``cli.chat.sessions``
-    shim used to return. Rather than rewire every consumer in one phase, this
-    helper sits at the boundary of those callers — they call
-    ``client.chat_sessions.X`` directly for persistence and convert to dict
-    here for display.
-    """
-    history = [[m.role, m.content] for m in messages]
-    updated_at = (
-        row.updated_at.isoformat() if isinstance(row.updated_at, datetime) else str(row.updated_at)
-    )
-    return {
-        "id": row.id,
-        "label": row.label,
-        "source": row.source,
-        "agent_backend": row.agent_backend,
-        "orchestrator_history": history,
-        "messages_rendered": [],
-        "updated_at": updated_at,
-        "project_id": row.project_id,
-    }
 
 
 def build_chat_session_list_items(

--- a/src/kagan/cli/chat/acp.py
+++ b/src/kagan/cli/chat/acp.py
@@ -36,8 +36,8 @@ from kagan.core import (
     friendly_acp_error_message,
     get_backend_spec,
     resolve_orchestrator_prompt,
+    resolve_spawn_command,
 )
-from kagan.core._subprocess import resolve_spawn_command
 from kagan.core.errors import AgentError
 
 _ACP_CLIENT_NAME = "kagan"

--- a/src/kagan/cli/chat/controller.py
+++ b/src/kagan/cli/chat/controller.py
@@ -283,9 +283,7 @@ class ChatController:
             self._restart_requested = True
 
         if self._persist_repl_session:
-            await self.client.chat_sessions.set_last_session_id(
-                scope="repl", session_id=session_id
-            )
+            await self.client.chat_sessions.set_last_session_id(scope="repl", session_id=session_id)
         return self._restart_requested
 
     def _print_restored_messages(self) -> None:

--- a/src/kagan/cli/doctor.py
+++ b/src/kagan/cli/doctor.py
@@ -6,13 +6,13 @@ from loguru import logger
 
 from kagan.cli._bootstrap import make_client, run_async
 from kagan.cli._doctor_output import emit_short, emit_technical, emit_tldr
-from kagan.core import PreflightCheckResult
-from kagan.core._analytics import emit_telemetry
-from kagan.core._db import create_db_engine, default_db_path
-from kagan.core._environment_checks import (
-    _VERIFY_HINTS,
-    _derive_category,
+from kagan.core import (
+    PreflightCheckResult,
     collect_environment_checks,
+    create_db_engine,
+    default_db_path,
+    derive_check_category,
+    emit_telemetry,
     resolve_backend_guidance,
     resolve_doctor_backend_name,
     verify_hint_for,
@@ -33,7 +33,7 @@ class DoctorCheck:
 
 
 def _verify_hint(name: str) -> str:
-    return _VERIFY_HINTS.get(name, "ls")
+    return verify_hint_for(name)
 
 
 def _backend_verify_hint(backend_name: str) -> str:
@@ -90,7 +90,7 @@ def _map_preflight_check(check: PreflightCheckResult, default_backend: str) -> D
         message=message,
         fix_hint=fix_hint,
         verify_hint=v_hint,
-        category=_derive_category(name),
+        category=derive_check_category(name),
     )
 
 
@@ -322,7 +322,7 @@ def doctor(verbosity: str, output_json: bool) -> None:
 
     has_failures = any(check.status == "fail" for check in checks)
     if has_failures and not output_json:
-        from kagan.core._logging import default_log_path
+        from kagan.core import default_log_path
 
         click.echo(f"\nLog file: {default_log_path()}")
 
@@ -355,7 +355,7 @@ def run_doctor_check_for_backend(backend_name: str) -> DoctorCheck | None:
     """
     import shutil
 
-    from kagan.core._agent import AgentError, get_backend_spec
+    from kagan.core import AgentError, get_backend_spec
 
     try:
         backend_spec = get_backend_spec(backend_name)
@@ -402,7 +402,7 @@ def render_doctor_report(
         emit_short(checks)
 
     if any(c.status == "fail" for c in checks):
-        from kagan.core._logging import default_log_path
+        from kagan.core import default_log_path
 
         click.echo(f"\nLog file: {default_log_path()}")
 

--- a/src/kagan/cli/main.py
+++ b/src/kagan/cli/main.py
@@ -79,7 +79,7 @@ _RUNTIME_SURFACES = {"tui", "web", "chat"}
 
 
 def _print_crash_footer() -> None:
-    from kagan.core._logging import default_log_path
+    from kagan.core import default_log_path
 
     log_path = default_log_path()
     click.echo(f"Log file: {log_path}", err=True)
@@ -314,7 +314,7 @@ def _dispatch_surface_choice(ctx: click.Context, choice: str) -> None:
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose stderr logging")
 @click.pass_context
 def cli(ctx: click.Context, skip_update_check: bool, verbose: bool) -> None:
-    from kagan.core._logging import configure_logging
+    from kagan.core import configure_logging
 
     _sanitize_startup_environment()
     configure_logging(verbose=verbose)

--- a/src/kagan/cli/prompts.py
+++ b/src/kagan/cli/prompts.py
@@ -48,7 +48,7 @@ def export(prompt_type: str, output: str | None, model: str, output_format: str)
     import asyncio
 
     from kagan.cli._bootstrap import make_client
-    from kagan.core._prompt_export import export_prompt_text, export_prompt_yml, write_prompt_file
+    from kagan.core import export_prompt_text, export_prompt_yml, write_prompt_file
 
     settings: dict[str, str] = {}
     try:

--- a/src/kagan/cli/tools.py
+++ b/src/kagan/cli/tools.py
@@ -166,7 +166,7 @@ def _resolve_backend(agent_backend: str | None, tool: str | None) -> str:
         if normalized in _AGENT_ALIASES:
             return _AGENT_ALIASES[normalized]
 
-        from kagan.core._agent import list_backends
+        from kagan.core import list_backends
 
         available = set(list_backends())
         if normalized in available:
@@ -176,7 +176,7 @@ def _resolve_backend(agent_backend: str | None, tool: str | None) -> str:
     if tool is not None:
         return _TOOL_TO_BACKEND[tool.lower()]
 
-    from kagan.core._agent import CLAUDE_CODE_BACKEND, OPENCODE_BACKEND
+    from kagan.core import CLAUDE_CODE_BACKEND, OPENCODE_BACKEND
 
     for backend in (CLAUDE_CODE_BACKEND, OPENCODE_BACKEND, "kimi-cli"):
         executable = _get_backend_executable(backend)
@@ -186,7 +186,7 @@ def _resolve_backend(agent_backend: str | None, tool: str | None) -> str:
 
 
 def _get_backend_executable(backend_name: str) -> str:
-    from kagan.core._agent import get_backend
+    from kagan.core import get_backend
 
     backend = get_backend(backend_name)
     executable = backend.get("executable")
@@ -210,7 +210,7 @@ def _extract_refined_prompt(response: str) -> str:
 
 
 def _build_agent_command(backend_name: str, prompt_text: str) -> list[str]:
-    from kagan.core._agent import OPENCODE_BACKEND
+    from kagan.core import OPENCODE_BACKEND
 
     executable = _get_backend_executable(backend_name)
     prompt = _get_refinement_prompt(prompt_text)

--- a/src/kagan/cli/web.py
+++ b/src/kagan/cli/web.py
@@ -74,7 +74,7 @@ def web(
     project_id: str | None,
     dev_mode: bool,
 ) -> None:
-    from kagan.server._web_ui import has_web_bundle
+    from kagan.server import has_web_bundle
 
     browser_timer = None
 

--- a/src/kagan/core/__init__.py
+++ b/src/kagan/core/__init__.py
@@ -39,10 +39,56 @@ from kagan.core._agent import (
     resolve_acp_command,
     resolve_default_agent_backend,
 )
+from kagan.core._analytics import Analytics, emit_telemetry
 from kagan.core._asyncio_compat import install_asyncio_subprocess_exception_filter
+from kagan.core._attached_backends import (
+    ANTIGRAVITY_BACKEND,
+    ATTACHED_TERMINAL_BACKEND_SPECS,
+    ATTACHED_TERMINAL_BACKEND_SPECS_BY_VALUE,
+    ATTACHED_TERMINAL_BACKEND_VALUE_SET,
+    ATTACHED_TERMINAL_BACKEND_VALUES,
+    CURSOR_BACKEND,
+    KIRO_BACKEND,
+    NVIM_BACKEND,
+    TMUX_BACKEND,
+    UNIX_ATTACHED_TERMINAL_FALLBACK_ORDER,
+    VSCODE_BACKEND,
+    WINDOWS_ATTACHED_TERMINAL_FALLBACK_ORDER,
+    WINDSURF_BACKEND,
+    AttachedTerminalBackendLiteral,
+    AttachedTerminalBackendSpec,
+    attached_terminal_backend_executable,
+    attached_terminal_backend_fallback_order,
+    coerce_attached_terminal_backend,
+)
 from kagan.core._audit import list_audit, record_audit
-from kagan.core._db import default_db_path
+from kagan.core._backend_selector import BackendSelector
+from kagan.core._checkpoints import (
+    Checkpoint,
+    cleanup_checkpoints,
+    create_checkpoint,
+    list_checkpoints,
+    rewind_to_checkpoint,
+)
+from kagan.core._compaction import COMPACTION_THRESHOLD, ContextCompactor
+from kagan.core._db import create_db_engine, default_db_path
+from kagan.core._db_helpers import _db_async, _db_sync
+from kagan.core._environment_checks import (
+    EnvCheckResult,
+    collect_environment_checks,
+    derive_check_category,
+    resolve_backend_guidance,
+    resolve_doctor_backend_name,
+    verify_hint_for,
+)
+from kagan.core._formatting import format_duration, format_percentage
+from kagan.core._insights import InsightCategory
+from kagan.core._io.projects import ProjectCreateRequest, RepoAddRequest
+from kagan.core._io.reviews import ReviewDecideRequest
+from kagan.core._io.sessions import ChatSessionCreateRequest, ChatSessionPatchRequest
+from kagan.core._io.tasks import TaskCreateRequest, TaskUpdateRequest
 from kagan.core._launchers import resolve_launcher
+from kagan.core._logging import configure_logging, default_log_path
 from kagan.core._orphan_reap import reap_orphan_sessions
 from kagan.core._preflight import CheckStatus, PreflightCheckResult
 from kagan.core._projects import (
@@ -58,6 +104,7 @@ from kagan.core._projects import (
     resolve_repo_path,
     set_repo_default_branch,
 )
+from kagan.core._prompt_export import export_prompt_text, export_prompt_yml, write_prompt_file
 from kagan.core._prompts import (
     ADDITIONAL_INSTRUCTIONS_KEY,
     AUTO_CONFIRM_SINGLE_KEY,
@@ -101,8 +148,11 @@ from kagan.core._sessions import (
     resolve_session_binding,
 )
 from kagan.core._settings import get_settings, set_settings
+from kagan.core._subprocess import resolve_spawn_command
 from kagan.core._task_classification import classify_task
 from kagan.core._tasks import Tasks
+from kagan.core._utils import utc_iso
+from kagan.core._verification import StepVerdict, StepVerification, VerificationSummary
 from kagan.core._worktrees import (
     cleanup_orphan_worktrees,
     cleanup_worktree,
@@ -155,14 +205,23 @@ from kagan.core.models import (
 __all__ = [
     "ACP_TIMEOUT_HINT",
     "ADDITIONAL_INSTRUCTIONS_KEY",
+    "ANTIGRAVITY_BACKEND",
+    "ATTACHED_TERMINAL_BACKEND_SPECS",
+    "ATTACHED_TERMINAL_BACKEND_SPECS_BY_VALUE",
+    "ATTACHED_TERMINAL_BACKEND_VALUES",
+    "ATTACHED_TERMINAL_BACKEND_VALUE_SET",
     "AUTO_CONFIRM_SINGLE_KEY",
     "CLAUDE_CODE_BACKEND",
     "CODEX_BACKEND",
+    "COMPACTION_THRESHOLD",
+    "CURSOR_BACKEND",
     "DEFAULT_ORCHESTRATOR_PROMPT",
     "GEMINI_CLI_BACKEND",
     "KAGAN_AGENT_EMAIL",
     "KAGAN_AGENT_NAME",
     "KIMI_CLI_BACKEND",
+    "KIRO_BACKEND",
+    "NVIM_BACKEND",
     "OPENCODE_BACKEND",
     "OS",
     "PERSONA_DEFINITIONS_KEY",
@@ -170,21 +229,36 @@ __all__ = [
     "PLANNING_DEPTH_KEY",
     "REFERENCE_BACKENDS",
     "REVIEW_STRICTNESS_KEY",
+    "TMUX_BACKEND",
+    "UNIX_ATTACHED_TERMINAL_FALLBACK_ORDER",
+    "VSCODE_BACKEND",
+    "WINDOWS_ATTACHED_TERMINAL_FALLBACK_ORDER",
+    "WINDSURF_BACKEND",
     "ACPClientBase",
     "AcceptanceCriterion",
     "AgentError",
     "AgentRole",
+    "Analytics",
+    "AttachedTerminalBackendLiteral",
+    "AttachedTerminalBackendSpec",
     "AuditEntry",
     "BackendCapability",
     "BackendCommand",
+    "BackendSelector",
     "BackendSpec",
     "BranchRefStrategy",
     "ChatMessage",
     "ChatSession",
+    "ChatSessionCreateRequest",
+    "ChatSessionPatchRequest",
     "CheckStatus",
+    "Checkpoint",
     "ConfigurationError",
+    "ContextCompactor",
     "DBWatcher",
+    "EnvCheckResult",
     "InjectionDetector",
+    "InsightCategory",
     "InvalidTransitionError",
     "KaganCore",
     "KaganError",
@@ -195,7 +269,10 @@ __all__ = [
     "PreflightError",
     "Priority",
     "Project",
+    "ProjectCreateRequest",
+    "RepoAddRequest",
     "Repository",
+    "ReviewDecideRequest",
     "ReviewVerdict",
     "Session",
     "SessionError",
@@ -203,14 +280,21 @@ __all__ = [
     "SessionEventType",
     "SessionStatus",
     "Setting",
+    "StepVerdict",
+    "StepVerification",
     "Task",
+    "TaskCreateRequest",
     "TaskNote",
     "TaskStatus",
     "TaskType",
+    "TaskUpdateRequest",
     "Tasks",
     "ValidationError",
+    "VerificationSummary",
     "Worktree",
     "WorktreeError",
+    "_db_async",
+    "_db_sync",
     "abort_rebase",
     "acp_handshake_timeout_seconds",
     "acp_process_exit_hint",
@@ -218,22 +302,37 @@ __all__ = [
     "active_session_summaries",
     "add_repo",
     "approve_review",
+    "attached_terminal_backend_executable",
+    "attached_terminal_backend_fallback_order",
     "build_agent_environment",
     "build_conflict_resolution_feedback",
     "build_mcp_manifest",
     "classify_task",
+    "cleanup_checkpoints",
     "cleanup_orphan_worktrees",
     "cleanup_worktree",
     "clear_review_verdicts",
+    "coerce_attached_terminal_backend",
+    "collect_environment_checks",
+    "configure_logging",
     "continue_rebase",
+    "create_checkpoint",
+    "create_db_engine",
     "create_project",
     "create_worktree",
     "default_db_path",
+    "default_log_path",
     "delete_project",
+    "derive_check_category",
     "detect_dotfile_overrides",
+    "emit_telemetry",
+    "export_prompt_text",
+    "export_prompt_yml",
     "fetch_project_learnings",
     "find_project_by_name",
     "find_project_by_repo",
+    "format_duration",
+    "format_percentage",
     "friendly_acp_error_message",
     "get_backend",
     "get_backend_spec",
@@ -254,6 +353,7 @@ __all__ = [
     "list_available_backends",
     "list_backend_specs",
     "list_backends",
+    "list_checkpoints",
     "list_projects",
     "list_repos",
     "list_task_sessions",
@@ -265,17 +365,24 @@ __all__ = [
     "record_audit",
     "reject_review",
     "resolve_acp_command",
+    "resolve_backend_guidance",
     "resolve_default_agent_backend",
+    "resolve_doctor_backend_name",
     "resolve_launcher",
     "resolve_orchestrator_prompt",
     "resolve_repo",
     "resolve_repo_path",
     "resolve_review_prompt",
     "resolve_session_binding",
+    "resolve_spawn_command",
     "resolve_task_prompt",
+    "rewind_to_checkpoint",
     "scan_text_for_injection",
     "serialize_persona_definitions",
     "set_criterion_verdict",
     "set_repo_default_branch",
     "set_settings",
+    "utc_iso",
+    "verify_hint_for",
+    "write_prompt_file",
 ]

--- a/src/kagan/core/__init__.py
+++ b/src/kagan/core/__init__.py
@@ -72,7 +72,8 @@ from kagan.core._checkpoints import (
 )
 from kagan.core._compaction import COMPACTION_THRESHOLD, ContextCompactor
 from kagan.core._db import create_db_engine, default_db_path
-from kagan.core._db_helpers import _db_async, _db_sync
+from kagan.core._db_helpers import _db_async as db_async
+from kagan.core._db_helpers import _db_sync as db_sync
 from kagan.core._environment_checks import (
     EnvCheckResult,
     collect_environment_checks,
@@ -293,8 +294,6 @@ __all__ = [
     "VerificationSummary",
     "Worktree",
     "WorktreeError",
-    "_db_async",
-    "_db_sync",
     "abort_rebase",
     "acp_handshake_timeout_seconds",
     "acp_process_exit_hint",
@@ -320,6 +319,8 @@ __all__ = [
     "create_db_engine",
     "create_project",
     "create_worktree",
+    "db_async",
+    "db_sync",
     "default_db_path",
     "default_log_path",
     "delete_project",

--- a/src/kagan/core/_environment_checks.py
+++ b/src/kagan/core/_environment_checks.py
@@ -60,6 +60,10 @@ def _derive_category(name: str) -> str:
     return "integration"
 
 
+# Public alias — callers outside kagan.core must use this name.
+derive_check_category = _derive_category
+
+
 # ---------------------------------------------------------------------------
 # Unified verify-hint mapping
 # ---------------------------------------------------------------------------

--- a/src/kagan/core/chat/__init__.py
+++ b/src/kagan/core/chat/__init__.py
@@ -39,6 +39,7 @@ from kagan.core.chat.sessions import (
     CHAT_LAST_SESSION_PREFIX,
     CHAT_SCOPE_PREFIX,
     ChatSessions,
+    chat_session_to_legacy_dict,
     clean_generated_title,
     format_relative_time,
 )
@@ -70,6 +71,7 @@ __all__ = [
     "UsageUpdate",
     "UserMessagePersisted",
     "acp_update_to_chat_event",
+    "chat_session_to_legacy_dict",
     "clean_generated_title",
     "format_relative_time",
 ]

--- a/src/kagan/core/chat/sessions.py
+++ b/src/kagan/core/chat/sessions.py
@@ -34,6 +34,33 @@ if TYPE_CHECKING:
 CHAT_SCOPE_PREFIX = "chat_scope_state_"
 CHAT_LAST_SESSION_PREFIX = "chat_last_session_"
 
+
+def chat_session_to_legacy_dict(
+    row: ChatSession,
+    messages: list[ChatMessage],
+) -> dict[str, Any]:
+    """Convert a ``(ChatSession, list[ChatMessage])`` pair into the legacy dict shape.
+
+    Several call sites (TUI orchestrator store, server SSE wire mapping, server
+    REST shape) consume the dict shape. Callers use ``client.chat_sessions.X``
+    for persistence and this helper for display serialization.
+    """
+    history = [[m.role, m.content] for m in messages]
+    updated_at = (
+        row.updated_at.isoformat() if isinstance(row.updated_at, datetime) else str(row.updated_at)
+    )
+    return {
+        "id": row.id,
+        "label": row.label,
+        "source": row.source,
+        "agent_backend": row.agent_backend,
+        "orchestrator_history": history,
+        "messages_rendered": [],
+        "updated_at": updated_at,
+        "project_id": row.project_id,
+    }
+
+
 _SESSION_TITLE_MAX_LENGTH = 80
 
 

--- a/src/kagan/server/__init__.py
+++ b/src/kagan/server/__init__.py
@@ -1,5 +1,6 @@
 """HTTP API server for the bundled dashboard and API clients."""
 
+from kagan.server._web_ui import has_web_bundle
 from kagan.server.server import ApiServerOptions, create_api_server, serve_http
 
-__all__ = ["ApiServerOptions", "create_api_server", "serve_http"]
+__all__ = ["ApiServerOptions", "create_api_server", "has_web_bundle", "serve_http"]

--- a/src/kagan/server/_analytics_routes.py
+++ b/src/kagan/server/_analytics_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from kagan.core._backend_selector import BackendSelector
+from kagan.core import BackendSelector
 from kagan.server._helpers import _ok, handle_errors, require_context
 
 if TYPE_CHECKING:

--- a/src/kagan/server/_chat_routes.py
+++ b/src/kagan/server/_chat_routes.py
@@ -26,9 +26,11 @@ import acp
 from loguru import logger
 from starlette.responses import JSONResponse, StreamingResponse
 
-from kagan.cli.chat._session_picker import chat_session_to_legacy_dict
-from kagan.core import resolve_default_agent_backend
-from kagan.core._io.sessions import ChatSessionCreateRequest, ChatSessionPatchRequest
+from kagan.core import (
+    ChatSessionCreateRequest,
+    ChatSessionPatchRequest,
+    resolve_default_agent_backend,
+)
 from kagan.core.chat import (
     AssistantChunk,
     AssistantMessagePersisted,
@@ -41,6 +43,7 @@ from kagan.core.chat import (
     TurnError,
     TurnInProgressError,
     TurnStarted,
+    chat_session_to_legacy_dict,
 )
 from kagan.server._access import AccessTier, is_access_allowed
 from kagan.server._helpers import _err, _ok, _require_access, handle_errors, require_context

--- a/src/kagan/server/_helpers.py
+++ b/src/kagan/server/_helpers.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ValidationError
 from sqlmodel import select
 from starlette.responses import JSONResponse
 
-from kagan.core import TaskStatus, _db_async
+from kagan.core import TaskStatus, db_async
 from kagan.core.errors import InvalidTransitionError, KaganError, NotFoundError
 from kagan.core.models import AcceptanceCriterion, ReviewVerdict
 from kagan.server._access import http_forbidden, is_access_allowed
@@ -233,7 +233,7 @@ async def bulk_task_review_verdicts(
         return {tid: grouped.get(tid, []) for tid in unique_ids}
 
     try:
-        return await _db_async(ctx.client.engine, op)
+        return await db_async(ctx.client.engine, op)
     except (KaganError, RuntimeError, OSError, AttributeError) as exc:
         logger.debug("bulk_task_review_verdicts failed: {}", exc, exc_info=True)
         return {tid: [] for tid in unique_ids}

--- a/src/kagan/server/_helpers.py
+++ b/src/kagan/server/_helpers.py
@@ -11,8 +11,7 @@ from pydantic import BaseModel, ValidationError
 from sqlmodel import select
 from starlette.responses import JSONResponse
 
-from kagan.core import TaskStatus
-from kagan.core._db_helpers import _db_async
+from kagan.core import TaskStatus, _db_async
 from kagan.core.errors import InvalidTransitionError, KaganError, NotFoundError
 from kagan.core.models import AcceptanceCriterion, ReviewVerdict
 from kagan.server._access import http_forbidden, is_access_allowed

--- a/src/kagan/server/_sse.py
+++ b/src/kagan/server/_sse.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
     from mcp.server.fastmcp import FastMCP
 
-    from kagan.core._tasks import Tasks
+    from kagan.core import Tasks
 
 _SSE_KEEPALIVE_SECONDS = 25.0
 # Safety-net fallback interval — the event bus delivers most mutations

--- a/src/kagan/server/_task_routes.py
+++ b/src/kagan/server/_task_routes.py
@@ -10,7 +10,7 @@ from sqlmodel import select
 from kagan.core import (
     BackendSelector,
     TaskStatus,
-    _db_async,
+    db_async,
     parse_priority,
     resolve_default_agent_backend,
     resolve_launcher,
@@ -452,7 +452,7 @@ def register_task_routes(mcp: FastMCP) -> None:
 
         if action in {"approve", "merge"}:
             task = await ctx.client.tasks.get(task_id)
-            criteria_list = await _db_async(
+            criteria_list = await db_async(
                 ctx.client.engine,
                 lambda s: list(
                     s.exec(

--- a/src/kagan/server/_task_routes.py
+++ b/src/kagan/server/_task_routes.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING, Any, cast
 from loguru import logger
 from sqlmodel import select
 
-from kagan.core import TaskStatus, parse_priority, resolve_default_agent_backend, resolve_launcher
-from kagan.core._backend_selector import BackendSelector
-from kagan.core._db_helpers import _db_async
+from kagan.core import (
+    BackendSelector,
+    TaskStatus,
+    _db_async,
+    parse_priority,
+    resolve_default_agent_backend,
+    resolve_launcher,
+)
 from kagan.core.models import AcceptanceCriterion
 from kagan.runtime_env import build_sanitized_subprocess_environment
 from kagan.server._access import AccessTier
@@ -77,7 +82,7 @@ async def _select_backend_intelligently(
 
     # Perform intelligent selection
     try:
-        from kagan.core._agent import list_available_backends
+        from kagan.core import list_available_backends
 
         # Get task details
         task = await ctx.client.tasks.get(task_id)

--- a/src/kagan/server/mcp/toolsets/review.py
+++ b/src/kagan/server/mcp/toolsets/review.py
@@ -8,8 +8,7 @@ import asyncio
 
 from mcp.server.fastmcp import Context, FastMCP
 
-from kagan.core import build_conflict_resolution_feedback
-from kagan.core._db_helpers import _db_async
+from kagan.core import _db_async, build_conflict_resolution_feedback
 from kagan.core.errors import MergeConflictError, ValidationError
 from kagan.core.models import AcceptanceCriterion, Task
 from kagan.server._helpers import _manual_review_payload

--- a/src/kagan/server/mcp/toolsets/review.py
+++ b/src/kagan/server/mcp/toolsets/review.py
@@ -8,7 +8,7 @@ import asyncio
 
 from mcp.server.fastmcp import Context, FastMCP
 
-from kagan.core import _db_async, build_conflict_resolution_feedback
+from kagan.core import build_conflict_resolution_feedback, db_async
 from kagan.core.errors import MergeConflictError, ValidationError
 from kagan.core.models import AcceptanceCriterion, Task
 from kagan.server._helpers import _manual_review_payload
@@ -20,7 +20,7 @@ from kagan.server.mcp.toolsets import mcp_error_boundary
 async def _has_acceptance_criteria(task_id: str, engine: object) -> bool:
     from sqlmodel import select as _select
 
-    criteria = await _db_async(
+    criteria = await db_async(
         engine,  # type: ignore[arg-type]
         lambda s: list(
             s.exec(_select(AcceptanceCriterion).where(AcceptanceCriterion.task_id == task_id)).all()
@@ -138,7 +138,7 @@ async def _review_verdict(
     app = get_context(ctx)
     await app.client.reviews.set_criterion_verdict(task_id, criterion_index, verdict, reason)
     total = len(
-        await _db_async(
+        await db_async(
             app.client.engine,
             lambda s: list(
                 s.exec(

--- a/src/kagan/server/mcp/toolsets/sessions.py
+++ b/src/kagan/server/mcp/toolsets/sessions.py
@@ -11,15 +11,18 @@ from typing import Any, cast
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 
-from kagan.core import resolve_default_agent_backend, resolve_launcher
-from kagan.core._checkpoints import (
+from kagan.core import (
     Checkpoint,
+    InsightCategory,
+    StepVerdict,
+    StepVerification,
+    VerificationSummary,
     create_checkpoint,
     list_checkpoints,
+    resolve_default_agent_backend,
+    resolve_launcher,
     rewind_to_checkpoint,
 )
-from kagan.core._insights import InsightCategory
-from kagan.core._verification import StepVerdict, StepVerification, VerificationSummary
 from kagan.core.enums import SessionEventType
 from kagan.core.errors import (
     InsightError,
@@ -192,7 +195,7 @@ async def _run_get(task_id: str, ctx: Context) -> dict[str, Any]:
     When a session exists, also returns context window usage fields:
     context_window_used, context_window_size, usage_ratio, needs_compaction.
     """
-    from kagan.core._compaction import COMPACTION_THRESHOLD, ContextCompactor
+    from kagan.core import COMPACTION_THRESHOLD, ContextCompactor
 
     app = get_context(ctx)
     task = await app.client.tasks.get(task_id)

--- a/src/kagan/server/mcp/toolsets/tasks.py
+++ b/src/kagan/server/mcp/toolsets/tasks.py
@@ -54,10 +54,10 @@ async def _task_to_dict(task: Any, engine: Any) -> dict[str, Any]:
     """
     from sqlmodel import select as _select
 
-    from kagan.core import _db_async, is_review_approved
+    from kagan.core import db_async, is_review_approved
     from kagan.core.models import AcceptanceCriterion as _AC
 
-    criteria = await _db_async(
+    criteria = await db_async(
         engine,
         lambda s: [
             c.text

--- a/src/kagan/server/mcp/toolsets/tasks.py
+++ b/src/kagan/server/mcp/toolsets/tasks.py
@@ -12,8 +12,7 @@ import pydantic
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
 
-from kagan.core import Priority, TaskStatus, parse_priority
-from kagan.core._io.tasks import TaskCreateRequest
+from kagan.core import Priority, TaskCreateRequest, TaskStatus, parse_priority
 from kagan.core.errors import KaganError, ValidationError
 from kagan.server.mcp._policy import is_tool_allowed
 from kagan.server.mcp.server import ServerOptions, get_context
@@ -55,8 +54,7 @@ async def _task_to_dict(task: Any, engine: Any) -> dict[str, Any]:
     """
     from sqlmodel import select as _select
 
-    from kagan.core._db_helpers import _db_async
-    from kagan.core._reviews import is_review_approved
+    from kagan.core import _db_async, is_review_approved
     from kagan.core.models import AcceptanceCriterion as _AC
 
     criteria = await _db_async(
@@ -287,9 +285,7 @@ async def _task_create(
             continue
         try:
             # Validate via shared model — enforces same constraints as REST surface.
-            req = TaskCreateRequest.model_validate(
-                {**raw_entry, "title": entry_title}
-            )
+            req = TaskCreateRequest.model_validate({**raw_entry, "title": entry_title})
             pri = parse_priority(req.priority)
             # MCP applies a project-level default_repo_id when the caller omits repo_id.
             # REST callers never receive this fallback — they must supply repo_id explicitly

--- a/src/kagan/server/requests.py
+++ b/src/kagan/server/requests.py
@@ -13,9 +13,13 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field, field_validator
 
-from kagan.core._io.projects import ProjectCreateRequest, RepoAddRequest
-from kagan.core._io.reviews import ReviewDecideRequest
-from kagan.core._io.tasks import TaskCreateRequest, TaskUpdateRequest
+from kagan.core import (
+    ProjectCreateRequest,
+    RepoAddRequest,
+    ReviewDecideRequest,
+    TaskCreateRequest,
+    TaskUpdateRequest,
+)
 
 # Re-export under the legacy names used by route imports.
 CreateTaskRequest = TaskCreateRequest

--- a/src/kagan/server/server.py
+++ b/src/kagan/server/server.py
@@ -170,8 +170,11 @@ async def serve_http(
     mcp = create_api_server(opts)
 
     # Initialise KaganCore for REST API routes.
-    from kagan.core import KaganCore, install_asyncio_subprocess_exception_filter
-    from kagan.core._orphan_reap import reap_orphan_sessions
+    from kagan.core import (
+        KaganCore,
+        install_asyncio_subprocess_exception_filter,
+        reap_orphan_sessions,
+    )
 
     install_asyncio_subprocess_exception_filter()
     client = KaganCore(db_path=opts.mcp_opts.db_path)

--- a/src/kagan/tui/orchestrator_sessions.py
+++ b/src/kagan/tui/orchestrator_sessions.py
@@ -2,12 +2,13 @@ import asyncio
 from collections.abc import Sequence
 from typing import Any
 
-from kagan.cli.chat._session_picker import (
+from kagan.cli.chat import (
     ChatSessionListItem,
     build_chat_session_list_items,
     chat_session_to_legacy_dict,
+    ensure_session_title,
+    is_default_title,
 )
-from kagan.cli.chat._title import ensure_session_title, is_default_title
 from kagan.core.enums import SessionKind
 
 _TUI_ORCHESTRATOR_SOURCE = "tui-orchestrator"

--- a/src/kagan/tui/screens/analytics.py
+++ b/src/kagan/tui/screens/analytics.py
@@ -11,7 +11,7 @@ from textual.containers import VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Footer, Static
 
-from kagan.core._formatting import format_duration, format_percentage
+from kagan.core import format_duration, format_percentage
 from kagan.tui.keybindings import ANALYTICS_BINDINGS
 
 if TYPE_CHECKING:

--- a/src/kagan/tui/screens/doctor_modal.py
+++ b/src/kagan/tui/screens/doctor_modal.py
@@ -25,8 +25,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Footer, Label, Static
 
 from kagan.cli.doctor import DoctorCheck, run_doctor_check_for_backend, run_doctor_checks
-from kagan.core._analytics import emit_telemetry
-from kagan.core._settings import set_settings
+from kagan.core import emit_telemetry, set_settings
 from kagan.core.enums import SessionEventType
 from kagan.tui.keybindings import CHECK_ROW_BINDINGS, DOCTOR_MODAL_BINDINGS
 

--- a/src/kagan/tui/screens/kanban.py
+++ b/src/kagan/tui/screens/kanban.py
@@ -13,8 +13,7 @@ from textual.screen import Screen
 from textual.widgets import Input, Select, Static, TextArea
 
 from kagan.cli.chat import resolve_default_agent_backend, warm_orchestrator_backend
-from kagan.core import resolve_launcher
-from kagan.core._subprocess import resolve_spawn_command
+from kagan.core import resolve_launcher, resolve_spawn_command
 from kagan.core.enums import ChatMode, Priority, SessionKind, TaskStatus
 from kagan.core.errors import KaganError
 from kagan.core.models import Task, Worktree

--- a/src/kagan/tui/screens/session_dashboard.py
+++ b/src/kagan/tui/screens/session_dashboard.py
@@ -10,8 +10,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Input, Label, Select, Static
 
 from kagan.cli.chat import resolve_default_agent_backend
-from kagan.core import git
-from kagan.core._subprocess import resolve_spawn_command
+from kagan.core import git, resolve_spawn_command
 from kagan.core.enums import ChatMode, SessionEventType, SessionKind, SessionStatus
 from kagan.core.errors import KaganError, NotFoundError, SessionError, WorktreeError
 from kagan.core.models import Session

--- a/src/kagan/tui/screens/session_resume_modal.py
+++ b/src/kagan/tui/screens/session_resume_modal.py
@@ -9,10 +9,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Footer, OptionList, Static
 from textual.widgets.option_list import Option
 
-from kagan.cli.chat._session_picker import (
-    build_chat_session_list_items,
-    chat_session_to_legacy_dict,
-)
+from kagan.cli.chat import build_chat_session_list_items, chat_session_to_legacy_dict
 from kagan.core.errors import KaganError
 
 if TYPE_CHECKING:

--- a/src/kagan/tui/screens/task_screen.py
+++ b/src/kagan/tui/screens/task_screen.py
@@ -859,7 +859,7 @@ class TaskScreen(Screen[None]):
             ):
                 self._replay_count += 1
                 if self._oldest_event_ts is None and event.created_at:
-                    from kagan.core._utils import utc_iso
+                    from kagan.core import utc_iso
 
                     self._oldest_event_ts = utc_iso(event.created_at)
                 if self._replay_count == TASK_SCREEN_REPLAY_EVENT_LIMIT:
@@ -943,7 +943,7 @@ class TaskScreen(Screen[None]):
             return
 
         if older_events[0].created_at:
-            from kagan.core._utils import utc_iso
+            from kagan.core import utc_iso
 
             self._oldest_event_ts = utc_iso(older_events[0].created_at) or self._oldest_event_ts
 

--- a/src/kagan/tui/screens/workspace.py
+++ b/src/kagan/tui/screens/workspace.py
@@ -10,8 +10,11 @@ from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Input, OptionList, Static
 
-from kagan.cli.chat import resolve_default_agent_backend, warm_orchestrator_backend
-from kagan.cli.chat._session_picker import ChatSessionListItem
+from kagan.cli.chat import (
+    ChatSessionListItem,
+    resolve_default_agent_backend,
+    warm_orchestrator_backend,
+)
 from kagan.core.enums import SessionKind, TaskStatus
 from kagan.core.errors import KaganError
 from kagan.tui._chat_helpers import TitleGenerationSession, kick_title_generation

--- a/src/kagan/tui/terminals/installer.py
+++ b/src/kagan/tui/terminals/installer.py
@@ -4,7 +4,7 @@ import asyncio
 import platform
 import shutil
 
-from kagan.core._attached_backends import (
+from kagan.core import (
     attached_terminal_backend_executable,
     attached_terminal_backend_fallback_order,
 )

--- a/src/kagan/tui/widgets/chat.py
+++ b/src/kagan/tui/widgets/chat.py
@@ -1056,7 +1056,7 @@ class ChatPanel(Vertical):
 
     async def _delete_chat_session(self, query: str) -> None:
         """Delete a chat session by number or id."""
-        from kagan.cli.chat._session_picker import (
+        from kagan.cli.chat import (
             build_chat_session_list_items,
             chat_session_to_legacy_dict,
             resolve_chat_session_selector,

--- a/tests/core/test_chat_lifecycle.py
+++ b/tests/core/test_chat_lifecycle.py
@@ -16,10 +16,7 @@ from typing import Any
 import pytest
 
 from kagan.core.chat import (
-    AssistantMessagePersisted,
-    TurnCancelled,
     TurnDone,
-    TurnError,
     TurnInProgressError,
     TurnStarted,
 )

--- a/tests/core/test_cli_surface.py
+++ b/tests/core/test_cli_surface.py
@@ -495,7 +495,10 @@ def test_web_ctrl_c_exits_cleanly(monkeypatch, tmp_path: Path) -> None:
         coro.close()
         raise KeyboardInterrupt
 
-    monkeypatch.setattr("kagan.server._web_ui.has_web_bundle", lambda: True)
+    # CLI does `from kagan.server import has_web_bundle` (public re-export
+    # since R4); patch the bound name in the consumer module.
+    monkeypatch.setattr("kagan.cli.web.has_web_bundle", lambda: True, raising=False)
+    monkeypatch.setattr("kagan.server.has_web_bundle", lambda: True)
     monkeypatch.setattr("kagan.cli.web._is_server_running", lambda *_args, **_kwargs: False)
     monkeypatch.setattr("kagan.cli.web.run_async", _raise_keyboard_interrupt)
 

--- a/tests/core/unit/test_doctor_telemetry.py
+++ b/tests/core/unit/test_doctor_telemetry.py
@@ -1,7 +1,7 @@
 """Unit tests for doctor --json flag, category field, and telemetry events.
 
 Covers:
-- DoctorCheck.category field assignment and _derive_category
+- DoctorCheck.category field assignment and derive_check_category
 - --json flag serialization (all six fields present, valid JSON)
 - _emit_doctor_warned_telemetry payload shape
 - first_session_success guard (fires once, not twice)
@@ -23,12 +23,10 @@ from sqlmodel import SQLModel, create_engine
 
 from kagan.cli.doctor import (
     DoctorCheck,
-    _derive_category,
     _emit_doctor_warned_telemetry,
     _emit_json,
 )
-from kagan.core._analytics import Analytics, emit_telemetry
-from kagan.core._db_helpers import _db_sync
+from kagan.core import Analytics, _db_sync, derive_check_category, emit_telemetry
 from kagan.core.enums import SessionEventType
 from kagan.core.models import Project, Session
 
@@ -67,22 +65,22 @@ def _make_check(
 # ── category field tests ──────────────────────────────────────────────
 
 
-def test_derive_category_core_checks() -> None:
+def testderive_check_category_core_checks() -> None:
     for name in ("git", "tmux", "db"):
-        assert _derive_category(name) == "core", f"Expected 'core' for '{name}'"
+        assert derive_check_category(name) == "core", f"Expected 'core' for '{name}'"
 
 
-def test_derive_category_backend() -> None:
-    assert _derive_category("agent backend") == "backend"
+def testderive_check_category_backend() -> None:
+    assert derive_check_category("agent backend") == "backend"
 
 
-def test_derive_category_environment() -> None:
+def testderive_check_category_environment() -> None:
     for name in ("ide", "terminal multiplexer", "project config", "startup env"):
-        assert _derive_category(name) == "environment", f"Expected 'environment' for '{name}'"
+        assert derive_check_category(name) == "environment", f"Expected 'environment' for '{name}'"
 
 
-def test_derive_category_unknown_becomes_integration() -> None:
-    assert _derive_category("some custom integration check") == "integration"
+def testderive_check_category_unknown_becomes_integration() -> None:
+    assert derive_check_category("some custom integration check") == "integration"
 
 
 def test_doctor_check_has_category_field() -> None:

--- a/tests/core/unit/test_doctor_telemetry.py
+++ b/tests/core/unit/test_doctor_telemetry.py
@@ -26,7 +26,7 @@ from kagan.cli.doctor import (
     _emit_doctor_warned_telemetry,
     _emit_json,
 )
-from kagan.core import Analytics, _db_sync, derive_check_category, emit_telemetry
+from kagan.core import Analytics, db_sync, derive_check_category, emit_telemetry
 from kagan.core.enums import SessionEventType
 from kagan.core.models import Project, Session
 
@@ -65,21 +65,21 @@ def _make_check(
 # ── category field tests ──────────────────────────────────────────────
 
 
-def testderive_check_category_core_checks() -> None:
+def test_derive_check_category_core_checks() -> None:
     for name in ("git", "tmux", "db"):
         assert derive_check_category(name) == "core", f"Expected 'core' for '{name}'"
 
 
-def testderive_check_category_backend() -> None:
+def test_derive_check_category_backend() -> None:
     assert derive_check_category("agent backend") == "backend"
 
 
-def testderive_check_category_environment() -> None:
+def test_derive_check_category_environment() -> None:
     for name in ("ide", "terminal multiplexer", "project config", "startup env"):
         assert derive_check_category(name) == "environment", f"Expected 'environment' for '{name}'"
 
 
-def testderive_check_category_unknown_becomes_integration() -> None:
+def test_derive_check_category_unknown_becomes_integration() -> None:
     assert derive_check_category("some custom integration check") == "integration"
 
 
@@ -272,7 +272,7 @@ async def test_first_session_success_fires_on_first_completion(tmp_path: Path) -
         s.refresh(session_obj)
         return session_obj.id
 
-    session_id = _db_sync(engine, setup, commit=False)
+    session_id = db_sync(engine, setup, commit=False)
 
     emitted: list[dict[str, Any]] = []
 
@@ -329,7 +329,7 @@ async def test_first_session_success_does_not_fire_on_subsequent_completion(
         s.refresh(new_sess)
         return new_sess.id
 
-    new_session_id = _db_sync(engine, setup, commit=False)
+    new_session_id = db_sync(engine, setup, commit=False)
 
     emitted: list[dict[str, Any]] = []
 

--- a/tests/server/test_access_control.py
+++ b/tests/server/test_access_control.py
@@ -134,7 +134,7 @@ async def test_review_decide_returns_structured_manual_review_block(
     monkeypatch.setattr(server_helpers, "get_server_context", lambda _mcp: fake_ctx)
     # Stub _db_async so the criteria lookup returns an empty list (no criteria → blocked)
     monkeypatch.setattr(
-        "kagan.server._task_routes._db_async",
+        "kagan.server._task_routes.db_async",
         lambda _engine, _fn: asyncio.sleep(0, result=[]),
     )
 

--- a/tests/server/test_chat_sse.py
+++ b/tests/server/test_chat_sse.py
@@ -112,7 +112,7 @@ def test_chat_event_to_sse_frame_mapping() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_sse_stream_broadcasts_to_watch_subscribers(tmp_path: "Path") -> None:
+async def test_sse_stream_broadcasts_to_watch_subscribers(tmp_path: Path) -> None:
     """Events yielded by _sse_stream are also pushed to /watch subscribers."""
     from kagan.core import KaganCore
     from kagan.server import _chat_routes
@@ -165,7 +165,7 @@ async def test_sse_stream_broadcasts_to_watch_subscribers(tmp_path: "Path") -> N
 # ---------------------------------------------------------------------------
 
 
-async def test_interrupt_emits_chat_turn_terminated_exactly_once(tmp_path: "Path") -> None:
+async def test_interrupt_emits_chat_turn_terminated_exactly_once(tmp_path: Path) -> None:
     """/interrupt during an active stream must emit CHAT_TURN_TERMINATED once."""
     from kagan.core import KaganCore
     from kagan.server import _chat_routes
@@ -228,7 +228,7 @@ async def test_interrupt_emits_chat_turn_terminated_exactly_once(tmp_path: "Path
 
 
 async def test_concurrent_stream_emits_chat_error_without_orphan_user_row(
-    tmp_path: "Path",
+    tmp_path: Path,
 ) -> None:
     """Second /stream for the same session emits CHAT_ERROR; no orphan user row."""
     from kagan.core import KaganCore

--- a/tests/unit/test_chat_commands.py
+++ b/tests/unit/test_chat_commands.py
@@ -15,13 +15,13 @@ from kagan.cli.chat.controller import (
     _bootstrap_noninteractive_message,
     _bootstrap_repository_status,
 )
+from kagan.core import BackendSpec
 from kagan.core.chat.sessions import (
     clean_generated_title as _clean_generated_title,
 )
 from kagan.core.chat.sessions import (
     format_relative_time as _format_relative_time,
 )
-from kagan.core import AgentError, BackendSpec
 
 pytestmark = [pytest.mark.unit]
 

--- a/tests/unit/test_chat_controller_streaming.py
+++ b/tests/unit/test_chat_controller_streaming.py
@@ -19,7 +19,6 @@ import kagan.cli.chat._permission_ui as chat_acp_module
 from kagan.cli.chat._permission_ui import PermissionUI
 from kagan.cli.chat._renderer import CLIRenderer
 from kagan.core.chat.events import (
-    AssistantChunk,
     PermissionRequest,
     ToolCallStart,
 )

--- a/uv.lock
+++ b/uv.lock
@@ -832,7 +832,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "import-linter", specifier = ">=2.1" },
     { name = "import-linter", specifier = ">=2.11" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.7.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,75 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882, upload-time = "2025-12-10T17:55:01.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/d6/a35ff62f35aa5fd148053506eddd7a8f2f6afaed31870dc608dd0eb38e4f/grimp-3.14-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ffabc6940301214753bad89ec0bfe275892fa1f64b999e9a101f6cebfc777133", size = 2178573, upload-time = "2025-12-10T17:53:42.836Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/bd2e80273da4d46110969fc62252e5372e0249feb872bc7fe76fdc7f1818/grimp-3.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:075d9a1c78d607792d0ed8d4d3d7754a621ef04c8a95eaebf634930dc9232bb2", size = 2110452, upload-time = "2025-12-10T17:53:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c3/7307249c657d34dca9d250d73ba027d6cfe15a98fb3119b6e5210bc388b7/grimp-3.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ff52addeb20955a4d6aa097bee910573ffc9ef0d3c8a860844f267ad958156", size = 2283064, upload-time = "2025-12-10T17:52:07.673Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d2/cae4cf32dc8d4188837cc4ab183300d655f898969b0f169e240f3b7c25be/grimp-3.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d10e0663e961fcbe8d0f54608854af31f911f164c96a44112d5173050132701f", size = 2235893, upload-time = "2025-12-10T17:52:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/3f58bc3064fc305dac107d08003ba65713a5bc89a6d327f1c06b30cce752/grimp-3.14-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ab874d7ddddc7a1291259cf7c31a4e7b5c612e9da2e24c67c0eb1a44a624e67", size = 2393376, upload-time = "2025-12-10T17:53:02.397Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b8/f476f30edf114f04cb58e8ae162cb4daf52bda0ab01919f3b5b7edb98430/grimp-3.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54fec672ec83355636a852177f5a470c964bede0f6730f9ba3c7b5c8419c9eab", size = 2571342, upload-time = "2025-12-10T17:52:35.214Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ae/2e44d3c4f591f95f86322a8f4dbb5aac17001d49e079f3a80e07e7caaf09/grimp-3.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9e221b5e8070a916c780e88c877fee2a61c95a76a76a2a076396e459511b0bb", size = 2359022, upload-time = "2025-12-10T17:52:49.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ac/42b4d6bc0ea119ce2e91e1788feabf32c5433e9617dbb495c2a3d0dc7f12/grimp-3.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea6b495f9b4a8d82f5ce544921e76d0d12017f5d1ac3a3bd2f5ac88ab055b1c", size = 2309424, upload-time = "2025-12-10T17:53:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/6a731989625c1790f4da7602dcbf9d6525512264e853cda77b3b3602d5e0/grimp-3.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:655e8d3f79cd99bb859e09c9dd633515150e9d850879ca71417d5ac31809b745", size = 2462754, upload-time = "2025-12-10T17:53:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4d/3d1571c0a39a59dd68be4835f766da64fe64cbab0d69426210b716a8bdf0/grimp-3.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a14f10b1b71c6c37647a76e6a49c226509648107abc0f48c1e3ecd158ba05531", size = 2501356, upload-time = "2025-12-10T17:54:06.014Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/8950b8229095ebda5c54c8784e4d1f0a6e19423f2847289ef9751f878798/grimp-3.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:81685111ee24d3e25f8ed9e77ed00b92b58b2414e1a1c2937236026900972744", size = 2504631, upload-time = "2025-12-10T17:54:34.441Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/23bed3da9206138d36d01890b656c7fb7adfb3a37daac8842d84d8777ade/grimp-3.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce8352a8ea0e27b143136ea086582fc6653419aa8a7c15e28ed08c898c42b185", size = 2514751, upload-time = "2025-12-10T17:54:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/6f1f55c97ee982f133ec5ccb22fc99bf5335aee70c208f4fb86cd833b8d5/grimp-3.14-cp312-cp312-win32.whl", hash = "sha256:3fc0f98b3c60d88e9ffa08faff3200f36604930972f8b29155f323b76ea25a06", size = 1875041, upload-time = "2025-12-10T17:55:13.326Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/03ba01288e2a41a948bc8526f32c2eeaddd683ed34be1b895e31658d5a4c/grimp-3.14-cp312-cp312-win_amd64.whl", hash = "sha256:6bca77d1d50c8dc402c96af21f4e28e2f1e9938eeabd7417592a22bd83cde3c3", size = 2013868, upload-time = "2025-12-10T17:55:05.907Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bd/d12a9c821b79ba31fc52243e564712b64140fc6d011c2bdbb483d9092a12/grimp-3.14-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af8a625554beea84530b98cc471902155b5fc042b42dc47ec846fa3e32b0c615", size = 2178632, upload-time = "2025-12-10T17:53:44.55Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8c/d6620dbc245149d5a5a7a9342733556ba91a672f358259c0ab31d889b56b/grimp-3.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0dd1942ffb419ad342f76b0c3d3d2d7f312b264ddc578179d13ce8d5acec1167", size = 2110288, upload-time = "2025-12-10T17:53:21.662Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9d/ea51edc4eb295c99786040051c66466bfa235fd1def9f592057b36e03d0f/grimp-3.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537f784ce9b4acf8657f0b9714ab69a6c72ffa752eccc38a5a85506103b1a194", size = 2282197, upload-time = "2025-12-10T17:52:09.304Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6e/7db27818ced6a797f976ca55d981a3af5c12aec6aeda12d63965847cd028/grimp-3.14-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:78ab18c08770aa005bef67b873bc3946d33f65727e9f3e508155093db5fa57d6", size = 2235720, upload-time = "2025-12-10T17:52:21.806Z" },
+    { url = "https://files.pythonhosted.org/packages/37/26/0e3bbae4826bd6eaabf404738400414071e73ddb1e65bf487dcce17858c4/grimp-3.14-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28ca58728c27e7292c99f964e6ece9295c2f9cfdefc37c18dea0679c783ffb6f", size = 2393023, upload-time = "2025-12-10T17:53:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f2/7da91db5703da34c7ef4c7cddcbb1a8fc30cd85fe54756eba942c6fb27d8/grimp-3.14-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9b5577de29c6c5ae6e08d4ca0ac361b45dba323aa145796e6b320a6ea35414b7", size = 2571108, upload-time = "2025-12-10T17:52:36.523Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5e/4d6278f18032c7208696edf8be24a4b5f7fad80acc20ffca737344bcecb5/grimp-3.14-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d7d1f9f42306f455abcec34db877e4887ff15f2777a43491f7ccbd6936c449b", size = 2358531, upload-time = "2025-12-10T17:52:50.521Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fb/231c32493161ac82f27af6a56965daefa0ec6030fdaf5b948ddd5d68d000/grimp-3.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39bd5c9b7cef59ee30a05535e9cb4cbf45a3c503f22edce34d0aa79362a311a9", size = 2308831, upload-time = "2025-12-10T17:53:12.587Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/f6db325bf5efbbebc9c85cad0af865e821a12a0ba58ee309e938cbd5fedf/grimp-3.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fec3116b4f780a1bc54176b19e6b9f2e36e2ef3164b8fc840660566af35df88", size = 2462138, upload-time = "2025-12-10T17:53:52.403Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/cc3fe29cf07f70364018086840c228a190539ab8105147e34588db590792/grimp-3.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0233a35a5bbb23688d63e1736b54415fa9994ace8dfeb7de8514ed9dee212968", size = 2501393, upload-time = "2025-12-10T17:54:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/eb/54cada9a726455148da23f64577b5cd164164d23a6449e3fa14551157356/grimp-3.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e46b2fef0f1da7e7e2f8129eb93c7e79db716ff7810140a22ce5504e10ed86df", size = 2504514, upload-time = "2025-12-10T17:54:36.34Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/e6afe4f0652df07e8762f61899d1202b73c22c559c804d0a09e5aab2ff17/grimp-3.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3e6d9b50623ee1c3d2a1927ec3f5d408995ea1f92f3e91ed996c908bb40e856f", size = 2514018, upload-time = "2025-12-10T17:54:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/2b8550acc1f010301f02c4fe9664810929fd9277cd032ab608b8534a96fb/grimp-3.14-cp313-cp313-win32.whl", hash = "sha256:fd57c56f5833c99320ec77e8ba5508d56f6fb48ec8032a942f7931cc6ebb80ce", size = 1874922, upload-time = "2025-12-10T17:55:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c7/bc9db5a54ef22972cd17d15ad80a8fee274a471bd3f02300405702d29ea5/grimp-3.14-cp313-cp313-win_amd64.whl", hash = "sha256:173307cf881a126fe5120b7bbec7d54384002e3c83dcd8c4df6ce7f0fee07c53", size = 2013705, upload-time = "2025-12-10T17:55:07.488Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7e/02710bf5e50997168c84ac622b10dd41d35515efd0c67549945ad20996a0/grimp-3.14-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe29f8f13fbd7c314908ed535183a36e6db71839355b04869b27f23c58fa082", size = 2281868, upload-time = "2025-12-10T17:52:10.589Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/2e440c6762cc78bd50582e1b092357d2255f0852ccc6218d8db25170ab31/grimp-3.14-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073d285b00100153fd86064c7726bb1b6d610df1356d33bb42d3fd8809cb6e72", size = 2230917, upload-time = "2025-12-10T17:52:23.212Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bb/2e7dce129b88f07fc525fe5c97f28cfb7ed7b62c59386d39226b4d08969c/grimp-3.14-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6d6efc37e1728bbfcd881b89467be5f7b046292597b3ebe5f8e44e89ea8b6cb", size = 2571371, upload-time = "2025-12-10T17:52:37.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2b/8f1be8294af60c953687db7dec25525d87ed9c2aa26b66dcbe5244abaca2/grimp-3.14-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5337d65d81960b712574c41e85b480d4480bbb5c6f547c94e634f6c60d730889", size = 2356980, upload-time = "2025-12-10T17:52:52.004Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ca/ead91e04b3ddd4774ae74601860ea0f0f21bcf6b970b6769ba9571eb2904/grimp-3.14-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:84a7fea63e352b325daa89b0b7297db411b7f0036f8d710c32f8e5090e1fc3ca", size = 2461540, upload-time = "2025-12-10T17:53:53.749Z" },
+    { url = "https://files.pythonhosted.org/packages/94/aa/f8a085ff73c37d6e6a37de9f58799a3fea9e16badf267aaef6f11c9a53a3/grimp-3.14-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d0b19a3726377165fe1f7184a8af317734d80d32b371b6c5578747867ab53c0b", size = 2497925, upload-time = "2025-12-10T17:54:23.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a3/db3c2d6df07fe74faf5a28fcf3b44fad2831d323ba4a3c2ff66b77a6520c/grimp-3.14-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9caa4991f530750f88474a3f5ecf6ef9f0d064034889d92db00cfb4ecb78aa24", size = 2501794, upload-time = "2025-12-10T17:54:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/095f4e3765e7b60425a41e9fbd2b167f8b0acb957cc88c387f631778a09d/grimp-3.14-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1876efc119b99332a5cc2b08a6bdaada2f0ad94b596f0372a497e2aa8bda4d94", size = 2515203, upload-time = "2025-12-10T17:54:52.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5f/ee02a3a1237282d324f596a50923bf9d2cb1b1230ef2fef49fb4d3563c2c/grimp-3.14-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3ccf03e65864d6bc7bf1c003c319f5330a7627b3677f31143f11691a088464c2", size = 2177150, upload-time = "2025-12-10T17:53:46.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/64/2a92889e5fc78e8ef5c548e6a5c6fed78b817eeb0253aca586c28108393a/grimp-3.14-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9ecd58fa58a270e7523f8bec9e6452f4fdb9c21e4cd370640829f1e43fa87a69", size = 2109280, upload-time = "2025-12-10T17:53:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/5d0b9ab54821e7fbdeb02f3919fa2cb8b9f0c3869fa6e4b969a5766f0ffa/grimp-3.14-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d75d1f8f7944978b39b08d870315174f1ffcd5123be6ccff8ce90467ace648a", size = 2283367, upload-time = "2025-12-10T17:52:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a77c40c92faf7500f42ac019ab8de108b04ffe3db8ec8d6f90416d2322ce/grimp-3.14-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f70bbb1dd6055d08d29e39a78a11c4118c1778b39d17cd8271e18e213524ca7", size = 2237125, upload-time = "2025-12-10T17:52:24.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/3e1483721c83057bff921cf454dd5ff3e661ae1d2e63150a380382d116c2/grimp-3.14-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f21b7c003626c902669dc26ede83a91220cf0a81b51b27128370998c2f247b4", size = 2391735, upload-time = "2025-12-10T17:53:05.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/25fad4a174fe672d42f3e5616761a8120a3b03c8e9e2ae3f31159561968a/grimp-3.14-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80d9f056415c936b45561310296374c4319b5df0003da802c84d2830a103792a", size = 2571388, upload-time = "2025-12-10T17:52:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/456df7f6a765ce3f160eb32a0f64ed0c1c3cd39b518555dde02087f9b6e4/grimp-3.14-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0332963cd63a45863775d4237e59dedf95455e0a1ea50c356be23100c5fc1d7c", size = 2359637, upload-time = "2025-12-10T17:52:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/3e5005ef21a4e2243f0da489aba86aaaff0bc11d5240d67113482cba88e0/grimp-3.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4144350d074f2058fe7c89230a26b34296b161f085b0471a692cb2fe27036f", size = 2308335, upload-time = "2025-12-10T17:53:13.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/03/4e055f756946d6f71ab7e9d1f8536a9e476777093dd7a050f40412d1a2b1/grimp-3.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e148e67975e92f90a8435b1b4c02180b9a3f3d725b7a188ba63793f1b1e445a0", size = 2463680, upload-time = "2025-12-10T17:53:55.507Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b9/3c76b7c2e1587e4303a6eff6587c2117c3a7efe1b100cd13d8a4a5613572/grimp-3.14-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1093f7770cb5f3ca6f99fb152f9c949381cc0b078dfdfe598c8ab99abaccda3b", size = 2502808, upload-time = "2025-12-10T17:54:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/20/80/ada10b85ad3125ebedea10256d9c568b6bf28339d2f79d2d196a7b94f633/grimp-3.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a213f45ec69e9c2b28ffd3ba5ab12cc9859da17083ba4dc39317f2083b618111", size = 2504013, upload-time = "2025-12-10T17:54:39.762Z" },
+    { url = "https://files.pythonhosted.org/packages/05/45/7c369f749d50b0ceac23cd6874ca4695cc1359a96091c7010301e5c8b619/grimp-3.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f003ac3f226d2437a49af0b6036f26edba57f8a32d329275dbde1b2b2a00a56", size = 2515043, upload-time = "2025-12-10T17:54:54.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/85135fe83826ce11ae56a340d32a1391b91eed94d25ce7bc318019f735de/grimp-3.14-cp314-cp314-win32.whl", hash = "sha256:eec81be65a18f4b2af014b1e97296cc9ee20d1115529bf70dd7e06f457eac30b", size = 1877509, upload-time = "2025-12-10T17:55:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/db/61/e4a2234edecb3bb3cff8963bc4ec5cc482a9e3c54f8df0946d7d90003830/grimp-3.14-cp314-cp314-win_amd64.whl", hash = "sha256:cd3bab6164f1d5e313678f0ab4bf45955afe7f5bdb0f2f481014aa9cca7e81ba", size = 2014364, upload-time = "2025-12-10T17:55:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/3d304443fbf1df4d60c09668846d0c8a605c6c95646226e41d8f5c3254da/grimp-3.14-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1df33de479be4d620f69633d1876858a8e64a79c07907d47cf3aaf896af057", size = 2281385, upload-time = "2025-12-10T17:52:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/493e2648dbb83b3fc517ee675e464beb0154551d726053c7982a3138c6a8/grimp-3.14-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07096d4402e9d5a2c59c402ea3d601f4b7f99025f5e32f077468846fc8d3821b", size = 2231470, upload-time = "2025-12-10T17:52:26.104Z" },
+    { url = "https://files.pythonhosted.org/packages/80/84/e772b302385a6b7ec752c88f84ffe35c33d14076245ae27a635aed9c63a2/grimp-3.14-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:712bc28f46b354316af50c469c77953ba3d6cb4166a62b8fb086436a8b05d301", size = 2571579, upload-time = "2025-12-10T17:52:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/5b23aa7b89c5f4f2cfa636cbeaf33e784378a6b0a823d77a3448670dfacc/grimp-3.14-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abe2bbef1cf8e27df636c02f60184319f138dee4f3a949405c21a4b491980397", size = 2356545, upload-time = "2025-12-10T17:52:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/bcf2116f4b1c3939ab35f9cdddd9ca59e953e57e9a0ac0c143deaf9f29cc/grimp-3.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2f9ae3fabb7a7a8468ddc96acc84ecabd84f168e7ca508ee94d8f32ea9bd5de2", size = 2461022, upload-time = "2025-12-10T17:53:56.923Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ce/1a076dce6bc22bca4b9ad5d1bbcd7e1023dcf7bf20ea9404c6462d78f049/grimp-3.14-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:efaf11ea73f7f12d847c54a5d6edcbe919e0369dce2d1aabae6c50792e16f816", size = 2498256, upload-time = "2025-12-10T17:54:27.214Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ea/ac735bed202c1c5c019e611b92d3861779e0cfbe2d20fdb0dec94266d248/grimp-3.14-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e089c9ab8aa755ff5af88c55891727783b4eb6b228e7bdf278e17209d954aa1e", size = 2502056, upload-time = "2025-12-10T17:54:41.537Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8f/774ce522de6a7e70fbeceeaeb6fbe502f5dfb8365728fb3bb4cb23463da8/grimp-3.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a424ad14d5deb56721ac24ab939747f72ab3d378d42e7d1f038317d33b052b77", size = 2515157, upload-time = "2025-12-10T17:54:55.874Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -613,6 +682,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682, upload-time = "2026-03-06T12:11:38.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315, upload-time = "2026-03-06T12:11:36.599Z" },
 ]
 
 [[package]]
@@ -702,6 +786,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "import-linter" },
     { name = "mkdocs" },
     { name = "mkdocs-material", extra = ["imaging"] },
     { name = "mkdocs-redirects" },
@@ -747,6 +832,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "import-linter", specifier = ">=2.1" },
+    { name = "import-linter", specifier = ">=2.11" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.7.0" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ wheels = [
 
 [[package]]
 name = "kagan"
-version = "0.19.0b20"
+version = "0.19.0b22"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Context

R4 of the multi-phase plan. ~30 files in \`kagan.tui\`, \`kagan.server\`, and \`kagan.cli\` were importing from \`kagan.core._*\` private modules. The \`_\` prefix was supposed to be the encapsulation contract; nothing enforced it.

After R1+R2+R3 added a lot of new public surface (\`core.chat.X\`, \`core.client._io\`, etc.), it's time to draw the line.

## What this PR does

Two phase commits:

1. **\`e3c598d\` — phase 4a — promote privates**
   - Audit found **32 distinct cross-package \`_*\` import locations** across 27 source files.
   - All resolved by promoting externally-used symbols to public modules:
     - \`core/__init__.py\` re-exports symbols from 18 private modules (\`_analytics\`, \`_attached_backends\`, \`_backend_selector\`, \`_checkpoints\`, \`_compaction\`, \`_db_helpers\`, \`_environment_checks\`, \`_formatting\`, \`_insights\`, \`_io\`, \`_logging\`, \`_prompt_export\`, \`_subprocess\`, \`_utils\`, \`_verification\`, …).
     - \`core.chat\` exports \`chat_session_to_legacy_dict\` (canonical home).
     - \`server\` exports \`has_web_bundle\`.
     - \`cli.chat\` exports session-picker UI helpers.
   - **No \`__all__\` dogma** — only the import-linter contract enforces, per the refined plan.
   - Underlying \`_*\` files keep their names (rename is a follow-up cleanup once the contract holds).

2. **\`32d9bbc\` — phase 4b — install \`import-linter\`**
   - \`import-linter\` added to dev dependencies.
   - \`[tool.importlinter]\` configures **5 forbidden contracts** banning \`_*\` imports across each top-level package (\`tui\`, \`server\`, \`cli\`, \`mcp\`, \`core\`).
   - \`poe check-boundaries\` runs \`lint-imports\` and is wired into the \`check\` composite task.
   - **Note:** \`import-linter\` doesn't support \`_*\` glob in \`forbidden_modules\`; each private module is listed explicitly. \`allow_indirect_imports = true\` is required because \`core/__init__.py\` is the public re-export layer that itself imports from privates by design.

## Verification

- \`uv run lint-imports\` — **5 contracts kept, 0 broken**
- \`uv run poe lint\` ✅
- \`uv run poe typecheck\` ✅
- \`uv run poe deadcode\` ✅
- \`uv run poe check-guardrails\` ✅
- \`uv run pytest tests/ -m \"not snapshot\"\` — **1538 passed, 5 skipped** (flat vs main)

## Wire format

Untouched. No REST/MCP/SSE/TS shape changes. Pure code-organization refactor.

## Test plan

- [x] \`lint-imports\` passes
- [x] Full Python test suite
- [x] Lint / typecheck / deadcode / guardrails
- [ ] Greptile review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)