### PR TITLE
fix: limit check workflow push trigger

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,7 @@ name: check
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
Limits the check workflow push trigger to main so PR branch pushes only run the pull_request check.