### PR TITLE
ci: streamline GitHub Actions feedback loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
       - run: uv sync --frozen --dev
       - run: uv run poe lint
       - run: uv run poe check-guardrails
@@ -51,12 +54,15 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
       - run: uv sync --frozen --dev
       - run: uv run poe db-migrations-check
       - run: uv run pytest tests/core/unit/ -m "core and unit" -n auto -q
 
   test-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     needs: [lint, fast-gate]
     timeout-minutes: 15
     runs-on: ${{ matrix.os }}
@@ -67,10 +73,6 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.12"
           - os: ubuntu-latest
-            python-version: "3.13"
-          - os: ubuntu-latest
-            python-version: "3.14"
-          - os: macos-latest
             python-version: "3.14"
     steps:
       - uses: actions/checkout@v6
@@ -84,8 +86,7 @@ jobs:
       - name: Install system dependencies
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y tmux git
+            sudo apt-get update -q && sudo apt-get install -y tmux
           elif [ "$RUNNER_OS" = "macOS" ]; then
             brew install tmux
           fi
@@ -106,8 +107,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.12", "3.13", "3.14"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14"
+          - os: macos-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -120,8 +130,7 @@ jobs:
       - name: Install system dependencies
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y tmux git
+            sudo apt-get update -q && sudo apt-get install -y tmux
           elif [ "$RUNNER_OS" = "macOS" ]; then
             brew install tmux
           fi
@@ -131,22 +140,16 @@ jobs:
           git config --global user.name "Kagan Test"
           git config --global commit.gpgsign false
       - run: uv sync --frozen --dev
-      - name: Test (with coverage)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        run: uv run pytest tests/ -m "not snapshot" -n auto --cov=src/kagan --cov-report=term-missing
       - name: Test
-        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.12'
         run: uv run pytest tests/ -m "not snapshot" -n auto
 
   test-windows:
-    if: github.event_name != 'schedule'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     needs: [lint, fast-gate]
     timeout-minutes: 30
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install system dependencies
-        run: choco install git -y
       - name: Configure git for tests
         run: |
           git config --global user.email "test@kagan.local"
@@ -155,6 +158,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
       - run: uv sync --frozen --dev
       - name: Test (windows compatibility marker)
         run: uv run pytest tests/ -m "windows_ci" -n 0 -v
@@ -175,15 +181,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tmux git
+        run: sudo apt-get update -q && sudo apt-get install -y tmux
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install tmux
-      - name: Install system dependencies (Windows)
-        if: runner.os == 'Windows'
-        run: choco install git -y
       - name: Configure git for tests
         run: |
           git config --global user.email "test@kagan.local"
@@ -192,6 +193,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
       - run: uv sync --frozen --dev
       - name: Snapshot tests
         shell: bash
@@ -209,7 +213,7 @@ jobs:
           uv run pytest tests/tui/smoke/ -n auto -v
 
   test-vscode:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     needs: [fast-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -236,6 +240,7 @@ jobs:
           fi
 
   test-web:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     needs: [lint, fast-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -251,9 +256,18 @@ jobs:
           path: ~/.local/share/pnpm/store
           key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ runner.os }}-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('packages/web/package.json') }}
+          restore-keys: playwright-${{ runner.os }}-
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
       - run: uv sync --frozen --dev
         working-directory: ${{ github.workspace }}
       - run: uv tool install --editable --force .
@@ -285,8 +299,7 @@ jobs:
       - name: Install system dependencies
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y tmux git
+            sudo apt-get update -q && sudo apt-get install -y tmux
           elif [ "$RUNNER_OS" = "macOS" ]; then
             brew install tmux
           fi
@@ -298,6 +311,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            pyproject.toml
       - run: uv sync --frozen --dev
       # Exclude snapshot tests from matrix runs; covered by dedicated job.
       - run: uv run pytest tests/ -m "not snapshot" -n auto


### PR DESCRIPTION
## Summary
- reduce PR test matrix to the highest-signal Linux versions and skip draft PR matrices across expensive PR-only jobs
- remove coverage-only main job because it only printed terminal coverage and had no upload/threshold consumer
- keep CD releases protected with a cheap synchronous smoke gate before semantic-release
- remove redundant Windows git installs
- add missing uv cache dependency keys and cache Playwright browsers with restore fallback

## Verification
- parsed `.github/workflows/ci.yml` and `.github/workflows/cd.yaml` with PyYAML
- `git diff --check`
- previously validated representative jobs with `act`: `lint`, `fast-gate`, `coverage` before coverage job removal

## Release
Commit type is `ci:`, so semantic-release should not publish a beta for this change.
