### PR TITLE
fix(chat): require ACP launchers for backend readiness

### DIFF
--- a/src/kagan/cli/chat/agents.py
+++ b/src/kagan/cli/chat/agents.py
@@ -1,9 +1,12 @@
 """Agent backend listing, selection, and formatting."""
 
+import shutil
 from typing import TypedDict
 
 from kagan.core import (
     AgentError,
+    BackendCapability,
+    BackendSpec,
     get_backend_spec,
     list_available_backends,
     list_backend_specs,
@@ -83,17 +86,48 @@ def format_agent_usage() -> str:
     return "Usage: `/agents`, `/agents name`, or `/agents number`"
 
 
+def _is_chat_backend_available(spec: BackendSpec, *, base_available: bool) -> bool:
+    """Return whether the backend can be launched by chat streaming."""
+    if not base_available:
+        return False
+    if not spec.has_capability(BackendCapability.ACP_STREAMING):
+        return True
+
+    acp_cmd = list(spec.acp_command) or ([spec.executable] if spec.executable else [])
+    return bool(acp_cmd) and shutil.which(acp_cmd[0]) is not None
+
+
 def list_backends_with_availability() -> list[AgentBackendAvailability]:
     availability = list_available_backends()
     specs = list_backend_specs()
     return [
         {
             "name": name,
-            "available": availability.get(name, False),
-            "reference": specs[name].reference,
+            "available": _is_chat_backend_available(
+                spec,
+                base_available=availability.get(name, False),
+            ),
+            "reference": spec.reference,
         }
-        for name in specs
+        for name, spec in specs.items()
     ]
+
+
+def resolve_available_chat_backend(
+    settings: dict[str, str],
+    *,
+    backends: list[AgentBackendAvailability] | None = None,
+) -> str:
+    """Return the configured default, or the first launchable chat backend."""
+    default = resolve_default_agent_backend(settings)
+    resolved_backends = backends if backends is not None else list_backends_with_availability()
+    by_name = {backend["name"]: backend for backend in resolved_backends}
+    if by_name.get(default, {}).get("available") is True:
+        return default
+    for backend in resolved_backends:
+        if backend["available"]:
+            return backend["name"]
+    return default
 
 
 def resolve_default_agent_backend(settings: dict[str, str]) -> str:

--- a/src/kagan/server/_chat_routes.py
+++ b/src/kagan/server/_chat_routes.py
@@ -31,7 +31,6 @@ from kagan.core import (
     AttachmentBody,
     ChatSessionCreateRequest,
     ChatSessionPatchRequest,
-    resolve_default_agent_backend,
 )
 from kagan.core.chat import (
     ChatEvent,
@@ -523,14 +522,17 @@ def _register_crud_routes(mcp: FastMCP) -> None:
     @handle_errors
     async def list_agents(_request: Request, *, ctx: ServerContext) -> JSONResponse:
         """List available agent backends."""
-        from kagan.cli.chat.agents import list_backends_with_availability
+        from kagan.cli.chat.agents import (
+            list_backends_with_availability,
+            resolve_available_chat_backend,
+        )
 
+        backend_availability = list_backends_with_availability()
         backends = [
-            AgentBackendResponse.model_validate(backend)
-            for backend in list_backends_with_availability()
+            AgentBackendResponse.model_validate(backend) for backend in backend_availability
         ]
         settings = await ctx.client.settings.get()
-        default = resolve_default_agent_backend(settings)
+        default = resolve_available_chat_backend(settings, backends=backend_availability)
         return _ok(ChatAgentsResponse(backends=backends, default=default).model_dump(mode="json"))
 
 
@@ -565,7 +567,12 @@ def _register_stream_routes(mcp: FastMCP) -> None:
         if session is None:
             return _err("Session not found", status=404)
         settings = await ctx.client.settings.get()
-        backend = agent_backend or session.agent_backend or resolve_default_agent_backend(settings)
+        if agent_backend or session.agent_backend:
+            backend = agent_backend or session.agent_backend
+        else:
+            from kagan.cli.chat.agents import resolve_available_chat_backend
+
+            backend = resolve_available_chat_backend(settings)
 
         # Pre-flight 409: cheap turn_status read keeps the early-error path
         # fast (no need to start the SSE response just to tear it down).

--- a/tests/unit/test_chat_agents_contract.py
+++ b/tests/unit/test_chat_agents_contract.py
@@ -16,6 +16,7 @@ def test_list_backends_with_availability_includes_reference_metadata(
         "list_available_backends",
         lambda: {"claude-code": True, "codex": False},
     )
+    monkeypatch.setattr(agents_module.shutil, "which", lambda exe: f"/usr/bin/{exe}")
 
     backends = agents_module.list_backends_with_availability()
     selected = {
@@ -40,3 +41,42 @@ def test_list_backends_with_availability_includes_reference_metadata(
         "codex": {"name": "codex", "available": False, "reference": True},
     }
     assert payload["default"] == "claude-code"
+
+
+def test_list_backends_with_availability_requires_acp_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chat availability reflects the ACP command, not just the base CLI."""
+    monkeypatch.setattr(
+        agents_module,
+        "list_available_backends",
+        lambda: {"claude-code": True},
+    )
+    monkeypatch.setattr(
+        agents_module.shutil,
+        "which",
+        lambda exe: "/usr/bin/claude" if exe == "claude" else None,
+    )
+
+    backends = agents_module.list_backends_with_availability()
+    claude = next(backend for backend in backends if backend["name"] == "claude-code")
+
+    assert claude == {"name": "claude-code", "available": False, "reference": True}
+
+
+def test_resolve_available_chat_backend_falls_back_from_unlaunchable_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        agents_module,
+        "list_backends_with_availability",
+        lambda: [
+            {"name": "claude-code", "available": False, "reference": True},
+            {"name": "kimi-cli", "available": True, "reference": False},
+        ],
+    )
+
+    assert (
+        agents_module.resolve_available_chat_backend({"default_agent_backend": "claude-code"})
+        == "kimi-cli"
+    )


### PR DESCRIPTION
## Summary\n- make chat backend availability require the ACP launcher executable, not only the base CLI\n- fall back from an unavailable configured default to the first launchable chat backend for implicit web chat streams\n- add regression tests for the Windows smoke case where claude exists but npx is missing\n\n## Verification\n- uv run pytest tests/unit/test_chat_agents_contract.py -q\n- uv run poe lint\n- uv run poe typecheck\n\n## Windows Smoke Context\nThe Windows VM smoke failed because /api/chat/agents reported claude-code as available while /api/chat/{id}/stream immediately failed with: ACP executable 'npx' not found on PATH.