### PR TITLE
chore: renderer crash fix, option-parsing refactor, CI, and docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,19 @@
+name: lint-workflows
+
+on:
+  push:
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ This rule will be updated after 1.0.0 release for now assume we are in 0.x alpha
   default conditions, to solid's inert server build — a board that renders once and ignores every
   refresh. Tests still need bunfig's `preload = ["@opentui/solid/preload"]` because `bun test` runs
   without the host.
+- In plugin source, use `TuiPluginApi` for renderer dimensions, keyboard input, and keymap layers; never import OpenTUI/Solid context hooks for those surfaces.
 - Behavior changes land with matching `.specs/`, `docs/`, and README updates in the same change.
 
 ## Style and discipline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thanks for helping improve Kagan — an OpenCode plugin that runs your AI coding tasks as a
+kanban board, one git worktree per task.
+
+## What you need
+
+- [OpenCode](https://opencode.ai/) installed.
+- [Bun](https://bun.sh/) installed.
+
+## Get set up
+
+```sh
+bun install      # dependencies
+bun run setup     # one-time: turns on the git hooks that check your work before each commit
+```
+
+## Try your changes locally
+
+```sh
+bun run plugin:install
+```
+
+This installs your local build into OpenCode. Open a project in OpenCode and launch the board to
+see your changes. Run `bun run plugin:reset` to undo it.
+
+## The one command that has to pass
+
+```sh
+bun run check
+```
+
+This runs formatting, linting, type-checking, and the tests — the exact same thing CI runs. If it
+passes, your change is ready. Two helpers:
+
+- `bun run format:fix` — auto-fix formatting before you finish.
+- `bun run test` — just the tests (use this, not a bare `bun test`).
+
+## Commits and pull requests
+
+- Work on a branch, not `main`. Open a pull request when you're ready.
+- Write [conventional commit](https://www.conventionalcommits.org/) messages — releases are cut
+  automatically from them when a change lands on `main`:
+  - `fix:` — a bug fix.
+  - `feat:` — a new feature (may include a breaking change while we're pre-1.0).
+  - `docs:`, `test:`, `chore:`, `ci:`, `build:`, `style:`, `refactor:` — no release.
+
+## Learn the code
+
+- [`AGENTS.md`](AGENTS.md) — how the plugin is built and the rules to follow when changing it.
+- [`.specs/README.md`](.specs/README.md) — how a task moves across the board, read this before
+  changing that behavior.
+- [docs.kagan.sh](https://docs.kagan.sh/) — user-facing docs.
+
+By contributing you agree your work is licensed under the project's [MIT license](LICENSE).

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -1,14 +1,13 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BorderCharacters, Renderable, ScrollBoxRenderable } from "@opentui/core"
-import { useTerminalDimensions } from "@opentui/solid"
-import { createEffect, createMemo, createSignal, For, onMount, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
 import { maybeShowOnboarding } from "./onboarding"
 import { Column } from "./column"
 import { BOARD_BINDINGS, createBoardCommands, footerHints, HelpOverlay, type BoardStore } from "./commands"
-import { COLUMNS, ROUTE, type ColumnType } from "./types"
-import { useBindings } from "@opentui/keymap/solid"
+import { COLUMNS, type ColumnType } from "./types"
 import { version } from "../package.json"
+import { useRendererDimensions } from "./tui-renderer"
 
 // Light │ so the rule stays subordinate to the heavy ┃ state bars on cards.
 const COLUMN_RULE_CHARS: BorderCharacters = {
@@ -141,7 +140,7 @@ const SIDE_BORDER_CHARS: BorderCharacters = {
 // api.ui.toast doesn't render on plugin routes — see the Notice rationale in store.ts.
 function Notice(props: { api: TuiPluginApi; store: BoardStore }) {
   const theme = () => props.api.theme.current
-  const dimensions = useTerminalDimensions()
+  const dimensions = useRendererDimensions(props.api)
 
   return (
     <box position="absolute" top={2} right={2} flexDirection="column" alignItems="flex-end" gap={1} zIndex={2}>
@@ -169,31 +168,31 @@ function Notice(props: { api: TuiPluginApi; store: BoardStore }) {
 }
 
 export function Board(props: { api: TuiPluginApi; store: BoardStore }) {
-  const dimensions = useTerminalDimensions()
   const store = props.store
   const [helpOpen, setHelpOpen] = createSignal(false)
   const commands = createBoardCommands(props.api, store, setHelpOpen)
 
+  let disposeLayer: (() => void) | undefined
+
   onMount(() => {
     maybeShowOnboarding(props.api)
+    disposeLayer = props.api.keymap.registerLayer({
+      mode: "base",
+      priority: 100,
+      commands,
+      bindings: BOARD_BINDINGS.map((binding) => ({
+        key: keymapKey(binding.key),
+        cmd: binding.cmd,
+        desc: binding.desc,
+      })),
+    })
   })
+
+  onCleanup(() => disposeLayer?.())
+
   const hints = createMemo(() => footerHints(store.selectedSession(), store.filter() !== ""))
-
-  useBindings(() => ({
-    // Disable board keys while a modal dialog (new/filter prompt) is open so
-    // typed characters reach the input instead of triggering hotkeys. Board
-    // keys stay active while the inline help overlay is open so ? toggles it
-    // and q closes it. Also disable when the board route is not active so the
-    // layer does not leak into other routes.
-    enabled: () => props.api.route.current.name === ROUTE && !props.api.ui.dialog.open,
-    commands,
-    bindings: BOARD_BINDINGS.flatMap((binding) =>
-      binding.key.split(",").map((key) => ({ ...binding, key: key.trim() })),
-    ),
-  }))
-
   return (
-    <box position="absolute" left={0} top={0} width={dimensions().width} height={dimensions().height}>
+    <box position="absolute" left={0} top={0} width="100%" height="100%">
       <box flexDirection="column" width="100%" height="100%">
         <box flexGrow={1} minHeight={0}>
           <Main
@@ -210,4 +209,11 @@ export function Board(props: { api: TuiPluginApi; store: BoardStore }) {
       <Notice api={props.api} store={store} />
     </box>
   )
+}
+
+function keymapKey(key: string): string | { name: string } {
+  if (key === ",") return { name: "," }
+  if (key === "?") return "?,shift+/"
+  if (key === "return") return "return,enter"
+  return key
 }

--- a/src/commands.tsx
+++ b/src/commands.tsx
@@ -26,7 +26,6 @@ import { openFindingsReviewDialog } from "./findings-review"
 import { isTrustPacket, openTrustPacketView, serializeTrustPacket } from "./trust-packet"
 import type { createBoardStore } from "./store"
 import type { BoardSession } from "./types"
-import { SETTINGS_ROUTE } from "./types"
 
 export type BoardStore = ReturnType<typeof createBoardStore>
 
@@ -276,10 +275,6 @@ export function createBoardCommands(
 
   const showHelp = () => {
     setHelpOpen((open) => !open)
-  }
-
-  const openSettings = () => {
-    api.route.navigate(SETTINGS_ROUTE)
   }
 
   const promptDelete = () => {
@@ -825,10 +820,6 @@ export function createBoardCommands(
       title: "Import trust packet",
       category: "Kagan",
       run: importPacket,
-    },
-    {
-      name: "kagan.settings",
-      run: openSettings,
     },
     {
       name: "kagan.help",

--- a/src/create-task.tsx
+++ b/src/create-task.tsx
@@ -1,12 +1,12 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
-import { useKeyboard } from "@opentui/solid"
 import { TextAttributes, type TextareaRenderable } from "@opentui/core"
 import { createMemo, createSignal, For, onMount, Show } from "solid-js"
 import { createTask, getOrder, setOrder } from "./session-api"
 import { bunGitRunner, listLocalBranches } from "./git"
 import type { ModelRef, TaskScope } from "./task"
 import type { createBoardStore } from "./store"
+import { useKeyIntercept } from "./tui-renderer"
 
 type BoardStore = ReturnType<typeof createBoardStore>
 
@@ -132,31 +132,37 @@ function CreateTaskForm(props: {
     )
   }
 
-  useKeyboard((key) => {
+  useKeyIntercept(props.api, (key) => {
     if (key.ctrl && key.name === "return") {
       void submit()
-      return
+      return true
     }
     if (key.name === "return") {
-      if (focusIndex() === 1) return
+      // In the description textarea, let Enter reach the field as a newline
+      // (ctrl+enter submits); consuming it here would swallow the newline.
+      if (focusIndex() === 1) return false
       if (focusIndex() >= 2) openPicker()
       else void submit()
-      return
+      return true
     }
     if (key.name === "right" && focusIndex() >= 2) {
       openPicker()
-      return
+      return true
     }
     if (key.name === "tab") {
       setFocusIndex((index) => (key.shift ? (index + 4) % 5 : (index + 1) % 5))
-      return
+      return true
     }
-    if (focusIndex() === 1) return
+    if (focusIndex() === 1) return false
     if (key.name === "down") {
       setFocusIndex((index) => (index + 1) % 5)
-      return
+      return true
     }
-    if (key.name === "up") setFocusIndex((index) => (index + 4) % 5)
+    if (key.name === "up") {
+      setFocusIndex((index) => (index + 4) % 5)
+      return true
+    }
+    return false
   })
 
   const labelColor = (index: number) => (focusIndex() === index ? theme().primary : theme().textMuted)
@@ -294,27 +300,31 @@ function ScopePicker(props: {
 
   onMount(() => props.api.ui.dialog.setSize("medium"))
 
-  useKeyboard((key) => {
+  useKeyIntercept(props.api, (key) => {
     if (key.name === "escape") {
       close()
-      return
+      return true
     }
     if (key.name === "down") {
       setIndex((value) => Math.min(value + 1, options().length - 1))
-      return
+      return true
     }
     if (key.name === "up") {
       setIndex((value) => Math.max(value - 1, 0))
-      return
+      return true
     }
     if (key.name === " " || key.name === "space") {
       const scope = options()[index()]
-      if (!scope) return
+      if (!scope) return false
       if (scope === "custom...") openCustomScopePrompt(props.api, props.state, props.reopenScope)
       else toggle(scope)
-      return
+      return true
     }
-    if (key.name === "return") close()
+    if (key.name === "return") {
+      close()
+      return true
+    }
+    return false
   })
 
   return (

--- a/src/findings-review.tsx
+++ b/src/findings-review.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/solid */
 import { TextAttributes } from "@opentui/core"
 import type { TuiPluginApi, TuiThemeCurrent } from "@opencode-ai/plugin/tui"
-import { useKeyboard } from "@opentui/solid"
 import { createSignal, For, onMount, Show } from "solid-js"
 import { resolveSessionFinding } from "./session-api"
 import {
@@ -16,6 +15,7 @@ import {
 import { confidenceBar, formatModeRationale } from "./format"
 import type { createBoardStore } from "./store"
 import type { BoardSession } from "./types"
+import { useKeyIntercept } from "./tui-renderer"
 
 type BoardStore = ReturnType<typeof createBoardStore>
 type Mode = "list" | "detail"
@@ -133,55 +133,60 @@ export function FindingsReview(props: {
     }
   }
 
-  useKeyboard((key) => {
+  useKeyIntercept(props.api, (key) => {
     if (mode() === "list") {
       if (key.name === "escape") {
         close()
-        return
+        return true
       }
       if (key.name === "s") {
         runSendBack()
-        return
+        return true
       }
       if (key.name === "a") {
         runApprove()
-        return
+        return true
       }
-      if (clean()) return
+      if (clean()) return true
       if (key.name === "down" || key.name === "j") {
         setIndex((i) => Math.min(i + 1, findings().length - 1))
-        return
+        return true
       }
       if (key.name === "up" || key.name === "k") {
         setIndex((i) => Math.max(i - 1, 0))
-        return
+        return true
       }
-      if (key.name === "return") openDetail(index())
-      return
+      if (key.name === "return") {
+        openDetail(index())
+        return true
+      }
+      return false
     }
 
     if (key.name === "escape") {
       setError(undefined)
       setMode("list")
-      return
+      return true
     }
     const slots = SLOT_RESOLUTIONS.length
     if (key.name === "tab") {
       setFocus((f) => (key.shift ? (f + slots - 1) % slots : (f + 1) % slots))
-      return
+      return true
     }
     if (key.name === "down") {
       setFocus((f) => (f + 1) % slots)
-      return
+      return true
     }
     if (key.name === "up") {
       setFocus((f) => (f + slots - 1) % slots)
-      return
+      return true
     }
     if (key.name === "return" && focus() > 0) {
       const resolution = SLOT_RESOLUTIONS[focus()]
       if (resolution) void commit(resolution)
+      return true
     }
+    return false
   })
 
   const title = () => {

--- a/src/intake.ts
+++ b/src/intake.ts
@@ -1,4 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import { parseOptions } from "./options"
 import { patchKagan } from "./session-api"
 import type { TaskScope } from "./task"
 
@@ -66,9 +67,8 @@ export async function spawnIntake(
     tools: { read: true, edit: false, write: false, bash: false, kagan_intake: true },
     parts: [{ type: "text", text: promptText }],
   }
-  if (typeof options?.intakeAgent === "string") {
-    body.agent = options.intakeAgent
-  }
+  const intakeAgent = parseOptions(options).intakeAgent
+  if (intakeAgent !== undefined) body.agent = intakeAgent
 
   await input.client.session.promptAsync({
     path: { id: childID },

--- a/src/onboarding.tsx
+++ b/src/onboarding.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { TextAttributes } from "@opentui/core"
-import { useKeyboard } from "@opentui/solid"
 import { createSignal, For, onMount } from "solid-js"
+import { useKeyIntercept } from "./tui-renderer"
 
 const SEEN_KEY = "kagan:onboarding"
 
@@ -52,21 +52,25 @@ export function Onboarding(props: { api: TuiPluginApi }) {
     close()
   }
 
-  useKeyboard((key) => {
+  useKeyIntercept(props.api, (key) => {
     if (key.name === "left" || key.name === "h") {
       setStep((current) => Math.max(0, current - 1))
-      return
+      return true
     }
     if (key.name === "right" || key.name === "l") {
       setStep((current) => Math.min(last, current + 1))
-      return
+      return true
     }
     if (key.name === "return") {
       if (step() === last) close()
       else setStep((current) => current + 1)
-      return
+      return true
     }
-    if (key.name === "x") dismissForever()
+    if (key.name === "x") {
+      dismissForever()
+      return true
+    }
+    return false
   })
 
   return (

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+import { DEFAULT_IN_PROGRESS_CAP } from "./types"
+
+const DEFAULT_HELPER_RETRIES = 1
+const DEFAULT_SEND_BACK_STOP_THRESHOLD = 3
+
+export const OptionsSchema = z.object({
+  inProgressLimit: z.number().int().min(1).catch(DEFAULT_IN_PROGRESS_CAP),
+  helperRetries: z.number().int().min(0).catch(DEFAULT_HELPER_RETRIES),
+  sendBackStopThreshold: z.number().int().min(1).catch(DEFAULT_SEND_BACK_STOP_THRESHOLD),
+  squashMerge: z.boolean().catch(true),
+  intakeAgent: z.string().optional().catch(undefined),
+  validatorAgent: z.string().optional().catch(undefined),
+})
+
+export type Options = z.infer<typeof OptionsSchema>
+
+export function parseOptions(raw?: unknown): Options {
+  return OptionsSchema.parse(typeof raw === "object" && raw !== null ? raw : {})
+}

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -1,13 +1,13 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { TextAttributes } from "@opentui/core"
-import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
 import { For, Show, createMemo, createSignal } from "solid-js"
 import { readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { commandSpec, helperRetries, inProgressCap, sendBackStopThreshold, squashMerge, type ModelRef } from "./task"
 import type { CommandSpec } from "./check"
 import { SETTINGS_ROUTE, ROUTE } from "./types"
+import { useKeyIntercept } from "./tui-renderer"
 
 type Section = "General" | "Agents" | "Commands" | "Validator models" | "JSON preview"
 
@@ -327,48 +327,49 @@ function CommandListEditor(props: {
     setRowIndex(target)
   }
 
-  useKeyboard((key) => {
+  useKeyIntercept(props.api, (key) => {
     if (key.name === "escape") {
       props.api.ui.dialog.clear()
       props.onChange(commands())
-      return
+      return true
     }
     if (key.name === "a") {
       addCommand()
-      return
+      return true
     }
     if (key.name === "d") {
       deleteCommand()
-      return
+      return true
     }
     if (key.shift && (key.name === "up" || key.name === "k")) {
       moveCommand(-1)
-      return
+      return true
     }
     if (key.shift && (key.name === "down" || key.name === "j")) {
       moveCommand(1)
-      return
+      return true
     }
     if (key.name === "up" || key.name === "k") {
       setRowIndex((i) => Math.max(i - 1, 0))
-      return
+      return true
     }
     if (key.name === "down" || key.name === "j") {
       setRowIndex((i) => Math.min(i + 1, commands().length - 1))
-      return
+      return true
     }
     if (key.name === "left" || key.name === "h") {
       setFieldIndex((i) => (i - 1 + fieldCount) % fieldCount)
-      return
+      return true
     }
     if (key.name === "right" || key.name === "l") {
       setFieldIndex((i) => (i + 1) % fieldCount)
-      return
+      return true
     }
     if (key.name === "return") {
       editField()
-      return
+      return true
     }
+    return false
   })
 
   return (
@@ -558,40 +559,41 @@ function ValidatorModelListEditor(props: {
     setRowIndex(Math.min(index, Math.max(next.length - 1, 0)))
   }
 
-  useKeyboard((key) => {
+  useKeyIntercept(props.api, (key) => {
     if (key.name === "escape") {
       props.api.ui.dialog.clear()
       props.onChange(models())
-      return
+      return true
     }
     if (key.name === "a") {
       addModel()
-      return
+      return true
     }
     if (key.name === "d") {
       deleteModel()
-      return
+      return true
     }
     if (key.name === "up" || key.name === "k") {
       setRowIndex((i) => Math.max(i - 1, 0))
-      return
+      return true
     }
     if (key.name === "down" || key.name === "j") {
       setRowIndex((i) => Math.min(i + 1, models().length - 1))
-      return
+      return true
     }
     if (key.name === "left" || key.name === "h") {
       setFieldIndex((i) => (i - 1 + fieldCount) % fieldCount)
-      return
+      return true
     }
     if (key.name === "right" || key.name === "l") {
       setFieldIndex((i) => (i + 1) % fieldCount)
-      return
+      return true
     }
     if (key.name === "return") {
       editField()
-      return
+      return true
     }
+    return false
   })
 
   return (
@@ -743,7 +745,6 @@ function rowsFor(
 }
 
 export function Settings(props: { api: TuiPluginApi; options?: Record<string, unknown> }) {
-  const dimensions = useTerminalDimensions()
   const theme = () => props.api.theme.current
   const [draft, setDraft] = createSignal(draftFromOptions(props.options))
   const [sectionIndex, setSectionIndex] = createSignal(0)
@@ -753,29 +754,29 @@ export function Settings(props: { api: TuiPluginApi; options?: Record<string, un
   const rows = createMemo(() => rowsFor(section(), draft(), setDraft, setMessage, props.api))
   const selectedRow = () => rows()[rowIndex()]
 
-  useKeyboard((key) => {
-    if (props.api.route.current.name !== SETTINGS_ROUTE || props.api.ui.dialog.open) return
+  useKeyIntercept(props.api, (key) => {
+    if (props.api.route.current.name !== SETTINGS_ROUTE || props.api.ui.dialog.open) return false
     if (key.name === "escape" || key.name === "q") {
       props.api.route.navigate(ROUTE)
-      return
+      return true
     }
     if (key.name === "tab" || key.name === "right") {
       setSectionIndex((index) => (index + 1) % SECTIONS.length)
       setRowIndex(0)
-      return
+      return true
     }
     if (key.name === "left") {
       setSectionIndex((index) => (index + SECTIONS.length - 1) % SECTIONS.length)
       setRowIndex(0)
-      return
+      return true
     }
     if (key.name === "down" || key.name === "j") {
       setRowIndex((index) => Math.min(index + 1, rows().length - 1))
-      return
+      return true
     }
     if (key.name === "up" || key.name === "k") {
       setRowIndex((index) => Math.max(index - 1, 0))
-      return
+      return true
     }
     if (key.name === "return" || key.name === "e") {
       try {
@@ -783,17 +784,19 @@ export function Settings(props: { api: TuiPluginApi; options?: Record<string, un
       } catch (error) {
         setMessage(error instanceof Error ? error.message : String(error))
       }
-      return
+      return true
     }
     if (key.name === "s") {
       void saveOptions(props.api.state.path.worktree, draft()).then(setMessage, (error) =>
         setMessage(error instanceof Error ? error.message : String(error)),
       )
+      return true
     }
+    return false
   })
 
   return (
-    <box position="absolute" left={0} top={0} width={dimensions().width} height={dimensions().height} padding={1}>
+    <box position="absolute" left={0} top={0} width="100%" height="100%" padding={1}>
       <box flexDirection="column" width="100%" height="100%" borderColor={theme().border}>
         <box flexDirection="row" justifyContent="space-between" flexShrink={0}>
           <text fg={theme().text} attributes={TextAttributes.BOLD}>

--- a/src/task.ts
+++ b/src/task.ts
@@ -2,32 +2,23 @@ import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2"
 import { z } from "zod"
 import { COLUMNS, DEFAULT_IN_PROGRESS_CAP, type ColumnType } from "./types"
 import { newSideHunkRanges } from "./git"
+import { parseOptions } from "./options"
 import type { CommandSpec } from "./check"
 
 export function inProgressCap(options?: Record<string, unknown>): number {
-  const value = options?.inProgressLimit
-  if (typeof value === "number" && Number.isInteger(value) && value >= 1) return value
-  return DEFAULT_IN_PROGRESS_CAP
+  return parseOptions(options).inProgressLimit
 }
 
-const DEFAULT_HELPER_RETRIES = 1
-const DEFAULT_SEND_BACK_STOP_THRESHOLD = 3
-
 export function helperRetries(options?: Record<string, unknown>): number {
-  const value = options?.helperRetries
-  if (typeof value === "number" && Number.isInteger(value) && value >= 0) return value
-  return DEFAULT_HELPER_RETRIES
+  return parseOptions(options).helperRetries
 }
 
 export function sendBackStopThreshold(options?: Record<string, unknown>): number {
-  const value = options?.sendBackStopThreshold
-  if (typeof value === "number" && Number.isInteger(value) && value >= 1) return value
-  return DEFAULT_SEND_BACK_STOP_THRESHOLD
+  return parseOptions(options).sendBackStopThreshold
 }
 
 export function squashMerge(options?: Record<string, unknown>): boolean {
-  const value = options?.squashMerge
-  return typeof value === "boolean" ? value : true
+  return parseOptions(options).squashMerge
 }
 
 export type TaskScope = { values: string[]; custom?: string }

--- a/src/tui-renderer.tsx
+++ b/src/tui-renderer.tsx
@@ -1,0 +1,30 @@
+import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { KeyInputContext, KeymapEvent } from "@opentui/keymap"
+import { createSignal, onCleanup, onMount } from "solid-js"
+
+type Dimensions = { width: number; height: number }
+
+export function useRendererDimensions(api: TuiPluginApi) {
+  const [dimensions, setDimensions] = createSignal<Dimensions>({
+    width: api.renderer.width,
+    height: api.renderer.height,
+  })
+  const onResize = (width: number, height: number) => setDimensions({ width, height })
+
+  onMount(() => api.renderer.on("resize", onResize))
+  onCleanup(() => api.renderer.off("resize", onResize))
+
+  return dimensions
+}
+
+export function useKeyIntercept(api: TuiPluginApi, handler: (key: KeymapEvent) => boolean) {
+  let dispose: (() => void) | undefined
+  onMount(() => {
+    dispose = api.keymap.intercept("key", (ctx: KeyInputContext) => {
+      if (handler(ctx.event)) {
+        ctx.consume({ preventDefault: true, stopPropagation: true })
+      }
+    })
+  })
+  onCleanup(() => dispose?.())
+}

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,6 +2,7 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2"
 import type { Finding, Intake, ModelRef } from "./task"
 import type { CheckResult } from "./check"
+import { parseOptions } from "./options"
 import { patchKagan } from "./session-api"
 import { orderDiffsByRisk } from "./git"
 
@@ -215,9 +216,8 @@ export async function spawnValidator(
     parts: [{ type: "text", text: promptText }],
   }
   if (model) body.model = { providerID: model.providerID, modelID: model.modelID }
-  if (typeof options?.validatorAgent === "string") {
-    body.agent = options.validatorAgent
-  }
+  const validatorAgent = parseOptions(options).validatorAgent
+  if (validatorAgent !== undefined) body.agent = validatorAgent
 
   await input.client.session.promptAsync({
     path: { id: childID },

--- a/test/board.test.tsx
+++ b/test/board.test.tsx
@@ -1,8 +1,7 @@
 /** @jsxImportSource @opentui/solid */
-import { afterEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import { createRoot } from "solid-js"
-import type { JSX } from "solid-js"
 import type { TuiToast } from "@opencode-ai/plugin/tui"
 import { Board } from "../src/board"
 import { createBoardStore } from "../src/store"
@@ -11,24 +10,18 @@ import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { mockSession, mockTuiApi } from "./fixtures/api"
 import type { TestRendererSetup } from "@opentui/core/testing"
 
-let lastBindings: unknown
+let lastLayer: Parameters<TuiPluginApi["keymap"]["registerLayer"]>[0] | undefined
 
-mock.module("@opentui/keymap/solid", () => ({
-  KeymapProvider: (props: { children: JSX.Element }) => props.children,
-  useBindings: (config: unknown) => {
-    lastBindings = config
-  },
-  useKeymap: () => ({}),
-  useKeymapSelector: () => () => [],
-  reactiveMatcherFromSignal: () => ({ get: () => false, subscribe: () => () => {} }),
-}))
+function keyName(key: string | { name?: string }): string {
+  return typeof key === "string" ? key : (key.name ?? "")
+}
 
 let renderSetup: TestRendererSetup | undefined
 
 afterEach(async () => {
   await renderSetup?.renderer.destroy()
   renderSetup = undefined
-  lastBindings = undefined
+  lastLayer = undefined
 })
 
 function session(id: string, status: ColumnType, title: string): BoardSession {
@@ -70,6 +63,12 @@ function mockBoardApi(
       },
     },
     route: { current: { name: options.routeName ?? ROUTE } },
+    keymap: {
+      registerLayer: (layer: Parameters<TuiPluginApi["keymap"]["registerLayer"]>[0]) => {
+        lastLayer = layer
+        return () => {}
+      },
+    },
     toasts,
     dialogReplaces: 0,
   } as unknown as TuiPluginApi & { toasts: TuiToast[]; dialogReplaces: number }
@@ -92,21 +91,37 @@ describe("Board", () => {
     expect(frame).not.toContain("Kagan")
   })
 
-  test("expands comma-separated bindings before passing them to useBindings", async () => {
-    const api = mockBoardApi()
+  test("dispatches board commands through the registered keymap layer", async () => {
+    const api = mockBoardApi({
+      sessions: [session("s1", "backlog", "First"), session("s2", "backlog", "Second")],
+    })
     const store = createRoot(() => createBoardStore(api))
     await store.refresh()
+    store.select("backlog", "s1")
     renderSetup = await testRender(() => <Board api={api} store={store} />, { width: 120, height: 20 })
     await renderSetup.flush()
-    const config =
-      typeof lastBindings === "function"
-        ? (lastBindings as () => { bindings: { key: string; command: string }[] })()
-        : undefined
-    const keys = config?.bindings.map((binding) => binding.key)
-    expect(keys).toContain("j")
-    expect(keys).toContain("down")
-    expect(keys).toContain("o")
-    expect(keys).toContain("return")
+
+    const commands = new Map(lastLayer?.commands?.map((command) => [command.name, command]))
+
+    commands.get("kagan.down")?.run(undefined as never)
+    await renderSetup.flush()
+    expect(store.selected()).toBe("s2")
+
+    commands.get("kagan.menu")?.run(undefined as never)
+    await renderSetup.flush()
+    expect(api.dialogReplaces).toBe(1)
+
+    commands.get("kagan.help")?.run(undefined as never)
+    await renderSetup.flush()
+    expect(renderSetup.captureCharFrame()).toContain("Help")
+
+    const settingsBinding = lastLayer?.bindings?.find((binding) => binding.cmd === "kagan.settings")
+    expect(settingsBinding).toBeTruthy()
+    expect(keyName(settingsBinding!.key)).toContain(",")
+
+    const filterBinding = lastLayer?.bindings?.find((binding) => binding.cmd === "kagan.filter")
+    expect(filterBinding).toBeTruthy()
+    expect(keyName(filterBinding!.key)).toContain("/")
   })
 
   test("renders the footer's baseline hints when nothing is selected", async () => {
@@ -240,8 +255,7 @@ describe("Board", () => {
     await store.refresh()
     renderSetup = await testRender(() => <Board api={api} store={store} />, { width: 120, height: 20 })
     await renderSetup.flush()
-    const config = typeof lastBindings === "function" ? (lastBindings as () => { enabled: () => boolean })() : undefined
-    expect(config?.enabled()).toBe(true)
+    expect(lastLayer?.commands?.some((command) => command.name === "kagan.help")).toBe(true)
   })
 
   test("opens the onboarding dialog on first mount", async () => {
@@ -328,16 +342,12 @@ describe("Board", () => {
     await store.refresh()
     renderSetup = await testRender(() => <Board api={api} store={store} />, { width: 120, height: 20 })
     await renderSetup.flush()
-    const config =
-      typeof lastBindings === "function"
-        ? (lastBindings as () => { commands: { name: string; run: () => void }[] })()
-        : undefined
-    const help = config?.commands.find((command) => command.name === "kagan.help")
+    const help = lastLayer?.commands?.find((command) => command.name === "kagan.help")
     expect(help).toBeDefined()
-    help?.run()
+    help?.run(undefined as never)
     await renderSetup.waitForVisualIdle()
     expect(renderSetup.captureCharFrame()).toContain("Help")
-    help?.run()
+    help?.run(undefined as never)
     await renderSetup.waitForVisualIdle()
     expect(renderSetup.captureCharFrame()).not.toContain("Help")
   })

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -11,7 +11,7 @@ import type { BoardSession } from "../src/types"
 import type { BoardStore, MergeDialogHandlers } from "../src/commands"
 import { bunGitRunner } from "../src/git"
 import { isTrustPacket, serializeTrustPacket } from "../src/trust-packet"
-import { mockSessionClient, mockTheme, mockTuiApi } from "./fixtures/api"
+import { attachRendererMockInput, mockSessionClient, mockTheme, mockTuiApi } from "./fixtures/api"
 
 const { createBoardCommands, footerHints, menuOptions, mergeChoiceOptions, openMergeDialog } = await import(
   "../src/commands"
@@ -251,14 +251,6 @@ describe("createBoardCommands", () => {
     expect(helpOpen).toBe(true)
     help?.run()
     expect(helpOpen).toBe(false)
-  })
-
-  test("kagan.settings navigates to the settings route", () => {
-    let route = ""
-    const api = { route: { navigate: (name: string) => (route = name) } } as unknown as TuiPluginApi
-    const commands = createBoardCommands(api, {} as BoardStore, () => {})
-    commands.find((command) => command.name === "kagan.settings")?.run()
-    expect(route).toBe("kagan-settings")
   })
 
   test("kagan.close closes the help overlay when it is open instead of navigating", () => {
@@ -646,7 +638,7 @@ describe("createBoardCommands", () => {
       checkCommand: "bun run check",
     })
     let dialogRendered: (() => unknown) | undefined
-    const api = {
+    const api = mockTuiApi({
       theme: {
         current: {
           text: "white",
@@ -666,7 +658,7 @@ describe("createBoardCommands", () => {
           replace: (render: () => unknown) => (dialogRendered = render),
         },
       },
-    } as unknown as TuiPluginApi
+    } as unknown as Partial<TuiPluginApi>)
     await createBoardCommands(api, store, () => {})
       .find((command) => command.name === "kagan.approve")
       ?.run()
@@ -1320,6 +1312,7 @@ describe("createBoardCommands", () => {
       .find((command) => command.name === "kagan.approve")
       ?.run()
     renderSetup = await testRender(renders.at(-1) as () => JSX.Element, { width: 100, height: 24 })
+    attachRendererMockInput(api, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressKey("a")
     await waitFor(() => renders.length === 2)

--- a/test/create-task.test.tsx
+++ b/test/create-task.test.tsx
@@ -4,7 +4,7 @@ import { testRender } from "@opentui/solid"
 import type { TestRendererSetup } from "@opentui/core/testing"
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { JSX } from "solid-js"
-import { mockTuiApi } from "./fixtures/api"
+import { attachRendererMockInput, mockTuiApi } from "./fixtures/api"
 
 let branches = ["main", "feature"]
 let createInput: Record<string, unknown> | undefined
@@ -103,9 +103,10 @@ function harness(scopes: string[] = []) {
   }
 }
 
-async function renderLatest(renders: Array<() => JSX.Element>) {
+async function renderLatest(api: TuiPluginApi, renders: Array<() => JSX.Element>) {
   await renderSetup?.renderer.destroy()
   renderSetup = await testRender(() => renders.at(-1)!(), { width: 80, height: 24 })
+  attachRendererMockInput(api, renderSetup)
   await renderSetup.flush()
 }
 
@@ -113,7 +114,7 @@ describe("openCreateTaskDialog", () => {
   test("warns and does not create when title is blank", async () => {
     const view = harness()
     await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
 
     renderSetup!.mockInput.pressEnter()
     await renderSetup!.flush()
@@ -126,7 +127,7 @@ describe("openCreateTaskDialog", () => {
   test("creates with the chosen model, current branch, order append, refresh, and success notice", async () => {
     const view = harness()
     await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
 
     await renderSetup!.mockInput.typeText("  Ship docs  ")
     renderSetup!.mockInput.pressTab()
@@ -136,10 +137,10 @@ describe("openCreateTaskDialog", () => {
     renderSetup!.mockInput.pressTab()
     await renderSetup!.flush()
     renderSetup!.mockInput.pressEnter()
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
     expect(view.selectProps?.title).toBe("Model")
     view.selectProps?.onSelect({ value: 1 })
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
 
     renderSetup!.mockInput.pressTab()
     await renderSetup!.flush()
@@ -165,6 +166,7 @@ describe("openCreateTaskDialog", () => {
     await openCreateTaskDialog(view.api, view.store as never)
     await renderSetup?.renderer.destroy()
     renderSetup = await testRender(() => view.renders.at(-1)!(), { width: 80, height: 24, otherModifiersMode: true })
+    attachRendererMockInput(view.api, renderSetup)
     await renderSetup.flush()
 
     await renderSetup.mockInput.typeText("Ship docs")
@@ -179,7 +181,7 @@ describe("openCreateTaskDialog", () => {
   test("preselects the only configured static scope", async () => {
     const view = harness(["project-alpha"])
     await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
 
     await renderSetup!.mockInput.typeText("Ship alpha project")
     renderSetup!.mockInput.pressEnter()
@@ -191,7 +193,7 @@ describe("openCreateTaskDialog", () => {
   test("requires a scope when multiple static scopes are configured", async () => {
     const view = harness(["project-alpha", "project-beta"])
     await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
 
     await renderSetup!.mockInput.typeText("Ship scoped work")
     renderSetup!.mockInput.pressEnter()
@@ -206,7 +208,7 @@ describe("openCreateTaskDialog", () => {
     createError = new Error("worktree failed")
     const view = harness()
     await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.renders)
+    await renderLatest(view.api, view.renders)
 
     await renderSetup!.mockInput.typeText("Fix flaky test")
     renderSetup!.mockInput.pressEnter()

--- a/test/findings-review.test.tsx
+++ b/test/findings-review.test.tsx
@@ -7,7 +7,7 @@ import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { detailHeader, FindingsReview, locationMarker, openFindingsReviewDialog } from "../src/findings-review"
 import type { Finding } from "../src/task"
 import type { BoardSession } from "../src/types"
-import { mockSession, mockTuiApi } from "./fixtures/api"
+import { attachRendererMockInput, mockSession, mockTuiApi } from "./fixtures/api"
 
 let renderSetup: TestRendererSetup | undefined
 
@@ -182,6 +182,7 @@ describe("FindingsReview — list mode", () => {
       ),
       { width: 100, height: 24, kittyKeyboard: true },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEscape()
     await renderSetup.waitFor(() => cleared)
@@ -190,10 +191,11 @@ describe("FindingsReview — list mode", () => {
 
   test("s sends the task back and closes the dialog", async () => {
     let sentBack = false
+    const boardApi = api()
     renderSetup = await testRender(
       () => (
         <FindingsReview
-          api={api()}
+          api={boardApi}
           store={store()}
           session={session([{ id: "f1", summary: "x" }])}
           onApprove={() => {}}
@@ -204,6 +206,7 @@ describe("FindingsReview — list mode", () => {
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressKey("s")
     await renderSetup.waitFor(() => sentBack)
@@ -212,10 +215,11 @@ describe("FindingsReview — list mode", () => {
 
   test("a does not approve while blocked", async () => {
     let approved: BoardSession | undefined
+    const boardApi = api()
     renderSetup = await testRender(
       () => (
         <FindingsReview
-          api={api()}
+          api={boardApi}
           store={store()}
           session={session([{ id: "f1", summary: "x" }])}
           onApprove={(s) => {
@@ -226,6 +230,7 @@ describe("FindingsReview — list mode", () => {
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressKey("a")
     await renderSetup.flush()
@@ -234,10 +239,11 @@ describe("FindingsReview — list mode", () => {
 
   test("a approves the clean session and closes the dialog", async () => {
     let approved: BoardSession | undefined
+    const boardApi = api()
     renderSetup = await testRender(
       () => (
         <FindingsReview
-          api={api()}
+          api={boardApi}
           store={store()}
           session={session([])}
           onApprove={(s) => {
@@ -248,6 +254,7 @@ describe("FindingsReview — list mode", () => {
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressKey("a")
     await renderSetup.waitFor(() => approved !== undefined)
@@ -271,10 +278,11 @@ describe("FindingsReview — detail mode", () => {
 
   test("refuses an ignore ruling with an empty note and does not persist", async () => {
     let updateCalls = 0
+    const boardApi = api({ update: () => updateCalls++ })
     renderSetup = await testRender(
       () => (
         <FindingsReview
-          api={api({ update: () => updateCalls++ })}
+          api={boardApi}
           store={store()}
           session={session([finding])}
           onApprove={() => {}}
@@ -283,6 +291,7 @@ describe("FindingsReview — detail mode", () => {
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEnter()
     await renderSetup.flush()
@@ -295,10 +304,11 @@ describe("FindingsReview — detail mode", () => {
 
   test("refuses a clarify ruling with an insubstantive note and does not persist", async () => {
     let updateCalls = 0
+    const boardApi = api({ update: () => updateCalls++ })
     renderSetup = await testRender(
       () => (
         <FindingsReview
-          api={api({ update: () => updateCalls++ })}
+          api={boardApi}
           store={store()}
           session={session([finding])}
           onApprove={() => {}}
@@ -307,6 +317,7 @@ describe("FindingsReview — detail mode", () => {
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEnter()
     await renderSetup.flush()
@@ -325,10 +336,11 @@ describe("FindingsReview — detail mode", () => {
 
   test("refuses an intended ruling on a high finding with an insubstantive note and does not persist", async () => {
     let updateCalls = 0
+    const boardApi = api({ update: () => updateCalls++ })
     renderSetup = await testRender(
       () => (
         <FindingsReview
-          api={api({ update: () => updateCalls++ })}
+          api={boardApi}
           store={store()}
           session={session([finding])}
           onApprove={() => {}}
@@ -337,6 +349,7 @@ describe("FindingsReview — detail mode", () => {
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEnter()
     await renderSetup.flush()
@@ -354,18 +367,14 @@ describe("FindingsReview — detail mode", () => {
   test("persists a clarify ruling with a substantive note and returns to list", async () => {
     let updateArgs: unknown
     const target = session([finding])
+    const boardApi = api({ update: (args) => (updateArgs = args), metadata: target.metadata })
     renderSetup = await testRender(
       () => (
-        <FindingsReview
-          api={api({ update: (args) => (updateArgs = args), metadata: target.metadata })}
-          store={store()}
-          session={target}
-          onApprove={() => {}}
-          onSendBack={() => {}}
-        />
+        <FindingsReview api={boardApi} store={store()} session={target} onApprove={() => {}} onSendBack={() => {}} />
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEnter()
     await renderSetup.flush()
@@ -389,18 +398,14 @@ describe("FindingsReview — detail mode", () => {
   test("persists an ignore ruling with a substantive note and returns to list", async () => {
     let updateArgs: unknown
     const target = session([finding])
+    const boardApi = api({ update: (args) => (updateArgs = args), metadata: target.metadata })
     renderSetup = await testRender(
       () => (
-        <FindingsReview
-          api={api({ update: (args) => (updateArgs = args), metadata: target.metadata })}
-          store={store()}
-          session={target}
-          onApprove={() => {}}
-          onSendBack={() => {}}
-        />
+        <FindingsReview api={boardApi} store={store()} session={target} onApprove={() => {}} onSendBack={() => {}} />
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEnter()
     await renderSetup.flush()
@@ -421,18 +426,14 @@ describe("FindingsReview — detail mode", () => {
     const ruled: Finding = { ...finding, resolution: "clarified", note: "Timeout defaults to 30s per the config" }
     let updateArgs: unknown
     const target = session([ruled])
+    const boardApi = api({ update: (args) => (updateArgs = args), metadata: target.metadata })
     renderSetup = await testRender(
       () => (
-        <FindingsReview
-          api={api({ update: (args) => (updateArgs = args), metadata: target.metadata })}
-          store={store()}
-          session={target}
-          onApprove={() => {}}
-          onSendBack={() => {}}
-        />
+        <FindingsReview api={boardApi} store={store()} session={target} onApprove={() => {}} onSendBack={() => {}} />
       ),
       { width: 100, height: 24 },
     )
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressEnter()
     await renderSetup.flush()

--- a/test/fixtures/api.ts
+++ b/test/fixtures/api.ts
@@ -1,5 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { KeyEvent, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { KeyInput, TestRendererSetup } from "@opentui/core/testing"
+import type { KeyInputContext } from "@opentui/keymap"
 import { COLUMNS, ROUTE, type BoardSession, type ColumnType } from "../../src/types"
 
 export const mockTheme = {
@@ -28,6 +30,8 @@ export function mockKv(overrides: Record<string, unknown> = {}): Record<string, 
 
 export function mockTuiApi(overrides: Partial<TuiPluginApi> & { kvMap?: Record<string, unknown> } = {}): TuiPluginApi {
   const kvMap = mockKv(overrides.kvMap)
+  const keyHandlers = new Set<(key: KeyEvent) => void>()
+  const interceptHandlers = new Set<(ctx: KeyInputContext) => void>()
   return {
     kv: {
       get: (key: string, defaultValue: unknown) => (key in kvMap ? kvMap[key] : defaultValue),
@@ -41,9 +45,117 @@ export function mockTuiApi(overrides: Partial<TuiPluginApi> & { kvMap?: Record<s
     },
     route: { current: { name: ROUTE } },
     theme: { current: mockTheme },
-    keymap: { registerLayer: () => {} },
+    keymap: {
+      registerLayer: () => {},
+      intercept: (name: "key", handler: (ctx: KeyInputContext) => void) => {
+        interceptHandlers.add(handler)
+        return () => interceptHandlers.delete(handler)
+      },
+    },
+    renderer: {
+      width: 120,
+      height: 40,
+      on: () => {},
+      off: () => {},
+      keyInput: {
+        on: (event: string, handler: (key: KeyEvent) => void) => {
+          if (event === "keypress") keyHandlers.add(handler)
+        },
+        off: (event: string, handler: (key: KeyEvent) => void) => {
+          if (event === "keypress") keyHandlers.delete(handler)
+        },
+        emitKey: (key: KeyEvent) => {
+          const ctx = {
+            event: key,
+            setData: () => {},
+            getData: () => undefined,
+            consume: () => {},
+          }
+          for (const handler of Array.from(interceptHandlers)) handler(ctx)
+          for (const handler of Array.from(keyHandlers)) handler(key)
+        },
+      },
+    },
     ...overrides,
   } as unknown as TuiPluginApi
+}
+
+export function attachRendererMockInput(api: TuiPluginApi, setup: TestRendererSetup) {
+  const emit = (api.renderer.keyInput as unknown as { emitKey?: (key: KeyEvent) => void }).emitKey
+  if (!emit) return
+  const pressKey = setup.mockInput.pressKey.bind(setup.mockInput)
+  const pressEnter = setup.mockInput.pressEnter.bind(setup.mockInput)
+  const pressEscape = setup.mockInput.pressEscape.bind(setup.mockInput)
+  const pressTab = setup.mockInput.pressTab.bind(setup.mockInput)
+  const pressArrow = setup.mockInput.pressArrow.bind(setup.mockInput)
+  const emitAndRender = (key: KeyEvent) => {
+    emit(key)
+    setup.renderer.requestRender()
+  }
+  setup.mockInput.pressKey = (key, modifiers) => {
+    pressKey(key, modifiers)
+    emitAndRender(mockKeyEvent(key, modifiers))
+  }
+  setup.mockInput.pressEnter = (modifiers) => {
+    pressEnter(modifiers)
+    emitAndRender(mockKeyEvent("RETURN", modifiers))
+  }
+  setup.mockInput.pressEscape = (modifiers) => {
+    pressEscape(modifiers)
+    emitAndRender(mockKeyEvent("ESCAPE", modifiers))
+  }
+  setup.mockInput.pressTab = (modifiers) => {
+    pressTab(modifiers)
+    emitAndRender(mockKeyEvent("TAB", modifiers))
+  }
+  setup.mockInput.pressArrow = (direction, modifiers) => {
+    pressArrow(direction, modifiers)
+    emitAndRender(mockKeyEvent(`ARROW_${direction.toUpperCase()}` as KeyInput, modifiers))
+  }
+}
+
+function mockKeyEvent(
+  key: KeyInput,
+  modifiers: { shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean; hyper?: boolean } = {},
+): KeyEvent {
+  const name =
+    key === "RETURN"
+      ? "return"
+      : key === "ESCAPE"
+        ? "escape"
+        : key === "TAB"
+          ? "tab"
+          : key === "ARROW_UP"
+            ? "up"
+            : key === "ARROW_DOWN"
+              ? "down"
+              : key === "ARROW_LEFT"
+                ? "left"
+                : key === "ARROW_RIGHT"
+                  ? "right"
+                  : key
+  let defaultPrevented = false
+  let propagationStopped = false
+  return {
+    name,
+    ctrl: !!modifiers.ctrl,
+    shift: !!modifiers.shift,
+    meta: !!modifiers.meta,
+    super: !!modifiers.super,
+    hyper: !!modifiers.hyper,
+    get defaultPrevented() {
+      return defaultPrevented
+    },
+    get propagationStopped() {
+      return propagationStopped
+    },
+    preventDefault() {
+      defaultPrevented = true
+    },
+    stopPropagation() {
+      propagationStopped = true
+    },
+  } as KeyEvent
 }
 
 export function mockSession(

--- a/test/onboarding.test.tsx
+++ b/test/onboarding.test.tsx
@@ -4,7 +4,7 @@ import { testRender } from "@opentui/solid"
 import type { TestRendererSetup } from "@opentui/core/testing"
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { maybeShowOnboarding, Onboarding, showOnboarding } from "../src/onboarding"
-import { mockTuiApi } from "./fixtures/api"
+import { attachRendererMockInput, mockTuiApi } from "./fixtures/api"
 
 let renderSetup: TestRendererSetup | undefined
 
@@ -78,6 +78,7 @@ describe("Onboarding", () => {
       cleared = true
     }
     renderSetup = await testRender(() => <Onboarding api={boardApi} />, { width: 70, height: 24 })
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     renderSetup.mockInput.pressKey("x")
     await renderSetup.waitFor(() => cleared)
@@ -91,6 +92,7 @@ describe("Onboarding", () => {
       cleared = true
     }
     renderSetup = await testRender(() => <Onboarding api={boardApi} />, { width: 70, height: 24 })
+    attachRendererMockInput(boardApi, renderSetup)
     await renderSetup.flush()
     for (let i = 0; i < 3; i++) {
       renderSetup.mockInput.pressEnter()

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test"
+import { parseOptions } from "../src/options"
+
+describe("parseOptions defaults", () => {
+  test("returns defaults when options are absent, empty, or garbage", () => {
+    for (const raw of [undefined, {}, null, "garbage", 42, true]) {
+      expect(parseOptions(raw)).toEqual({
+        inProgressLimit: 2,
+        helperRetries: 1,
+        sendBackStopThreshold: 3,
+        squashMerge: true,
+        intakeAgent: undefined,
+        validatorAgent: undefined,
+      })
+    }
+  })
+})
+
+describe("parseOptions inProgressLimit", () => {
+  test("reads an integer >= 1", () => {
+    expect(parseOptions({ inProgressLimit: 5 }).inProgressLimit).toBe(5)
+    expect(parseOptions({ inProgressLimit: 1 }).inProgressLimit).toBe(1)
+  })
+
+  test("falls back on non-integer, zero, negative, and wrong type", () => {
+    expect(parseOptions({ inProgressLimit: 0 }).inProgressLimit).toBe(2)
+    expect(parseOptions({ inProgressLimit: -3 }).inProgressLimit).toBe(2)
+    expect(parseOptions({ inProgressLimit: 2.5 }).inProgressLimit).toBe(2)
+    expect(parseOptions({ inProgressLimit: "3" }).inProgressLimit).toBe(2)
+  })
+})
+
+describe("parseOptions helperRetries", () => {
+  test("reads an integer >= 0", () => {
+    expect(parseOptions({ helperRetries: 0 }).helperRetries).toBe(0)
+    expect(parseOptions({ helperRetries: 3 }).helperRetries).toBe(3)
+  })
+
+  test("falls back on negative, non-integer, and wrong type", () => {
+    expect(parseOptions({ helperRetries: -1 }).helperRetries).toBe(1)
+    expect(parseOptions({ helperRetries: 1.5 }).helperRetries).toBe(1)
+    expect(parseOptions({ helperRetries: "2" }).helperRetries).toBe(1)
+  })
+})
+
+describe("parseOptions sendBackStopThreshold", () => {
+  test("reads an integer >= 1", () => {
+    expect(parseOptions({ sendBackStopThreshold: 1 }).sendBackStopThreshold).toBe(1)
+    expect(parseOptions({ sendBackStopThreshold: 7 }).sendBackStopThreshold).toBe(7)
+  })
+
+  test("falls back on zero, non-integer, and wrong type", () => {
+    expect(parseOptions({ sendBackStopThreshold: 0 }).sendBackStopThreshold).toBe(3)
+    expect(parseOptions({ sendBackStopThreshold: 2.5 }).sendBackStopThreshold).toBe(3)
+    expect(parseOptions({ sendBackStopThreshold: "4" }).sendBackStopThreshold).toBe(3)
+  })
+})
+
+describe("parseOptions squashMerge", () => {
+  test("reads a boolean", () => {
+    expect(parseOptions({ squashMerge: true }).squashMerge).toBe(true)
+    expect(parseOptions({ squashMerge: false }).squashMerge).toBe(false)
+  })
+
+  test("falls back to true on wrong type", () => {
+    expect(parseOptions({ squashMerge: "false" }).squashMerge).toBe(true)
+    expect(parseOptions({ squashMerge: 0 }).squashMerge).toBe(true)
+  })
+})
+
+describe("parseOptions agent overrides", () => {
+  test("reads a string agent, including empty", () => {
+    expect(parseOptions({ intakeAgent: "plan" }).intakeAgent).toBe("plan")
+    expect(parseOptions({ validatorAgent: "reviewer" }).validatorAgent).toBe("reviewer")
+    expect(parseOptions({ intakeAgent: "" }).intakeAgent).toBe("")
+  })
+
+  test("falls back to undefined on wrong type", () => {
+    expect(parseOptions({ intakeAgent: 5 }).intakeAgent).toBeUndefined()
+    expect(parseOptions({ validatorAgent: {} }).validatorAgent).toBeUndefined()
+  })
+})
+
+describe("parseOptions passthrough", () => {
+  test("resolves a full valid options object and ignores keys owned by other readers", () => {
+    expect(
+      parseOptions({
+        inProgressLimit: 4,
+        helperRetries: 2,
+        sendBackStopThreshold: 5,
+        squashMerge: false,
+        intakeAgent: "plan",
+        validatorAgent: "reviewer",
+        validatorModels: [{ providerID: "openai", modelID: "gpt-5" }],
+        commands: { check: "bun run test" },
+      }),
+    ).toEqual({
+      inProgressLimit: 4,
+      helperRetries: 2,
+      sendBackStopThreshold: 5,
+      squashMerge: false,
+      intakeAgent: "plan",
+      validatorAgent: "reviewer",
+    })
+  })
+})

--- a/test/reactivity-guard.test.ts
+++ b/test/reactivity-guard.test.ts
@@ -17,4 +17,19 @@ describe("host Solid bridge", () => {
     )
     expect(offenders).toEqual([])
   })
+
+  test("src does not import OpenTUI context hooks that bypass TuiPluginApi", () => {
+    const dir = new URL("../src/", import.meta.url)
+    const offenders = readdirSync(dir).filter((name) => {
+      if (!name.endsWith(".tsx")) return false
+      const source = readFileSync(new URL(name, dir), "utf8")
+      return (
+        /\bfrom\s+["']@opentui\/keymap\/solid["']/.test(source) ||
+        /\bimport\s+\{[^}]*\b(useRenderer|useTerminalDimensions|useKeyboard|Portal)\b[^}]*\}\s+from\s+["']@opentui\/solid["']/.test(
+          source,
+        )
+      )
+    })
+    expect(offenders).toEqual([])
+  })
 })

--- a/test/settings.test.tsx
+++ b/test/settings.test.tsx
@@ -7,7 +7,7 @@ import type { JSX } from "solid-js"
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { Settings } from "../src/settings"
 import { SETTINGS_ROUTE } from "../src/types"
-import { mockTuiApi } from "./fixtures/api"
+import { attachRendererMockInput, mockTuiApi } from "./fixtures/api"
 
 let renderSetups: TestRendererSetup[] = []
 
@@ -97,6 +97,7 @@ async function renderSettingsWithDialog(options?: Record<string, unknown>) {
     width: 120,
     height: 24,
   })
+  attachRendererMockInput(harness.api, setup)
   await flushAndSettle(setup)
   renderSetups.push(setup)
   return { harness, setup }
@@ -307,6 +308,7 @@ describe("Settings", () => {
     setup.mockInput.pressKey("ARROW_RIGHT")
     await flushAndSettle(setup)
     setup.mockInput.pressKey("RETURN")
+    await flushAndSettle(setup)
     await flushAndSettle(setup)
 
     setup.mockInput.pressKey("ARROW_DOWN")


### PR DESCRIPTION
Batch of four unrelated changes that accumulated on this branch. Listed separately since a squash merge collapses them into one commit.

## fix: route renderer, keyboard, and keymap through `TuiPluginApi`
The npm-installed plugin bundles its own `@opentui/solid` and `@opentui/keymap/solid` copies, whose Solid context the host never populates. `useTerminalDimensions` / `useKeyboard` / `useBindings` therefore threw **"No renderer found" / "Keymap not found"** on install (the Ubuntu crash). All renderer dimensions, keyboard input, and keymap registration now go through the host-provided `api` — the one object identical across module copies.
- board keys → `api.keymap.registerLayer({ mode: "base" })`, matching `tui.tsx`
- dialog keys → `api.keymap.intercept` via a small `useKeyIntercept` wrapper
- dimensions → `useRendererDimensions` over `api.renderer` resize events
- `reactivity-guard` test fails the build if a context hook reappears
- create-task: Enter reaches the description textarea as a newline again (ctrl+enter still submits)

## refactor: centralize plugin option parsing in a single schema
Plugin option parsing consolidated into one schema (`src/options.ts`) with matching tests.

## ci: cancel superseded check runs and add workflow linting
Concurrency cancels in-flight check runs on new pushes; adds a workflow-lint job.

## docs: add CONTRIBUTING guide

## Test plan
- `bun run check` green: prettier, oxlint, `tsc`, 635 tests pass, package bundle check passes
- Verified no `@opentui/solid` / `@opentui/keymap/solid` context-hook imports remain in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)