### PR TITLE
fix: treat Windows root-relative commands as paths

### DIFF
--- a/src/kagan/core/_subprocess.py
+++ b/src/kagan/core/_subprocess.py
@@ -49,8 +49,11 @@ def resolve_spawn_command(executable: str, *args: str) -> list[str]:
 
     # --- Windows path ---
 
-    # If the caller passed an absolute path, skip which() and inspect suffix.
-    if Path(executable).is_absolute():
+    # If the caller passed an absolute or root-relative path, skip which() and
+    # inspect suffix. On Windows/Python 3.13, pathlib no longer treats
+    # "\foo" or "/foo" as absolute because they lack a drive, but those are
+    # still explicit paths rather than command names.
+    if Path(executable).is_absolute() or executable.startswith(("/", "\\")):
         return _wrap_windows(executable, args)
 
     resolved = shutil.which(executable)


### PR DESCRIPTION
## Summary
- treat Windows root-relative command paths like `/tools/foo.cmd` and `\\tools\\foo.cmd` as explicit paths
- keep skipping `shutil.which()` for those paths so `.cmd`/`.bat` suffix wrapping works

## Why
The main Windows full-suite job failed on Python 3.12/Windows because `Path('/tools/claude.cmd').is_absolute()` is false there, so the resolver called `shutil.which()` despite receiving an explicit path.

## Verification
- `uv run pytest tests/core/unit/test_subprocess_resolve.py -q`
- `uv run poe lint`
- `uv run poe typecheck`
