### PR TITLE
test: make runtime env test platform-explicit

### DIFF
--- a/tests/unit/core/test_runtime_env.py
+++ b/tests/unit/core/test_runtime_env.py
@@ -315,7 +315,7 @@ class TestBuildSanitizedSubprocessEnvironment:
             "SSH_AUTH_SOCK": "/tmp/ssh.sock",
             "GIT_CONFIG_GLOBAL": "/home/user/.gitconfig",
         }
-        result = build_sanitized_subprocess_environment(base_env)
+        result = build_sanitized_subprocess_environment(base_env, platform_name="linux")
         for key in _ESSENTIAL_ENV:
             assert key in result
             assert result[key] == base_env[key]


### PR DESCRIPTION
## Summary\n- pin the POSIX essential-env preservation test to platform_name=linux\n- fixes the Windows CI failure where the test asserted POSIX SSH_AUTH_SOCK while build_sanitized_subprocess_environment correctly selected Windows essentials by default\n\n## Verification\n- uv run pytest tests/unit/core/test_runtime_env.py -q\n- uv run poe lint\n- uv run poe typecheck\n\n## CI context\nMain CI failed only in test-windows: tests/unit/core/test_runtime_env.py::TestBuildSanitizedSubprocessEnvironment::test_preserves_essential_vars.