### PR TITLE
fix(chat): filter ACP stdout noise before parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,42 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.detect.outputs.web }}
+      vscode: ${{ steps.detect.outputs.vscode }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: detect
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "vscode=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA"...HEAD > /tmp/changed-files
+
+          if grep -Eq '^(packages/web/|packages/shared/|src/kagan/server/|src/kagan/wire/|scripts/generate_wire_types\.py|pnpm-lock\.yaml|package\.json|pnpm-workspace\.yaml)' /tmp/changed-files; then
+            echo "web=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "web=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '^(packages/vscode/|packages/shared/|src/kagan/server/responses\.py|src/kagan/wire/|scripts/generate_wire_types\.py|pnpm-lock\.yaml|package\.json|pnpm-workspace\.yaml)' /tmp/changed-files; then
+            echo "vscode=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "vscode=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
@@ -210,8 +246,8 @@ jobs:
           uv run pytest tests/tui/smoke/ -n auto -v
 
   test-vscode:
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
-    needs: [fast-gate]
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && needs.changes.outputs.vscode == 'true'
+    needs: [fast-gate, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -237,8 +273,8 @@ jobs:
           fi
 
   test-web:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-    needs: [lint, fast-gate]
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false && needs.changes.outputs.web == 'true')
+    needs: [lint, fast-gate, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/src/kagan/cli/chat/acp.py
+++ b/src/kagan/cli/chat/acp.py
@@ -37,6 +37,7 @@ from kagan.core import (
     get_backend_spec,
     resolve_orchestrator_prompt,
     resolve_spawn_command,
+    spawn_filtered_agent_process,
 )
 from kagan.core.errors import AgentError
 
@@ -305,10 +306,11 @@ async def run_orchestrator_turn(
     capture_client = _CaptureACPClient(on_update=on_update, permission_resolver=permission_resolver)
     timeout_s = _acp_handshake_timeout_seconds(agent_backend)
     try:
-        async with acp.spawn_agent_process(
+        async with spawn_filtered_agent_process(
             capture_client,
             resolved_cmd[0],
             *resolved_cmd[1:],
+            backend_name=agent_backend,
             cwd=str(resolved_cwd),
             env=env,
             transport_kwargs={"limit": _ACP_STDIO_BUFFER_LIMIT_BYTES},

--- a/src/kagan/core/__init__.py
+++ b/src/kagan/core/__init__.py
@@ -18,6 +18,7 @@ from kagan.core._acp import (
     acp_startup_timeout_seconds,
     friendly_acp_error_message,
 )
+from kagan.core._acp_spawn import spawn_filtered_agent_process
 from kagan.core._agent import (
     CLAUDE_CODE_BACKEND,
     CODEX_BACKEND,
@@ -392,6 +393,7 @@ __all__ = [
     "set_criterion_verdict",
     "set_repo_default_branch",
     "set_settings",
+    "spawn_filtered_agent_process",
     "transition_session",
     "transition_task",
     "utc_iso",

--- a/src/kagan/core/_acp.py
+++ b/src/kagan/core/_acp.py
@@ -474,8 +474,11 @@ async def run_acp_session(
     if process.stdin is None or process.stdout is None:
         raise RuntimeError("ACP process must expose stdin/stdout pipes")
 
-    conn = acp.connect_to_agent(client, process.stdin, process.stdout)
     resolved_backend = backend_name or _infer_backend_name_from_process(process)
+    from kagan.core._acp_streams import JsonRpcObjectStreamReader
+
+    stdout = JsonRpcObjectStreamReader(process.stdout, backend_name=resolved_backend)
+    conn = acp.connect_to_agent(client, process.stdin, stdout)
     timeout_s = _acp_startup_timeout_seconds(resolved_backend)
     try:
         try:

--- a/src/kagan/core/_acp_spawn.py
+++ b/src/kagan/core/_acp_spawn.py
@@ -1,0 +1,44 @@
+"""ACP subprocess spawning helpers."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from acp.client.connection import ClientSideConnection
+from acp.transports import spawn_stdio_transport
+
+from kagan.core._acp_streams import JsonRpcObjectStreamReader
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable, Mapping
+    from pathlib import Path
+
+    import acp
+
+
+@asynccontextmanager
+async def spawn_filtered_agent_process(
+    to_client: Callable[[acp.Agent], acp.Client] | acp.Client,
+    command: str,
+    *args: str,
+    backend_name: str,
+    env: Mapping[str, str] | None = None,
+    cwd: str | Path | None = None,
+    transport_kwargs: Mapping[str, Any] | None = None,
+    **connection_kwargs: Any,
+) -> AsyncIterator[tuple[ClientSideConnection, Any]]:
+    """Spawn an ACP agent with stdout noise filtered before SDK parsing."""
+    async with spawn_stdio_transport(
+        command,
+        *args,
+        env=env,
+        cwd=cwd,
+        **(dict(transport_kwargs) if transport_kwargs else {}),
+    ) as (reader, writer, process):
+        filtered_reader = JsonRpcObjectStreamReader(reader, backend_name=backend_name)
+        conn = ClientSideConnection(to_client, writer, filtered_reader, **connection_kwargs)
+        try:
+            yield conn, process
+        finally:
+            await conn.close()

--- a/src/kagan/core/_acp_streams.py
+++ b/src/kagan/core/_acp_streams.py
@@ -1,0 +1,71 @@
+"""ACP stdio stream guards."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from loguru import logger
+
+
+class JsonRpcObjectStreamReader(asyncio.StreamReader):
+    """Drop non-JSON-RPC stdout lines before the ACP SDK parses them.
+
+    ACP transports are line-delimited JSON-RPC. Some Windows agent launchers can
+    emit terminal/control output on stdout before or between JSON-RPC frames.
+    The upstream ACP SDK logs a full traceback for every such line, so we filter
+    non-object JSON here and leave valid frames untouched.
+    """
+
+    def __init__(self, reader: asyncio.StreamReader, *, backend_name: str) -> None:
+        self._reader = reader
+        self._backend_name = backend_name
+        self._dropped = 0
+
+    async def readline(self) -> bytes:
+        while True:
+            line = await self._reader.readline()
+            if not line:
+                return line
+
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            try:
+                message: Any = json.loads(line)
+            except Exception:
+                self._record_drop(line, reason="non-JSON")
+                continue
+
+            if not isinstance(message, dict):
+                self._record_drop(line, reason=f"JSON {type(message).__name__}")
+                continue
+
+            return line
+
+    def at_eof(self) -> bool:
+        return self._reader.at_eof()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._reader, name)
+
+    def _record_drop(self, line: bytes, *, reason: str) -> None:
+        self._dropped += 1
+        if self._dropped > 1:
+            logger.debug(
+                "Discarding ACP stdout noise from backend={} reason={} count={}",
+                self._backend_name,
+                reason,
+                self._dropped,
+            )
+            return
+
+        preview = line.decode("utf-8", errors="replace").strip().replace("\x1b", "\\x1b")
+        logger.warning(
+            "Discarding ACP stdout noise from backend={} reason={} preview={!r}",
+            self._backend_name,
+            reason,
+            preview[:200],
+        )

--- a/src/kagan/core/chat/_factories.py
+++ b/src/kagan/core/chat/_factories.py
@@ -33,6 +33,7 @@ from acp.schema import (
 )
 from loguru import logger
 
+from kagan.core._acp_spawn import spawn_filtered_agent_process
 from kagan.core.errors import AgentError
 
 if TYPE_CHECKING:
@@ -241,10 +242,11 @@ class LongLivedACPFactory:
 
         try:
             conn, proc = await stack.enter_async_context(
-                acp.spawn_agent_process(
+                spawn_filtered_agent_process(
                     capture,
                     resolved_cmd[0],
                     *resolved_cmd[1:],
+                    backend_name=self.agent_backend,
                     cwd=str(resolved_cwd),
                     env=env,
                     transport_kwargs={"limit": _ACP_STDIO_BUFFER_LIMIT_BYTES},

--- a/tests/core/unit/test_long_lived_acp_factory.py
+++ b/tests/core/unit/test_long_lived_acp_factory.py
@@ -1,6 +1,6 @@
 """Unit tests for ``kagan.core.chat._factories.LongLivedACPFactory``.
 
-Mocks ``acp.spawn_agent_process`` and the ACP-capable-backend lookup so these
+Mocks the ACP spawn helper and the ACP-capable-backend lookup so these
 tests don't actually spawn an orchestrator subprocess. The factory's contract:
 ONE subprocess across many turns; ``restart()`` tears down + respawns; the
 permission resolver round-trips through the long-lived ``_CaptureACPClient``.
@@ -60,7 +60,7 @@ class _FakeConn:
 
 
 class _SpawnRecorder:
-    """Tracks how many times spawn_agent_process is invoked."""
+    """Tracks how many times the ACP spawn helper is invoked."""
 
     def __init__(self) -> None:
         self.count = 0
@@ -116,8 +116,6 @@ def patched_factory(
     monkeypatch.setattr(core_agent_mod, "get_backend_spec", lambda _name: spec)
 
     recorder = _SpawnRecorder()
-    monkeypatch.setattr(cli_chat_acp.acp, "spawn_agent_process", recorder.spawn)
-
     # Stub orchestrator system-prompt resolution so _build_prompt_blocks is fast.
     import kagan.core.chat._factories as factories_mod
 
@@ -135,6 +133,7 @@ def patched_factory(
         lambda _settings, _cwd: "SYSTEM",
         raising=False,
     )
+    monkeypatch.setattr(factories_mod, "spawn_filtered_agent_process", recorder.spawn)
     # The factory imports it lazily inside _build_prompt_blocks. Patch the
     # source module that the lazy import resolves to.
     import kagan.core as core_pkg
@@ -177,7 +176,7 @@ async def test_long_lived_factory_shares_subprocess_across_turns(
             )
             assert result.cancelled is False
 
-    assert recorder.count == 1, "spawn_agent_process must be called once across turns"
+    assert recorder.count == 1, "ACP spawn helper must be called once across turns"
     assert len(recorder.conns[0].prompt_calls) == 2
 
 

--- a/tests/unit/core/test_acp_streams.py
+++ b/tests/unit/core/test_acp_streams.py
@@ -1,0 +1,32 @@
+"""Unit tests for ACP stream guards."""
+
+import asyncio
+
+import pytest
+
+from kagan.core._acp_streams import JsonRpcObjectStreamReader
+
+pytestmark = [pytest.mark.unit]
+
+
+async def test_json_rpc_reader_skips_stdout_noise_before_object() -> None:
+    source = asyncio.StreamReader()
+    source.feed_data(b"\x1b[118;1:3u\n")
+    source.feed_data(b'"terminal noise"\n')
+    source.feed_data(b'{"jsonrpc":"2.0","id":1,"result":{}}\n')
+    source.feed_eof()
+
+    reader = JsonRpcObjectStreamReader(source, backend_name="claude-code")
+
+    assert await reader.readline() == b'{"jsonrpc":"2.0","id":1,"result":{}}\n'
+    assert await reader.readline() == b""
+
+
+async def test_json_rpc_reader_preserves_valid_object_line() -> None:
+    source = asyncio.StreamReader()
+    source.feed_data(b'{"method":"session/update","params":{}}\n')
+    source.feed_eof()
+
+    reader = JsonRpcObjectStreamReader(source, backend_name="claude-code")
+
+    assert await reader.readline() == b'{"method":"session/update","params":{}}\n'

--- a/tests/unit/test_chat_acp_backend_contract.py
+++ b/tests/unit/test_chat_acp_backend_contract.py
@@ -95,7 +95,7 @@ async def test_run_orchestrator_turn_uses_backend_spec_env_vars(
         captured["cwd"] = kwargs["cwd"]
         return _FakeSpawnContext()
 
-    monkeypatch.setattr(chat_acp.acp, "spawn_agent_process", _fake_spawn_agent_process)
+    monkeypatch.setattr(chat_acp, "spawn_filtered_agent_process", _fake_spawn_agent_process)
 
     client = SimpleNamespace(
         active_project_id=None,
@@ -176,8 +176,8 @@ async def test_run_orchestrator_turn_retries_without_mcp_servers_when_backend_re
             return False
 
     monkeypatch.setattr(
-        chat_acp.acp,
-        "spawn_agent_process",
+        chat_acp,
+        "spawn_filtered_agent_process",
         lambda *_args, **_kwargs: _FakeSpawnContext(),
     )
 


### PR DESCRIPTION
## Summary

Fixes Windows ACP JSON-RPC parse spam seen when running `kg web` with ACP-backed chat sessions.

Some Windows agent launchers can emit terminal/control output on stdout before or between JSON-RPC frames. The upstream ACP SDK expects every stdout line to be a JSON-RPC object and logs a traceback for every non-object/non-JSON line. This change wraps ACP stdout at Kagan's transport boundary and drops non-JSON-RPC object lines before they reach the SDK parser.

## Changes

- Add `JsonRpcObjectStreamReader` to filter non-JSON and non-object stdout lines.
- Add `spawn_filtered_agent_process` and use it for CLI chat and long-lived chat ACP factories.
- Wrap direct `run_acp_session` stdout before `acp.connect_to_agent`.
- Add unit tests for escape-sequence and JSON-string stdout noise.

## Validation

- `uv run pytest tests/unit/core/test_acp_streams.py tests/unit/test_chat_acp_backend_contract.py tests/core/unit/test_long_lived_acp_factory.py tests/unit/core/test_chat_engine.py -q`
- `uv run poe lint`
- `uv run poe typecheck`
- `uv run poe check`
