### PR TITLE
fix: npm keyboard, Enter submit, and duplicate helper spawn

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,22 +6,38 @@
       "name": "kagan",
       "dependencies": {
         "@opencode-ai/plugin": "1.17.13",
-        "@opentui/core": "0.4.2",
-        "@opentui/keymap": "0.4.2",
-        "@opentui/solid": "0.4.2",
-        "solid-js": "1.9.13",
         "zod": "4.1.8",
       },
       "devDependencies": {
+        "@babel/core": "7.28.0",
+        "@babel/preset-typescript": "7.27.1",
         "@opencode-ai/sdk": "1.17.13",
+        "@opentui/core": "0.4.2",
+        "@opentui/keymap": "0.4.2",
+        "@opentui/solid": "0.4.2",
         "@tsconfig/bun": "1.0.10",
         "@types/bun": "1.3.13",
+        "babel-plugin-module-resolver": "5.0.2",
+        "babel-preset-solid": "1.9.12",
         "oxlint": "1.60.0",
         "prettier": "3.6.2",
         "semantic-release": "25.0.5",
+        "solid-js": "1.9.13",
         "typescript": "5.8.2",
         "vitepress": "1.6.4",
       },
+      "peerDependencies": {
+        "@opentui/core": ">=0.4.3",
+        "@opentui/keymap": ">=0.4.3",
+        "@opentui/solid": ">=0.4.3",
+        "solid-js": ">=1.9.10",
+      },
+      "optionalPeers": [
+        "@opentui/core",
+        "@opentui/keymap",
+        "@opentui/solid",
+        "solid-js",
+      ],
     },
   },
   "packages": {
@@ -611,7 +627,7 @@
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
-    "find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
     "find-up-simple": ["find-up-simple@1.0.1", "", {}, "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="],
 
@@ -735,7 +751,7 @@
 
     "load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
 
-    "locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
     "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
@@ -749,7 +765,7 @@
 
     "lodash.uniqby": ["lodash.uniqby@4.7.0", "", {}, "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="],
 
-    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -757,7 +773,7 @@
 
     "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
 
-    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
 
@@ -837,9 +853,9 @@
 
     "p-filter": ["p-filter@4.1.0", "", { "dependencies": { "p-map": "^7.0.1" } }, "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw=="],
 
-    "p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
 
     "p-map": ["p-map@7.0.5", "", {}, "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA=="],
 
@@ -847,7 +863,7 @@
 
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
-    "p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
@@ -855,7 +871,7 @@
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
-    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
@@ -935,7 +951,7 @@
 
     "semantic-release": ["semantic-release@25.0.5", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g=="],
 
-    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "semver-regex": ["semver-regex@4.0.5", "", {}, "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="],
 
@@ -1111,31 +1127,25 @@
 
     "@actions/http-client/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
 
-    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
-    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@opentui/core/marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
-
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
+
+    "@semantic-release/npm/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 
-    "babel-plugin-jsx-dom-expressions/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cli-highlight/parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
 
     "cli-highlight/yargs": ["yargs@16.2.2", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w=="],
 
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "conventional-changelog-writer/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
@@ -1145,11 +1155,17 @@
 
     "fdir/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "hosted-git-info/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
     "make-asynchronous/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "marked-terminal/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "normalize-package-data/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "npm/@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
 
@@ -1437,17 +1453,23 @@
 
     "npm-run-path/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
+    "pkg-conf/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "read-pkg/parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
+
+    "semantic-release/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "semantic-release/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -1464,8 +1486,6 @@
     "@semantic-release/release-notes-generator/read-package-up/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 
     "@semantic-release/release-notes-generator/read-package-up/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
-
-    "babel-plugin-jsx-dom-expressions/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -1493,7 +1513,7 @@
 
     "npm/minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
-    "pkg-up/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+    "pkg-conf/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
 
     "read-pkg/parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -1527,11 +1547,13 @@
 
     "npm/minipass-pipeline/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
-    "pkg-up/find-up/locate-path/p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+    "pkg-conf/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "signale/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "cli-highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
@@ -1541,13 +1563,13 @@
 
     "cli-highlight/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+    "pkg-conf/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "^1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
-    "pkg-up/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+    "pkg-conf/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@1.0.0", "", {}, "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="],
 
     "cli-highlight/yargs/cliui/wrap-ansi/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
   }

--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "@babel/core": "7.28.0",
         "@babel/preset-typescript": "7.27.1",
         "@opencode-ai/sdk": "1.17.13",
-        "@opentui/core": "0.4.2",
-        "@opentui/keymap": "0.4.2",
-        "@opentui/solid": "0.4.2",
+        "@opentui/core": "0.4.3",
+        "@opentui/keymap": "0.4.3",
+        "@opentui/solid": "0.4.3",
         "@tsconfig/bun": "1.0.10",
         "@types/bun": "1.3.13",
         "babel-plugin-module-resolver": "5.0.2",
@@ -22,14 +22,14 @@
         "oxlint": "1.60.0",
         "prettier": "3.6.2",
         "semantic-release": "25.0.5",
-        "solid-js": "1.9.13",
+        "solid-js": "1.9.10",
         "typescript": "5.8.2",
         "vitepress": "1.6.4",
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.4.3",
-        "@opentui/keymap": ">=0.4.3",
-        "@opentui/solid": ">=0.4.3",
+        "@opentui/core": ">=0.3.4",
+        "@opentui/keymap": ">=0.3.4",
+        "@opentui/solid": ">=0.3.4",
         "solid-js": ">=1.9.10",
       },
       "optionalPeers": [
@@ -249,27 +249,27 @@
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-VItOGjMzRQx3zypwmeFLNhCiIx32kxS7FqzIJvVZLfyNGCifs3rfGC9qzNKWcxQo4SjNvAw++v4gWWU6Inv+JQ=="],
 
-    "@opentui/core": ["@opentui/core@0.4.2", "", { "dependencies": { "bun-ffi-structs": "0.2.3", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.2", "@opentui/core-darwin-x64": "0.4.2", "@opentui/core-linux-arm64": "0.4.2", "@opentui/core-linux-arm64-musl": "0.4.2", "@opentui/core-linux-x64": "0.4.2", "@opentui/core-linux-x64-musl": "0.4.2", "@opentui/core-win32-arm64": "0.4.2", "@opentui/core-win32-x64": "0.4.2" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-ulx6RMqftf2fm7Itf9e81GcCDMNY6NAhmnKYhllDOMYD+PxYXR+vomy2bxQNV5ow31RE7s8WQFnb7hWTRUbx2g=="],
+    "@opentui/core": ["@opentui/core@0.4.3", "", { "dependencies": { "bun-ffi-structs": "0.2.4", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.3", "@opentui/core-darwin-x64": "0.4.3", "@opentui/core-linux-arm64": "0.4.3", "@opentui/core-linux-arm64-musl": "0.4.3", "@opentui/core-linux-x64": "0.4.3", "@opentui/core-linux-x64-musl": "0.4.3", "@opentui/core-win32-arm64": "0.4.3", "@opentui/core-win32-x64": "0.4.3" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ=="],
 
-    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-is+O+sS/l3E9cZXyM9pRF1WhqnE+hYSPYoZkbseR9CthJcaWPGi3R3jUJa1cLj325252jWgxVupnDqFUtKg36w=="],
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ=="],
 
-    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ACi42h81DurSeybUAD1XyKT6xmXZcKeTxS54lZFi0CVZh46w0g99vNj8PlQzIFXvvFLT0e0IlRS//eWSWS2zGQ=="],
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-+fh0vEUE0lwVC7RW5ijYLRlTLp5NfvCRj8SzxDVd7IL2j2ssB6YXcfIbXq2EW7UGnrejwPRXf1tgUrIXW9KmOw=="],
 
-    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-RjOx2HcjLRtGSy9WrAGSdr5M9SpJuPifPORpImx6Mciovw0ltnE0uoYjIyor82uf6/LExWC7YA2AcAl+YBxayA=="],
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-gl6qA5QJy6u8Cbt7gOtHbhhfMZ4qQDb0kEwFXHcMGmbnKzz4OHoq74D6tNjyvSQB9saoC7C6C0tvn2DcJOuNog=="],
 
-    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-heNciL2ngPU+kq1h01PHLsxn6Fr8iqTFtbxSdVbhaY3XihuIjkuXyEhFeuoa1lsXY7Bb2gpWnX5EQVWnZsAuDQ=="],
+    "@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-8p8g8/AEq/xFGpQ7XcIFKcAqjc0QwsZcv+Ll9RbCDpUA56FGH6jfLDir0KYTNTgYXJTIrBIENI9K46VuxMUMQA=="],
 
-    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9s0s/ooK+AhWP306By3gu+XhzcVEThC2sqKMPK1nQmGDujQhd+xOrtbtfCVcJSx62UzAovC2VNqypvP8vHByOg=="],
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-dXpJitiZdYE3hq2Pvx6e9I0uPQSOcnaLLp1pDgWAHv+3kvKSHEX//9Yr/pV/Ua6qqT7p+2D/K4vXNap/NKVo2w=="],
 
-    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cjv6Bv7l3p/KLNJr5RyqCS0FmRlAGJnkA2IK3S+HkHhCOv/O02S1G+DBUY6POnyjp1eNy95vauustApobhdbig=="],
+    "@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/QiFpCrpU2O7vy8QYmLIQYbvAtKDgmqcVjR7dGtqSzkiQk3ktNJoo5RozG7ueXnjung1Wp0nKldKxo2Csg/OrA=="],
 
-    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mfJZrJ0TNPFRZUzXNsxAPe1YdiWsy/vbTl93+yeXGHPI1B8Qnk9V5hpzSxxEyBGhlTHSfGNtgiO+VrrdRC3kZA=="],
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-Mx2zuOjrhm/z2SDS6RExIyjP/SnN/8QhhagxURUw0jQi/NssGSeAllu1cBAFFnhobJL5QLTE4FU4CRhUK9svgg=="],
 
-    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-P2oguG3ng3OMjAdasFSA3GhHaQXtzDUsIRDGbzWFOimpZ/zMemidp+JQ0V8V6XwK6Utk5G0aQ03oBaRCoLyYDw=="],
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.3", "", { "os": "win32", "cpu": "x64" }, "sha512-NuoqvWKGXaYnmlqvu7Gg2lLI6yVMnS9OfWBvxp+7Q+McSgHFSTQmYBXaPpvQ8HikpQXE1nCeMPtuSG4PdZHe2w=="],
 
-    "@opentui/keymap": ["@opentui/keymap@0.4.2", "", { "dependencies": { "@opentui/core": "0.4.2" }, "peerDependencies": { "@opentui/react": "0.4.2", "@opentui/solid": "0.4.2", "react": ">=19.2.0", "solid-js": "1.9.12" }, "optionalPeers": ["@opentui/react", "@opentui/solid", "react", "solid-js"] }, "sha512-wxBEFfWgm3feqCRLckWg1JH4tbMJinpyK3yobkLTsWJ7PDsM+fPoFMyQ8ieKVdUL2eP6ELTmHvM1bHKShZ7SUQ=="],
+    "@opentui/keymap": ["@opentui/keymap@0.4.3", "", { "dependencies": { "@opentui/core": "0.4.3" }, "peerDependencies": { "@opentui/react": "0.4.3", "@opentui/solid": "0.4.3", "react": ">=19.2.0", "solid-js": "1.9.12" }, "optionalPeers": ["@opentui/react", "@opentui/solid", "react", "solid-js"] }, "sha512-sinX0pyQBRrEvo89PSSUbSUDIYpL3xWo81VEfec58VFoVRB5FG48/deAtvRTQfJ8w1kgbzN8hzdOXdSm61zBmw=="],
 
-    "@opentui/solid": ["@opentui/solid@0.4.2", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.4.2", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.12", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.12" } }, "sha512-zuYXsnrlsMtnXrS7QCYBdPzMtUSonG2LqnJikBR2NjEE2O4zEKvJd48n3eB1igcxjv96tiotTXRNCylYS0SNdQ=="],
+    "@opentui/solid": ["@opentui/solid@0.4.3", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.4.3", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.12", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.12" } }, "sha512-RcV0+S8HMdXOASyr7HmJUBuTUIaFPzAxMDa44VftS5C2JUgrmAuWo0Njv1q3TWRB1owjHnyKhEfWGKq7A82wxw=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.60.0", "", { "os": "android", "cpu": "arm" }, "sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA=="],
 
@@ -503,7 +503,7 @@
 
     "browserslist": ["browserslist@4.28.4", "", { "dependencies": { "baseline-browser-mapping": "^2.10.38", "caniuse-lite": "^1.0.30001799", "electron-to-chromium": "^1.5.376", "node-releases": "^2.0.48", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw=="],
 
-    "bun-ffi-structs": ["bun-ffi-structs@0.2.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg=="],
+    "bun-ffi-structs": ["bun-ffi-structs@0.2.4", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -955,9 +955,9 @@
 
     "semver-regex": ["semver-regex@4.0.5", "", {}, "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="],
 
-    "seroval": ["seroval@1.5.4", "", {}, "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw=="],
+    "seroval": ["seroval@1.3.2", "", {}, "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ=="],
 
-    "seroval-plugins": ["seroval-plugins@1.5.4", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw=="],
+    "seroval-plugins": ["seroval-plugins@1.3.3", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -971,7 +971,7 @@
 
     "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
 
-    "solid-js": ["solid-js@1.9.13", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ=="],
+    "solid-js": ["solid-js@1.9.10", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.3.0", "seroval-plugins": "~1.3.0" } }, "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "worktree"
   ],
   "files": [
-    "src",
+    "dist",
     "tsconfig.json",
     "bun.lock",
     "README.md",
@@ -43,16 +43,18 @@
     "lint": "oxlint --ignore-pattern node_modules .",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "test": "bun test ./test/*.test.ts ./test/*.test.tsx --conditions browser",
+    "build": "bun scripts/build.ts",
+    "prepack": "bun scripts/build.ts",
     "package:check": "bun scripts/package-check.ts",
-    "check": "prettier --check . && oxlint --ignore-pattern node_modules . && tsc --noEmit -p tsconfig.test.json && bun run test && bun run package:check",
+    "check": "prettier --check . && oxlint --ignore-pattern node_modules . && tsc --noEmit -p tsconfig.test.json && bun run test && bun run build && bun run package:check",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "setup": "node scripts/setup.mjs"
   },
   "exports": {
-    "./tui": "./src/tui.tsx",
-    "./server": "./src/server.ts"
+    "./tui": "./dist/tui.js",
+    "./server": "./dist/server.js"
   },
   "prettier": {
     "semi": false,
@@ -60,19 +62,43 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": "1.17.13",
+    "zod": "4.1.8"
+  },
+  "peerDependencies": {
+    "@opentui/core": ">=0.4.3",
+    "@opentui/keymap": ">=0.4.3",
+    "@opentui/solid": ">=0.4.3",
+    "solid-js": ">=1.9.10"
+  },
+  "peerDependenciesMeta": {
+    "@opentui/core": {
+      "optional": true
+    },
+    "@opentui/keymap": {
+      "optional": true
+    },
+    "@opentui/solid": {
+      "optional": true
+    },
+    "solid-js": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@babel/core": "7.28.0",
+    "@babel/preset-typescript": "7.27.1",
+    "@opencode-ai/sdk": "1.17.13",
     "@opentui/core": "0.4.2",
     "@opentui/keymap": "0.4.2",
     "@opentui/solid": "0.4.2",
-    "solid-js": "1.9.13",
-    "zod": "4.1.8"
-  },
-  "devDependencies": {
-    "@opencode-ai/sdk": "1.17.13",
     "@tsconfig/bun": "1.0.10",
     "@types/bun": "1.3.13",
+    "babel-plugin-module-resolver": "5.0.2",
+    "babel-preset-solid": "1.9.12",
     "oxlint": "1.60.0",
     "prettier": "3.6.2",
     "semantic-release": "25.0.5",
+    "solid-js": "1.9.13",
     "typescript": "5.8.2",
     "vitepress": "1.6.4"
   }

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "zod": "4.1.8"
   },
   "peerDependencies": {
-    "@opentui/core": ">=0.3.4",
-    "@opentui/keymap": ">=0.3.4",
-    "@opentui/solid": ">=0.3.4",
+    "@opentui/core": ">=0.4.3",
+    "@opentui/keymap": ">=0.4.3",
+    "@opentui/solid": ">=0.4.3",
     "solid-js": ">=1.9.10"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "plugin:install": "bun scripts/install-plugin.ts dev",
+    "plugin:install:prod": "bun scripts/install-plugin.ts prod",
     "plugin:reset": "bun scripts/install-plugin.ts reset",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "zod": "4.1.8"
   },
   "peerDependencies": {
-    "@opentui/core": ">=0.4.3",
-    "@opentui/keymap": ">=0.4.3",
-    "@opentui/solid": ">=0.4.3",
+    "@opentui/core": ">=0.3.4",
+    "@opentui/keymap": ">=0.3.4",
+    "@opentui/solid": ">=0.3.4",
     "solid-js": ">=1.9.10"
   },
   "peerDependenciesMeta": {
@@ -88,9 +88,9 @@
     "@babel/core": "7.28.0",
     "@babel/preset-typescript": "7.27.1",
     "@opencode-ai/sdk": "1.17.13",
-    "@opentui/core": "0.4.2",
-    "@opentui/keymap": "0.4.2",
-    "@opentui/solid": "0.4.2",
+    "@opentui/core": "0.4.3",
+    "@opentui/keymap": "0.4.3",
+    "@opentui/solid": "0.4.3",
     "@tsconfig/bun": "1.0.10",
     "@types/bun": "1.3.13",
     "babel-plugin-module-resolver": "5.0.2",
@@ -98,7 +98,7 @@
     "oxlint": "1.60.0",
     "prettier": "3.6.2",
     "semantic-release": "25.0.5",
-    "solid-js": "1.9.13",
+    "solid-js": "1.9.10",
     "typescript": "5.8.2",
     "vitepress": "1.6.4"
   }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,12 @@
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
-import { transformSolidSource } from "../node_modules/@opentui/solid/scripts/solid-transform.js"
+import { transformAsync } from "@babel/core"
+// @ts-expect-error untyped preset
+import solidPreset from "babel-preset-solid"
+// @ts-expect-error untyped preset
+import tsPreset from "@babel/preset-typescript"
+// @ts-expect-error untyped plugin
+import moduleResolver from "babel-plugin-module-resolver"
 
 const repoRoot = resolve(import.meta.dir, "..")
 const srcDir = join(repoRoot, "src")
@@ -11,6 +17,26 @@ function resolveImportPath(specifier: string): string | null {
   if (/\.(json|js|mjs|cjs)$/.test(specifier)) return specifier
   if (/\.tsx?$/.test(specifier)) return specifier.replace(/\.tsx?$/, ".js")
   return `${specifier}.js`
+}
+
+async function transformSolidSource(code: string, filename: string): Promise<string> {
+  const cleanFilename = filename.replace(/[?#].*$/, "")
+  const presets: unknown[] = []
+  if (/\.[cm]?[jt]sx$/.test(cleanFilename)) {
+    presets.push([solidPreset, { moduleName: "@opentui/solid", generate: "universal" }])
+  }
+  if (/\.[cm]?tsx?$/.test(cleanFilename)) {
+    presets.push([tsPreset])
+  }
+  const plugins = [[moduleResolver, { resolvePath: (specifier: string) => resolveImportPath(specifier) ?? specifier }]]
+  const result = await transformAsync(code, {
+    filename: cleanFilename,
+    configFile: false,
+    babelrc: false,
+    presets,
+    plugins,
+  })
+  return result?.code ?? code
 }
 
 async function listSourceFiles(): Promise<string[]> {
@@ -29,10 +55,7 @@ for (const file of files) {
   const rel = relative(srcDir, file)
   const outPath = join(distDir, rel.replace(/\.tsx?$/, ".js"))
   const code = await readFile(file, "utf8")
-  const transformed = await transformSolidSource(code, {
-    filename: rel,
-    resolvePath: (specifier) => resolveImportPath(specifier) ?? specifier,
-  })
+  const transformed = await transformSolidSource(code, rel)
   await writeFile(outPath, transformed)
 }
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -36,4 +36,4 @@ for (const file of files) {
   await writeFile(outPath, transformed)
 }
 
-console.log(`built ${files.length} files to dist/`)
+console.error(`built ${files.length} files to dist/`)

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
 import { transformAsync } from "@babel/core"
+import { runtimeModuleIdForSpecifier } from "@opentui/core/runtime-plugin"
 // @ts-expect-error untyped preset
 import solidPreset from "babel-preset-solid"
 // @ts-expect-error untyped preset
@@ -11,8 +12,28 @@ import moduleResolver from "babel-plugin-module-resolver"
 const repoRoot = resolve(import.meta.dir, "..")
 const srcDir = join(repoRoot, "src")
 const distDir = join(repoRoot, "dist")
+const hostRuntimeSpecifiers = new Set([
+  "@opentui/core",
+  "@opentui/core/testing",
+  "@opentui/keymap",
+  "@opentui/keymap/extras",
+  "@opentui/keymap/extras/graph",
+  "@opentui/keymap/addons",
+  "@opentui/keymap/addons/opentui",
+  "@opentui/keymap/html",
+  "@opentui/keymap/opentui",
+  "@opentui/keymap/react",
+  "@opentui/keymap/solid",
+  "@opentui/solid",
+  "@opentui/solid/components",
+  "@opentui/solid/jsx-runtime",
+  "@opentui/solid/jsx-dev-runtime",
+  "solid-js",
+  "solid-js/store",
+])
 
 function resolveImportPath(specifier: string): string | null {
+  if (hostRuntimeSpecifiers.has(specifier)) return runtimeModuleIdForSpecifier(specifier)
   if (!specifier.startsWith(".")) return null
   if (/\.(json|js|mjs|cjs)$/.test(specifier)) return specifier
   if (/\.tsx?$/.test(specifier)) return specifier.replace(/\.tsx?$/, ".js")
@@ -23,7 +44,7 @@ async function transformSolidSource(code: string, filename: string): Promise<str
   const cleanFilename = filename.replace(/[?#].*$/, "")
   const presets: unknown[] = []
   if (/\.[cm]?[jt]sx$/.test(cleanFilename)) {
-    presets.push([solidPreset, { moduleName: "@opentui/solid", generate: "universal" }])
+    presets.push([solidPreset, { moduleName: runtimeModuleIdForSpecifier("@opentui/solid"), generate: "universal" }])
   }
   if (/\.[cm]?tsx?$/.test(cleanFilename)) {
     presets.push([tsPreset])

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,39 @@
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join, relative, resolve } from "node:path"
+import { transformSolidSource } from "../node_modules/@opentui/solid/scripts/solid-transform.js"
+
+const repoRoot = resolve(import.meta.dir, "..")
+const srcDir = join(repoRoot, "src")
+const distDir = join(repoRoot, "dist")
+
+function resolveImportPath(specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null
+  if (/\.(json|js|mjs|cjs)$/.test(specifier)) return specifier
+  if (/\.tsx?$/.test(specifier)) return specifier.replace(/\.tsx?$/, ".js")
+  return `${specifier}.js`
+}
+
+async function listSourceFiles(): Promise<string[]> {
+  const entries = await readdir(srcDir, { withFileTypes: true })
+  return entries
+    .filter((entry) => entry.isFile() && /\.tsx?$/.test(entry.name))
+    .map((entry) => join(srcDir, entry.name))
+    .sort()
+}
+
+await rm(distDir, { recursive: true, force: true })
+await mkdir(distDir, { recursive: true })
+
+const files = await listSourceFiles()
+for (const file of files) {
+  const rel = relative(srcDir, file)
+  const outPath = join(distDir, rel.replace(/\.tsx?$/, ".js"))
+  const code = await readFile(file, "utf8")
+  const transformed = await transformSolidSource(code, {
+    filename: rel,
+    resolvePath: (specifier) => resolveImportPath(specifier) ?? specifier,
+  })
+  await writeFile(outPath, transformed)
+}
+
+console.log(`built ${files.length} files to dist/`)

--- a/scripts/install-plugin.ts
+++ b/scripts/install-plugin.ts
@@ -4,6 +4,10 @@ import { join, resolve } from "node:path"
 
 const repoRoot = resolve(import.meta.dir, "..")
 const snapshotDir = join(homedir(), ".kagan", "plugin", "kagan-pinned")
+const prodPackageDir = join(homedir(), ".kagan", "plugin", "prod")
+const opencodeCacheDir = process.env.XDG_CACHE_HOME
+  ? join(process.env.XDG_CACHE_HOME, "opencode")
+  : join(homedir(), ".cache", "opencode")
 const globalConfigDir = process.env.XDG_CONFIG_HOME
   ? join(process.env.XDG_CONFIG_HOME, "opencode")
   : join(homedir(), ".config", "opencode")
@@ -44,13 +48,31 @@ async function addGlobalPluginSpec(spec: string): Promise<void> {
   await prettify(globalConfigFiles)
 }
 
-async function removeGlobalPluginSpecs(prefix: string): Promise<void> {
+function pluginSpec(entry: unknown): string | undefined {
+  if (typeof entry === "string") return entry
+  if (!Array.isArray(entry)) return
+  return typeof entry[0] === "string" ? entry[0] : undefined
+}
+
+function isKaganSpec(spec: string): boolean {
+  return (
+    spec.startsWith(snapshotDir) ||
+    spec.startsWith(`file:${prodPackageDir}/`) ||
+    spec === "@kagan-sh/kagan" ||
+    spec.startsWith("@kagan-sh/kagan@")
+  )
+}
+
+async function removeGlobalKaganPluginSpecs(): Promise<void> {
   const touched: string[] = []
   for (const file of globalConfigFiles) {
     if (!(await Bun.file(file).exists())) continue
     const config = await readConfig(file)
     const plugins = Array.isArray(config.plugin) ? (config.plugin as unknown[]) : []
-    const kept = plugins.filter((entry) => typeof entry !== "string" || !entry.startsWith(prefix))
+    const kept = plugins.filter((entry) => {
+      const spec = pluginSpec(entry)
+      return spec === undefined || !isKaganSpec(spec)
+    })
     if (kept.length === plugins.length) continue
     if (kept.length > 0) config.plugin = kept
     else delete config.plugin
@@ -64,6 +86,24 @@ async function removeGlobalPluginSpecs(prefix: string): Promise<void> {
     }
   }
   if (touched.length > 0) await prettify(touched)
+}
+
+async function run(args: string[], options?: { cwd?: string; stdout?: "pipe" | "inherit" }): Promise<string> {
+  const proc = Bun.spawn(args, {
+    cwd: options?.cwd ?? repoRoot,
+    stdout: options?.stdout ?? "pipe",
+    stderr: "inherit",
+  })
+  const [stdout, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  if (code !== 0) throw new Error(`${args.join(" ")} failed`)
+  return stdout
+}
+
+function parsePackedFilename(stdout: string): string {
+  const packed = JSON.parse(stdout) as Array<{ filename?: string }>
+  const filename = packed[0]?.filename
+  if (!filename) throw new Error("npm pack returned no package")
+  return filename
 }
 
 async function gitDescription(): Promise<string> {
@@ -102,15 +142,32 @@ async function installDev(): Promise<void> {
   console.log("kagan loads in every folder. Re-run `bun run plugin:install` after edits, then restart opencode.")
 }
 
+async function packProductionPlugin(): Promise<string> {
+  await rm(prodPackageDir, { recursive: true, force: true })
+  await mkdir(prodPackageDir, { recursive: true })
+  const filename = parsePackedFilename(await run(["npm", "pack", "--json", "--pack-destination", prodPackageDir]))
+  return join(prodPackageDir, filename)
+}
+
+async function installProd(): Promise<void> {
+  const tgz = await packProductionPlugin()
+  await removeGlobalKaganPluginSpecs()
+  await rm(join(opencodeCacheDir, "packages", `file:${tgz}`), { recursive: true, force: true })
+  await run(["opencode", "plugin", `file:${tgz}`, "--global", "--force"], { stdout: "inherit" })
+  console.log(`Packed production plugin: ${tgz}`)
+  console.log("kagan loads from the packed package. Restart opencode to apply.")
+}
+
 async function reset(): Promise<void> {
-  await removeGlobalPluginSpecs(snapshotDir)
-  console.log("Removed the local kagan pin from the global config. Restart opencode to apply.")
+  await removeGlobalKaganPluginSpecs()
+  console.log("Removed kagan plugin entries from the global config. Restart opencode to apply.")
 }
 
 const mode = Bun.argv[2]
 if (mode === "dev") await installDev()
+else if (mode === "prod") await installProd()
 else if (mode === "reset") await reset()
 else {
-  console.error("Usage: bun scripts/install-plugin.ts <dev|reset>")
+  console.error("Usage: bun scripts/install-plugin.ts <dev|prod|reset>")
   process.exit(1)
 }

--- a/scripts/package-check.ts
+++ b/scripts/package-check.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, stat, writeFile } from "node:fs/promises"
+import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -6,6 +6,8 @@ const repoRoot = resolve(import.meta.dir, "..")
 
 type PackedFile = { path: string }
 type PackResult = { filename: string; files: PackedFile[] }
+
+const rawJsxPattern = /<(?:box|text)\b/
 
 async function run(args: string[], cwd = repoRoot) {
   const proc = Bun.spawn(args, { cwd, stdout: "pipe", stderr: "pipe" })
@@ -20,7 +22,7 @@ async function run(args: string[], cwd = repoRoot) {
 
 async function expectedPackageFiles() {
   const files = new Set(["package.json", "README.md", "LICENSE", "tsconfig.json", "bun.lock"])
-  for await (const file of new Bun.Glob("src/**/*").scan({ cwd: repoRoot, onlyFiles: true })) {
+  for await (const file of new Bun.Glob("dist/**/*").scan({ cwd: repoRoot, onlyFiles: true })) {
     if ((await stat(join(repoRoot, file))).isFile()) files.add(file)
   }
   return [...files].sort()
@@ -43,6 +45,29 @@ function assertSameFiles(actual: string[], expected: string[]) {
   }
 }
 
+function assertCompiledSolid(file: string) {
+  const source = Bun.file(join(repoRoot, file))
+  if (!source.size) throw new Error(`${file} is empty`)
+  return source.text().then((code) => {
+    if (rawJsxPattern.test(code)) throw new Error(`${file} still contains raw JSX`)
+    if (!code.includes("createComponent")) throw new Error(`${file} missing compiled Solid output`)
+  })
+}
+
+async function assertNoBundledHostDeps(pluginRoot: string) {
+  const nested = join(pluginRoot, "node_modules")
+  if (!(await Bun.file(nested).exists())) return
+  const entries = await readdir(nested)
+  for (const name of ["@opentui", "solid-js"]) {
+    if (entries.includes(name)) {
+      throw new Error(`packed install bundles host dependency under ${nested}/${name}`)
+    }
+  }
+}
+
+await run(["bun", "scripts/build.ts"])
+await Promise.all([assertCompiledSolid("dist/tui.js"), assertCompiledSolid("dist/board.js")])
+
 const expected = await expectedPackageFiles()
 assertSameFiles(
   parsePackJson(await run(["npm", "pack", "--dry-run", "--json"]))
@@ -59,12 +84,23 @@ try {
   await writeFile(
     join(consumer, "package.json"),
     JSON.stringify(
-      { type: "module", dependencies: { "@kagan-sh/kagan": `file:${join(dir, packed.filename)}` } },
+      {
+        type: "module",
+        dependencies: {
+          "@kagan-sh/kagan": `file:${join(dir, packed.filename)}`,
+          "@opentui/core": "0.4.3",
+          "@opentui/keymap": "0.4.3",
+          "@opentui/solid": "0.4.3",
+          "solid-js": "1.9.12",
+        },
+      },
       null,
       2,
     ),
   )
   await run(["npm", "install", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"], consumer)
+  const pluginRoot = join(consumer, "node_modules", "@kagan-sh", "kagan")
+  await assertNoBundledHostDeps(pluginRoot)
   await run(
     [
       "bun",

--- a/scripts/package-check.ts
+++ b/scripts/package-check.ts
@@ -107,7 +107,10 @@ try {
       "--conditions",
       "browser",
       "-e",
-      `const server = await import("@kagan-sh/kagan/server")
+      `import { ensureRuntimePluginSupport } from "@opentui/solid/runtime-plugin-support/configure"
+import { runtimeModules } from "@opentui/keymap/runtime-modules"
+ensureRuntimePluginSupport({ additional: runtimeModules })
+const server = await import("@kagan-sh/kagan/server")
 const tui = await import("@kagan-sh/kagan/tui")
 if (typeof server.default?.server !== "function") throw new Error("server export missing")
 if (typeof tui.default?.tui !== "function") throw new Error("tui export missing")`,

--- a/src/create-task.tsx
+++ b/src/create-task.tsx
@@ -137,7 +137,13 @@ function CreateTaskForm(props: {
       void submit()
       return true
     }
-    if (key.ctrl && key.name === "j") return false
+    if (
+      focusIndex() === 1 &&
+      ((key.ctrl && key.name === "j") || key.name === "linefeed" || (key.shift && key.name === "return"))
+    ) {
+      descriptionRef?.newLine()
+      return true
+    }
     if (key.name === "return") {
       if (focusIndex() >= 2) openPicker()
       else void submit()

--- a/src/create-task.tsx
+++ b/src/create-task.tsx
@@ -137,10 +137,8 @@ function CreateTaskForm(props: {
       void submit()
       return true
     }
+    if (key.ctrl && key.name === "j") return false
     if (key.name === "return") {
-      // In the description textarea, let Enter reach the field as a newline
-      // (ctrl+enter submits); consuming it here would swallow the newline.
-      if (focusIndex() === 1) return false
       if (focusIndex() >= 2) openPicker()
       else void submit()
       return true
@@ -224,8 +222,13 @@ function CreateTaskForm(props: {
           tab <span style={{ fg: theme().textMuted }}>move</span>
         </text>
         <text fg={theme().text}>
-          {focusIndex() === 0 ? "enter" : "ctrl+enter"} <span style={{ fg: theme().textMuted }}>create</span>
+          enter <span style={{ fg: theme().textMuted }}>create</span>
         </text>
+        <Show when={focusIndex() === 1}>
+          <text fg={theme().text}>
+            ctrl+j <span style={{ fg: theme().textMuted }}>newline</span>
+          </text>
+        </Show>
         <text fg={theme().text}>
           esc <span style={{ fg: theme().textMuted }}>cancel</span>
         </text>

--- a/src/intake.ts
+++ b/src/intake.ts
@@ -34,10 +34,7 @@ export async function spawnIntake(
   const childID = child.data?.id
   if (!childID) return undefined
 
-  await patchKagan(input.client, parentSessionID, {
-    intakeSessionID: childID,
-    intakeOutcome: "pending",
-  })
+  await patchKagan(input.client, parentSessionID, { intakeSessionID: childID })
 
   const scope = formatScope(task.scope)
   const promptText = [

--- a/src/server.ts
+++ b/src/server.ts
@@ -264,6 +264,8 @@ async function onEnterReview(input: PluginInput, sessionID: string, options?: Re
     const worktree = view.worktree
     if (!worktree) return
 
+    if (!(await claimHelperSpawn(input.client, sessionID, "validator"))) return
+
     const attempts = before.attempts + 1
     const diffs = await worktreeDiffs(shellGitRunner(input.$), worktree, view.baseBranch ?? "HEAD")
     const checkCommands = commandPlan(options, "check")

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ import {
 import { isGitPushCommand, worktreeDiffs, shellGitRunner } from "./git"
 import { composeStartPrompt, formatTaskRef, parseTaskRefs } from "./handoff"
 import { spawnIntake } from "./intake"
-import { getStatus, lastAssistantText, patchKagan } from "./session-api"
+import { claimHelperSpawn, getStatus, lastAssistantText, patchKagan } from "./session-api"
 import type { ColumnType } from "./types"
 import { spawnValidator } from "./validator"
 import { runCommandPlan, type CheckResult } from "./check"
@@ -199,7 +199,8 @@ async function resolveOwningBoardTask(input: PluginInput, sessionID: string): Pr
   return owningRootTaskID(session?.metadata, sessionID, session?.parentID)
 }
 
-const helperEntryClaims = new Set<string>()
+const helperEntryClaims = ((globalThis as Record<string, unknown>).__kaganHelperEntryClaims ??=
+  new Set<string>()) as Set<string>
 
 async function onEnterBacklog(input: PluginInput, sessionID: string, options?: Record<string, unknown>): Promise<void> {
   const key = `${sessionID}:intake`
@@ -214,6 +215,8 @@ async function onEnterBacklog(input: PluginInput, sessionID: string, options?: R
     const before = helper(metadata, "intake")
     if (before.outcome !== undefined) return
     if (before.sessionID !== undefined) return
+
+    if (!(await claimHelperSpawn(input.client, sessionID, "intake"))) return
 
     const attempts = before.attempts + 1
     const description = view.description

--- a/src/server.ts
+++ b/src/server.ts
@@ -219,10 +219,10 @@ async function onEnterBacklog(input: PluginInput, sessionID: string, options?: R
     if (!(await claimHelperSpawn(input.client, sessionID, "intake"))) return
 
     const attempts = before.attempts + 1
-    const description = view.description
-    const references = await resolveTaskRefs(input, description)
     let childID: string | undefined
     try {
+      const description = view.description
+      const references = await resolveTaskRefs(input, description)
       childID = await spawnIntake(
         input,
         sessionID,
@@ -267,22 +267,22 @@ async function onEnterReview(input: PluginInput, sessionID: string, options?: Re
     if (!(await claimHelperSpawn(input.client, sessionID, "validator"))) return
 
     const attempts = before.attempts + 1
-    const diffs = await worktreeDiffs(shellGitRunner(input.$), worktree, view.baseBranch ?? "HEAD")
-    const checkCommands = commandPlan(options, "check")
-    let check: CheckResult | undefined
-    if (checkCommands.length > 0) {
-      const changedFiles = diffs.map((diff) => diff.file).filter((file): file is string => typeof file === "string")
-      check = await runCommandPlan(checkCommands, worktree, (command) =>
-        commandMatchesChangedFile(command, changedFiles),
-      )
-      try {
-        await patchKagan(input.client, sessionID, { check })
-      } catch (error) {
-        console.error(`[kagan] failed to record check evidence for ${sessionID}: ${errorMessage(error)}`)
-      }
-    }
     let childID: string | undefined
     try {
+      const diffs = await worktreeDiffs(shellGitRunner(input.$), worktree, view.baseBranch ?? "HEAD")
+      const checkCommands = commandPlan(options, "check")
+      let check: CheckResult | undefined
+      if (checkCommands.length > 0) {
+        const changedFiles = diffs.map((diff) => diff.file).filter((file): file is string => typeof file === "string")
+        check = await runCommandPlan(checkCommands, worktree, (command) =>
+          commandMatchesChangedFile(command, changedFiles),
+        )
+        try {
+          await patchKagan(input.client, sessionID, { check })
+        } catch (error) {
+          console.error(`[kagan] failed to record check evidence for ${sessionID}: ${errorMessage(error)}`)
+        }
+      }
       childID = await spawnValidator(
         input,
         sessionID,

--- a/src/session-api.ts
+++ b/src/session-api.ts
@@ -6,6 +6,7 @@ import { runCommandPlan, type CommandSpec } from "./check"
 import {
   approveDenyReason,
   commandInTaskScope,
+  helper,
   kagan,
   nextGenerationPatch,
   rawKagan,
@@ -48,7 +49,10 @@ function mergeKagan(current: Record<string, unknown>, partial: Record<string, un
 // TUI plugins can run concurrently against the same session. Without serialization, two concurrent
 // patches read the same metadata snapshot and the second write clobbers the first (lost update).
 // This queues patches per session so each read-modify-write completes before the next one starts.
-const sessionLocks = new Map<string, Promise<unknown>>()
+const sessionLocks = ((globalThis as Record<string, unknown>).__kaganSessionLocks ??= new Map<
+  string,
+  Promise<unknown>
+>()) as Map<string, Promise<unknown>>
 
 // OpenCode also delivers a session.updated event — which can trigger another patch on the same
 // session — before the session.update() call that caused it has resolved. That makes the follow-up
@@ -90,6 +94,42 @@ async function patchCore(
     const currentMetadata = await get()
     const merged = mergeKagan(currentMetadata, partial)
     await update(merged)
+  })
+}
+
+async function patchKaganWhen(
+  client: PluginInput["client"],
+  sessionID: string,
+  compute: (metadata: Record<string, unknown>) => Record<string, unknown> | undefined,
+): Promise<boolean> {
+  let applied = false
+  await withSessionLock(sessionID, async () => {
+    const result = await client.session.get({ path: { id: sessionID }, throwOnError: true })
+    const currentMetadata = ((result.data as { metadata?: Record<string, unknown> } | undefined)?.metadata ??
+      {}) as Record<string, unknown>
+    const partial = compute(currentMetadata)
+    if (partial === undefined) return
+    applied = true
+    const merged = mergeKagan(currentMetadata, partial)
+    await client.session.update({
+      path: { id: sessionID },
+      body: { metadata: merged },
+      throwOnError: true,
+    } as Parameters<typeof client.session.update>[0])
+  })
+  return applied
+}
+
+export async function claimHelperSpawn(
+  client: PluginInput["client"],
+  sessionID: string,
+  role: HelperRole,
+): Promise<boolean> {
+  const outcomeField = `${role}Outcome`
+  return patchKaganWhen(client, sessionID, (metadata) => {
+    const before = helper(metadata, role)
+    if (before.outcome !== undefined || before.sessionID !== undefined) return undefined
+    return { [outcomeField]: "pending" }
   })
 }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -177,10 +177,7 @@ export async function spawnValidator(
   const childID = child.data?.id
   if (!childID) return undefined
 
-  await patchKagan(input.client, parentSessionID, {
-    validatorSessionID: childID,
-    validatorOutcome: "pending",
-  })
+  await patchKagan(input.client, parentSessionID, { validatorSessionID: childID })
 
   const priorTriage = formatPriorTriage(context.priorTriage)
   const check = context.check

--- a/test/create-task.test.tsx
+++ b/test/create-task.test.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource @opentui/solid */
-import { afterEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { testRender } from "@opentui/solid"
+import { EditBufferRenderable } from "@opentui/core"
 import type { TestRendererSetup } from "@opentui/core/testing"
-import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { KeyEvent, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { JSX } from "solid-js"
 import { attachRendererMockInput, mockTuiApi } from "./fixtures/api"
 
@@ -114,6 +115,12 @@ function lastKeyConsumed(api: TuiPluginApi): boolean {
   return !!(api.renderer.keyInput as { lastConsumed?: boolean }).lastConsumed
 }
 
+// Emit a raw key event through the mock keyInput. Used for chords the mockInput helper cannot
+// name directly (e.g. the Kitty-mode "linefeed" name, or shift+return).
+function emitKey(api: TuiPluginApi, event: Partial<KeyEvent> & { name: string }) {
+  ;(api.renderer.keyInput as unknown as { emitKey: (key: KeyEvent) => void }).emitKey(event as KeyEvent)
+}
+
 async function focusField(tabCount: number) {
   for (let i = 0; i < tabCount; i++) {
     renderSetup!.mockInput.pressTab()
@@ -185,18 +192,67 @@ describe("openCreateTaskDialog", () => {
     expect(createInput).toMatchObject({ title: "Ship docs", baseBranch: "feature" })
   })
 
-  test("ctrl+j inserts a newline in the description field instead of submitting", async () => {
-    const view = harness()
-    await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.api, view.renders)
+  test("ctrl+j inserts a newline in the focused description field and consumes the key instead of submitting", async () => {
+    const newLine = spyOn(EditBufferRenderable.prototype, "newLine").mockImplementation(() => true)
+    try {
+      const view = harness()
+      await openCreateTaskDialog(view.api, view.store as never)
+      await renderLatest(view.api, view.renders)
 
-    await renderSetup!.mockInput.typeText("Ship docs")
-    await focusField(1)
-    renderSetup!.mockInput.pressKey("j", { ctrl: true })
-    await renderSetup!.flush()
+      await renderSetup!.mockInput.typeText("Ship docs")
+      await focusField(1)
+      renderSetup!.mockInput.pressKey("j", { ctrl: true })
+      await renderSetup!.flush()
 
-    expect(createInput).toBeUndefined()
-    expect(lastKeyConsumed(view.api)).toBe(false)
+      // The real test renderer also decodes legacy Ctrl+J as linefeed into the textarea, so newLine
+      // may fire both from that path and from our intercept — assert it fired, not an exact count.
+      expect(newLine).toHaveBeenCalled()
+      expect(createInput).toBeUndefined()
+      expect(lastKeyConsumed(view.api)).toBe(true)
+    } finally {
+      newLine.mockRestore()
+    }
+  })
+
+  test("linefeed (legacy Ctrl+J decode) and shift+return also insert a newline in the description", async () => {
+    const newLine = spyOn(EditBufferRenderable.prototype, "newLine").mockImplementation(() => true)
+    try {
+      const view = harness()
+      await openCreateTaskDialog(view.api, view.store as never)
+      await renderLatest(view.api, view.renders)
+
+      await renderSetup!.mockInput.typeText("Ship docs")
+      await focusField(1)
+
+      emitKey(view.api, { name: "linefeed" })
+      expect(lastKeyConsumed(view.api)).toBe(true)
+
+      emitKey(view.api, { name: "return", shift: true })
+      expect(lastKeyConsumed(view.api)).toBe(true)
+
+      expect(newLine).toHaveBeenCalledTimes(2)
+      expect(createInput).toBeUndefined()
+    } finally {
+      newLine.mockRestore()
+    }
+  })
+
+  test("ctrl+j outside the description field is not treated as a newline", async () => {
+    const newLine = spyOn(EditBufferRenderable.prototype, "newLine").mockImplementation(() => true)
+    try {
+      const view = harness()
+      await openCreateTaskDialog(view.api, view.store as never)
+      await renderLatest(view.api, view.renders)
+
+      // focusIndex 0 (title): the newline handler must not fire.
+      renderSetup!.mockInput.pressKey("j", { ctrl: true })
+      await renderSetup!.flush()
+
+      expect(newLine).not.toHaveBeenCalled()
+      expect(lastKeyConsumed(view.api)).toBe(false)
+    } finally {
+      newLine.mockRestore()
+    }
   })
 
   test("ctrl+enter still submits from the description field on Kitty-style terminals", async () => {
@@ -216,7 +272,7 @@ describe("openCreateTaskDialog", () => {
     expect(createInput).toMatchObject({ title: "Ship docs", baseBranch: "feature" })
   })
 
-  test("return is intercepted from every focus field; ctrl+j is not in description", async () => {
+  test("return is intercepted from every focus field; ctrl+j is intercepted in the description", async () => {
     async function assertReturnConsumed(tabToFocus: number, scopes: string[] = []) {
       const view = harness(scopes)
       await openCreateTaskDialog(view.api, view.store as never)
@@ -233,13 +289,18 @@ describe("openCreateTaskDialog", () => {
     await assertReturnConsumed(3)
     await assertReturnConsumed(4)
 
-    const view = harness()
-    await openCreateTaskDialog(view.api, view.store as never)
-    await renderLatest(view.api, view.renders)
-    await focusField(1)
-    renderSetup!.mockInput.pressKey("j", { ctrl: true })
-    await renderSetup!.flush()
-    expect(lastKeyConsumed(view.api)).toBe(false)
+    const newLine = spyOn(EditBufferRenderable.prototype, "newLine").mockImplementation(() => true)
+    try {
+      const view = harness()
+      await openCreateTaskDialog(view.api, view.store as never)
+      await renderLatest(view.api, view.renders)
+      await focusField(1)
+      renderSetup!.mockInput.pressKey("j", { ctrl: true })
+      await renderSetup!.flush()
+      expect(lastKeyConsumed(view.api)).toBe(true)
+    } finally {
+      newLine.mockRestore()
+    }
   })
 
   test("preselects the only configured static scope", async () => {

--- a/test/create-task.test.tsx
+++ b/test/create-task.test.tsx
@@ -110,6 +110,17 @@ async function renderLatest(api: TuiPluginApi, renders: Array<() => JSX.Element>
   await renderSetup.flush()
 }
 
+function lastKeyConsumed(api: TuiPluginApi): boolean {
+  return !!(api.renderer.keyInput as { lastConsumed?: boolean }).lastConsumed
+}
+
+async function focusField(tabCount: number) {
+  for (let i = 0; i < tabCount; i++) {
+    renderSetup!.mockInput.pressTab()
+    await renderSetup!.flush()
+  }
+}
+
 describe("openCreateTaskDialog", () => {
   test("warns and does not create when title is blank", async () => {
     const view = harness()
@@ -161,7 +172,34 @@ describe("openCreateTaskDialog", () => {
     expect(view.notices.at(-1)).toEqual({ variant: "success", title: "Kagan", message: 'Created "Ship docs"' })
   })
 
-  test("ctrl+enter submits from the description field instead of inserting a newline", async () => {
+  test("enter submits from the description field", async () => {
+    const view = harness()
+    await openCreateTaskDialog(view.api, view.store as never)
+    await renderLatest(view.api, view.renders)
+
+    await renderSetup!.mockInput.typeText("Ship docs")
+    await focusField(1)
+    renderSetup!.mockInput.pressEnter()
+    await renderSetup!.flush()
+
+    expect(createInput).toMatchObject({ title: "Ship docs", baseBranch: "feature" })
+  })
+
+  test("ctrl+j inserts a newline in the description field instead of submitting", async () => {
+    const view = harness()
+    await openCreateTaskDialog(view.api, view.store as never)
+    await renderLatest(view.api, view.renders)
+
+    await renderSetup!.mockInput.typeText("Ship docs")
+    await focusField(1)
+    renderSetup!.mockInput.pressKey("j", { ctrl: true })
+    await renderSetup!.flush()
+
+    expect(createInput).toBeUndefined()
+    expect(lastKeyConsumed(view.api)).toBe(false)
+  })
+
+  test("ctrl+enter still submits from the description field on Kitty-style terminals", async () => {
     const view = harness()
     await openCreateTaskDialog(view.api, view.store as never)
     await renderSetup?.renderer.destroy()
@@ -176,6 +214,32 @@ describe("openCreateTaskDialog", () => {
     await renderSetup.flush()
 
     expect(createInput).toMatchObject({ title: "Ship docs", baseBranch: "feature" })
+  })
+
+  test("return is intercepted from every focus field; ctrl+j is not in description", async () => {
+    async function assertReturnConsumed(tabToFocus: number, scopes: string[] = []) {
+      const view = harness(scopes)
+      await openCreateTaskDialog(view.api, view.store as never)
+      await renderLatest(view.api, view.renders)
+      await focusField(tabToFocus)
+      renderSetup!.mockInput.pressEnter()
+      await renderSetup!.flush()
+      expect(lastKeyConsumed(view.api)).toBe(true)
+    }
+
+    await assertReturnConsumed(0)
+    await assertReturnConsumed(1)
+    await assertReturnConsumed(2, ["alpha", "beta"])
+    await assertReturnConsumed(3)
+    await assertReturnConsumed(4)
+
+    const view = harness()
+    await openCreateTaskDialog(view.api, view.store as never)
+    await renderLatest(view.api, view.renders)
+    await focusField(1)
+    renderSetup!.mockInput.pressKey("j", { ctrl: true })
+    await renderSetup!.flush()
+    expect(lastKeyConsumed(view.api)).toBe(false)
   })
 
   test("preselects the only configured static scope", async () => {

--- a/test/fixtures/api.ts
+++ b/test/fixtures/api.ts
@@ -32,6 +32,33 @@ export function mockTuiApi(overrides: Partial<TuiPluginApi> & { kvMap?: Record<s
   const kvMap = mockKv(overrides.kvMap)
   const keyHandlers = new Set<(key: KeyEvent) => void>()
   const interceptHandlers = new Set<(ctx: KeyInputContext) => void>()
+  const keyInput: {
+    on: (event: string, handler: (key: KeyEvent) => void) => void
+    off: (event: string, handler: (key: KeyEvent) => void) => void
+    emitKey: (key: KeyEvent) => void
+    lastConsumed?: boolean
+  } = {
+    on: (event: string, handler: (key: KeyEvent) => void) => {
+      if (event === "keypress") keyHandlers.add(handler)
+    },
+    off: (event: string, handler: (key: KeyEvent) => void) => {
+      if (event === "keypress") keyHandlers.delete(handler)
+    },
+    emitKey: (key: KeyEvent) => {
+      let consumed = false
+      const ctx = {
+        event: key,
+        setData: () => {},
+        getData: () => undefined,
+        consume: () => {
+          consumed = true
+        },
+      }
+      for (const handler of Array.from(interceptHandlers)) handler(ctx)
+      for (const handler of Array.from(keyHandlers)) handler(key)
+      keyInput.lastConsumed = consumed
+    },
+  }
   return {
     kv: {
       get: (key: string, defaultValue: unknown) => (key in kvMap ? kvMap[key] : defaultValue),
@@ -57,24 +84,7 @@ export function mockTuiApi(overrides: Partial<TuiPluginApi> & { kvMap?: Record<s
       height: 40,
       on: () => {},
       off: () => {},
-      keyInput: {
-        on: (event: string, handler: (key: KeyEvent) => void) => {
-          if (event === "keypress") keyHandlers.add(handler)
-        },
-        off: (event: string, handler: (key: KeyEvent) => void) => {
-          if (event === "keypress") keyHandlers.delete(handler)
-        },
-        emitKey: (key: KeyEvent) => {
-          const ctx = {
-            event: key,
-            setData: () => {},
-            getData: () => undefined,
-            consume: () => {},
-          }
-          for (const handler of Array.from(interceptHandlers)) handler(ctx)
-          for (const handler of Array.from(keyHandlers)) handler(key)
-        },
-      },
+      keyInput,
     },
     ...overrides,
   } as unknown as TuiPluginApi
@@ -133,7 +143,9 @@ function mockKeyEvent(
                 ? "left"
                 : key === "ARROW_RIGHT"
                   ? "right"
-                  : key
+                  : typeof key === "string" && key.length === 1
+                    ? key.toLowerCase()
+                    : key
   let defaultPrevented = false
   let propagationStopped = false
   return {

--- a/test/intake.test.ts
+++ b/test/intake.test.ts
@@ -83,13 +83,12 @@ describe("spawnIntake", () => {
     )
   })
 
-  test("patches intakeSessionID and pending outcome before prompting", async () => {
+  test("patches intakeSessionID before prompting", async () => {
     const order: string[] = []
     const { input } = mockSpawnInput({
       onUpdate: (options) => {
         order.push("update")
         const metadata = (options as { body?: { metadata?: Record<string, unknown> } }).body?.metadata
-        expect((metadata?.kagan as Record<string, unknown> | undefined)?.intakeOutcome).toBe("pending")
         expect((metadata?.kagan as Record<string, unknown> | undefined)?.intakeSessionID).toBe("child-1")
       },
       onPrompt: () => order.push("prompt"),

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1695,6 +1695,68 @@ describe("kagan server — duplicate helper spawn regression", () => {
     expect(roleCreates(captured, "intake")).toHaveLength(1)
   })
 
+  test("two module copies with stale reads spawn validator exactly once", async () => {
+    ;((globalThis as Record<string, unknown>).__kaganHelperEntryClaims as Set<string> | undefined)?.clear()
+
+    const reviewKagan = { status: "review", boardTask: true, worktree: "/wt", description: "Do the thing" }
+    const store: Record<string, SessionData> = {
+      s1: { title: "Add retry", metadata: { kagan: { ...reviewKagan } } },
+    }
+    const captured: Captured = { updates: [], creates: [], prompts: [], listCalls: [] }
+    let createCount = 0
+    const sharedInput = {
+      client: {
+        session: {
+          get: (async (options: unknown) => {
+            const id = (options as { path: { id: string } }).path.id
+            return { data: store[id] ?? { metadata: {} } }
+          }) as never,
+          update: (async (options: unknown) => {
+            const typed = options as { path: { id: string }; body: { metadata: Record<string, unknown> } }
+            const kagan = typed.body.metadata.kagan as Record<string, unknown>
+            captured.updates.push({ id: typed.path.id, kagan })
+            const existing = store[typed.path.id] ?? { metadata: {} }
+            const existingKagan = (existing.metadata?.kagan as Record<string, unknown>) ?? {}
+            store[typed.path.id] = {
+              ...existing,
+              metadata: { ...existing.metadata, kagan: { ...existingKagan, ...kagan } },
+            }
+            return { data: undefined }
+          }) as never,
+          create: (async (options: unknown) => {
+            captured.creates.push((options as { body: Record<string, unknown> }).body)
+            createCount += 1
+            return { data: { id: `validator-${createCount}` } }
+          }) as never,
+          promptAsync: (async (options: unknown) => {
+            const typed = options as { path: { id: string }; body: Record<string, unknown> }
+            captured.prompts.push({ id: typed.path.id, body: typed.body })
+            return { data: undefined }
+          }) as never,
+          list: (async () => ({ data: [] })) as never,
+          messages: (async () => ({ data: [] })) as never,
+        },
+      },
+      $: ((_s: TemplateStringsArray, ..._e: unknown[]) => ({
+        nothrow: () => ({
+          quiet: async () => ({ stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 0 }),
+        }),
+      })) as PluginInput["$"],
+      worktree: "/tmp/worktree",
+    } as unknown as PluginInput
+
+    const [modA, modB] = await Promise.all([loadServerCopy("val-a"), loadServerCopy("val-b")])
+    const [hooksA, hooksB] = await Promise.all([modA.server(sharedInput, {}), modB.server(sharedInput, {})])
+    const info = { id: "s1", title: "Add retry", metadata: { kagan: { ...reviewKagan, lastGatedStatus: "review" } } }
+
+    await Promise.all([
+      hooksA.event?.({ event: { type: "session.updated", properties: { info } } } as never),
+      hooksB.event?.({ event: { type: "session.updated", properties: { info } } } as never),
+    ])
+
+    expect(roleCreates(captured, "validator")).toHaveLength(1)
+  })
+
   test("spawn-failure auto-retry survives across two module copies", async () => {
     ;((globalThis as Record<string, unknown>).__kaganHelperEntryClaims as Set<string> | undefined)?.clear()
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1276,6 +1276,88 @@ describe("kagan server — helper failure: spawn-time throw", () => {
   })
 })
 
+describe("kagan server — helper failure: pre-spawn work throws before the claim is released", () => {
+  function roleCreates(captured: Captured, role: string) {
+    return captured.creates.filter((c) => (c.metadata as { kagan?: { role?: string } })?.kagan?.role === role)
+  }
+
+  test("validator: worktreeDiffs throwing before spawn clears the pending claim and a later event retries", async () => {
+    const metadata = { kagan: { ...boardReview.kagan, worktree: "/wt" } }
+    const store: Record<string, SessionData> = { s1: { title: "Task", metadata } }
+    let diffThrows = true
+    const { input, captured } = makeInput({
+      store,
+      createId: "validator-1",
+      gitStdout: (args) => {
+        if (diffThrows && args[0] === "merge-base") throw new Error("git merge-base exploded")
+        if (args[0] === "merge-base") return "abc123"
+        if (args.includes("--numstat")) return "1\t1\tfile.txt"
+        if (args.includes("--name-status")) return "M\tfile.txt"
+        return ""
+      },
+    })
+    const hooks = await plugin.server(input, {})
+
+    await hooks.event?.({
+      event: { type: "session.updated", properties: { info: { id: "s1", metadata } } },
+    } as never)
+
+    // The claim must be cleared by the failure funnel, not left stuck at "pending" forever.
+    expect(store.s1?.metadata?.kagan).toMatchObject({ validatorOutcome: undefined, validatorSessionID: undefined })
+    const cleared = captured.updates.find(
+      (u) => u.id === "s1" && u.kagan.validatorOutcome === undefined && u.kagan.validatorSessionID === undefined,
+    )
+    expect(cleared).toBeDefined()
+    expect(roleCreates(captured, "validator")).toHaveLength(0)
+
+    // A follow-up session.updated (diffs now succeed) must re-attempt the spawn.
+    diffThrows = false
+    await hooks.event?.({
+      event: { type: "session.updated", properties: { info: { id: "s1", metadata: store.s1!.metadata } } },
+    } as never)
+    expect(roleCreates(captured, "validator")).toHaveLength(1)
+  })
+
+  test("intake: a throw in the widened try (with resolveTaskRefs run inside it) clears the claim and the retry succeeds", async () => {
+    const metadata = { kagan: { status: "backlog", boardTask: true, description: "Build on #3" } }
+    const store: Record<string, SessionData> = { s1: { title: "T", metadata } }
+    let child = 0
+    const { input, captured } = makeInput({
+      store,
+      // sessions is empty so resolveTaskRefs does real work (resolves #3 to a not-found block)
+      // inside the widened try before spawnIntake runs.
+      sessions: [],
+      createId: () => `intake-${++child}`,
+      promptError: (id) => (id === "intake-1" ? new Error("ProviderModelNotFoundError: bad model") : undefined),
+    })
+    const hooks = await plugin.server(input, {})
+
+    const info = { id: "s1", title: "T", metadata }
+    await hooks.event?.({ event: { type: "session.created", properties: { info } } } as never)
+    await hooks.event?.({ event: { type: "session.updated", properties: { info } } } as never)
+
+    // First attempt threw inside spawnIntake: the claim must be cleared (not left pending), attempts bumped.
+    expect(store.s1?.metadata?.kagan).toMatchObject({ intakeOutcome: undefined, intakeSessionID: undefined })
+    const cleared = captured.updates.find(
+      (u) =>
+        u.id === "s1" &&
+        "intakeOutcome" in u.kagan &&
+        u.kagan.intakeOutcome === undefined &&
+        u.kagan.intakeSessionID === undefined,
+    )
+    expect(cleared?.kagan.intakeAttempts).toBe(1)
+    expect(roleCreates(captured, "intake")).toHaveLength(1)
+
+    // Follow-up session.updated drives the retry; the second child prompt succeeds.
+    await hooks.event?.({
+      event: { type: "session.updated", properties: { info: { id: "s1", metadata: store.s1!.metadata } } },
+    } as never)
+    expect(roleCreates(captured, "intake")).toHaveLength(2)
+    expect(captured.prompts.filter((p) => p.id === "intake-2")).toHaveLength(1)
+    expect(captured.updates.some((u) => u.id === "s1" && u.kagan.intakeOutcome === "failed")).toBe(false)
+  })
+})
+
 describe("kagan server — helper failure: session.error event", () => {
   const runningValidator = {
     kagan: {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -3,6 +3,12 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import plugin from "../src/server"
 import { approveDenyReason, helper, intakeReady } from "../src/task"
 
+const serverModuleUrl = new URL("../src/server.ts", import.meta.url).href
+
+async function loadServerCopy(suffix: string) {
+  return (await import(`${serverModuleUrl}?copy=${suffix}`)).default as typeof plugin
+}
+
 type SessionData = { title?: string; metadata?: Record<string, unknown>; parentID?: string | null }
 type ListedSession = { id: string; title?: string; parentID?: string | null; metadata?: Record<string, unknown> }
 
@@ -142,8 +148,10 @@ describe("kagan server — session.created", () => {
       bash: false,
       kagan_intake: true,
     })
+    const claim = captured.updates.find((u) => u.id === "s1" && u.kagan.intakeOutcome === "pending")
+    expect(claim).toBeDefined()
     const patch = captured.updates.find((u) => u.kagan.intakeSessionID === "intake-1")
-    expect(patch?.kagan.intakeOutcome).toBe("pending")
+    expect(patch?.kagan.intakeSessionID).toBe("intake-1")
   })
 
   test("skips non-board sessions", async () => {
@@ -1618,6 +1626,141 @@ describe("kagan server — duplicate helper spawn regression", () => {
     hooks = await plugin.server(input, {})
 
     await hooks.event?.({
+      event: { type: "session.updated", properties: { info: { id: "s1", ...store.s1 } } },
+    } as never)
+
+    const intakes = roleCreates(captured, "intake")
+    expect(intakes).toHaveLength(2)
+    expect(captured.prompts.filter((p) => p.id === "intake-2")).toHaveLength(1)
+  })
+
+  test("two module copies with stale reads spawn intake exactly once", async () => {
+    ;((globalThis as Record<string, unknown>).__kaganHelperEntryClaims as Set<string> | undefined)?.clear()
+
+    const store: Record<string, SessionData> = {
+      s1: { title: "Add retry", metadata: { kagan: { status: "backlog", boardTask: true } } },
+    }
+    const captured: Captured = { updates: [], creates: [], prompts: [], listCalls: [] }
+    let createCount = 0
+    const sharedInput = {
+      client: {
+        session: {
+          get: (async (options: unknown) => {
+            const id = (options as { path: { id: string } }).path.id
+            return { data: store[id] ?? { metadata: {} } }
+          }) as never,
+          update: (async (options: unknown) => {
+            const typed = options as { path: { id: string }; body: { metadata: Record<string, unknown> } }
+            const kagan = typed.body.metadata.kagan as Record<string, unknown>
+            captured.updates.push({ id: typed.path.id, kagan })
+            const existing = store[typed.path.id] ?? { metadata: {} }
+            const existingKagan = (existing.metadata?.kagan as Record<string, unknown>) ?? {}
+            store[typed.path.id] = {
+              ...existing,
+              metadata: { ...existing.metadata, kagan: { ...existingKagan, ...kagan } },
+            }
+            return { data: undefined }
+          }) as never,
+          create: (async (options: unknown) => {
+            captured.creates.push((options as { body: Record<string, unknown> }).body)
+            createCount += 1
+            return { data: { id: `intake-${createCount}` } }
+          }) as never,
+          promptAsync: (async (options: unknown) => {
+            const typed = options as { path: { id: string }; body: Record<string, unknown> }
+            captured.prompts.push({ id: typed.path.id, body: typed.body })
+            return { data: undefined }
+          }) as never,
+          list: (async () => ({ data: [] })) as never,
+          messages: (async () => ({ data: [] })) as never,
+        },
+      },
+      $: ((_s: TemplateStringsArray, ..._e: unknown[]) => ({
+        nothrow: () => ({
+          quiet: async () => ({ stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 0 }),
+        }),
+      })) as PluginInput["$"],
+      worktree: "/tmp/worktree",
+    } as unknown as PluginInput
+
+    const [modA, modB] = await Promise.all([loadServerCopy("a"), loadServerCopy("b")])
+    const [hooksA, hooksB] = await Promise.all([modA.server(sharedInput, {}), modB.server(sharedInput, {})])
+    const info = { id: "s1", title: "Add retry", metadata: { kagan: { status: "backlog", boardTask: true } } }
+
+    await Promise.all([
+      hooksA.event?.({ event: { type: "session.updated", properties: { info } } } as never),
+      hooksB.event?.({ event: { type: "session.updated", properties: { info } } } as never),
+    ])
+
+    expect(roleCreates(captured, "intake")).toHaveLength(1)
+  })
+
+  test("spawn-failure auto-retry survives across two module copies", async () => {
+    ;((globalThis as Record<string, unknown>).__kaganHelperEntryClaims as Set<string> | undefined)?.clear()
+
+    const store: Record<string, SessionData> = {
+      s1: {
+        title: "Add retry",
+        metadata: { kagan: { status: "backlog", boardTask: true, lastGatedStatus: "backlog" } },
+      },
+    }
+    const captured: Captured = { updates: [], creates: [], prompts: [], listCalls: [] }
+    let child = 0
+    const hooksByMod: Array<Awaited<ReturnType<typeof plugin.server>>> = []
+    const sharedInput = {
+      client: {
+        session: {
+          get: (async (options: unknown) => {
+            const id = (options as { path: { id: string } }).path.id
+            return { data: store[id] ?? { metadata: {} } }
+          }) as never,
+          update: (async (options: unknown) => {
+            const typed = options as { path: { id: string }; body: { metadata: Record<string, unknown> } }
+            const kagan = typed.body.metadata.kagan as Record<string, unknown>
+            captured.updates.push({ id: typed.path.id, kagan })
+            const existing = store[typed.path.id] ?? { metadata: {} }
+            const existingKagan = (existing.metadata?.kagan as Record<string, unknown>) ?? {}
+            store[typed.path.id] = {
+              ...existing,
+              metadata: { ...existing.metadata, kagan: { ...existingKagan, ...kagan } },
+            }
+            for (const hooks of hooksByMod) {
+              await hooks.event?.({
+                event: {
+                  type: "session.updated",
+                  properties: { info: { id: typed.path.id, ...store[typed.path.id] } },
+                },
+              } as never)
+            }
+            return { data: undefined }
+          }) as never,
+          create: (async (options: unknown) => {
+            captured.creates.push((options as { body: Record<string, unknown> }).body)
+            return { data: { id: `intake-${++child}` } }
+          }) as never,
+          promptAsync: (async (options: unknown) => {
+            const typed = options as { path: { id: string }; body: Record<string, unknown> }
+            captured.prompts.push({ id: typed.path.id, body: typed.body })
+            if (typed.path.id === "intake-1") throw new Error("boom")
+            return { data: undefined }
+          }) as never,
+          list: (async () => ({ data: [] })) as never,
+          messages: (async () => ({ data: [] })) as never,
+        },
+      },
+      $: ((_s: TemplateStringsArray, ..._e: unknown[]) => ({
+        nothrow: () => ({
+          quiet: async () => ({ stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 0 }),
+        }),
+      })) as PluginInput["$"],
+      worktree: "/tmp/worktree",
+    } as unknown as PluginInput
+
+    const [modA, modB] = await Promise.all([loadServerCopy("retry-a"), loadServerCopy("retry-b")])
+    const [hooksA, hooksB] = await Promise.all([modA.server(sharedInput, {}), modB.server(sharedInput, {})])
+    hooksByMod.push(hooksA, hooksB)
+
+    await hooksA.event?.({
       event: { type: "session.updated", properties: { info: { id: "s1", ...store.s1 } } },
     } as never)
 

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -324,13 +324,12 @@ describe("spawnValidator", () => {
     )
   })
 
-  test("patches validatorSessionID and pending outcome before prompting", async () => {
+  test("patches validatorSessionID before prompting", async () => {
     const order: string[] = []
     const { input } = mockSpawnInput({
       onUpdate: (options) => {
         order.push("update")
         const metadata = (options as { body?: { metadata?: Record<string, unknown> } }).body?.metadata
-        expect((metadata?.kagan as Record<string, unknown> | undefined)?.validatorOutcome).toBe("pending")
         expect((metadata?.kagan as Record<string, unknown> | undefined)?.validatorSessionID).toBe("child-1")
       },
       onPrompt: () => order.push("prompt"),


### PR DESCRIPTION
## Summary
Three independent bugs surfaced when kagan is installed from npm (vs. the local dev snapshot), plus their fixes:

- **Dead keyboard on npm installs.** OpenCode's Solid compile transform skips any path under `node_modules`, so publishing raw `src/*.tsx` meant the plugin's components were never Solid-compiled — no `onMount` ran, so no key handlers registered. Now we pre-compile `src` → `dist` per-file with OpenTUI's own `transformSolidSource` (`scripts/build.ts`), keeping `@opentui/*` and `solid-js` as external bare imports the host provides. Publish `dist` instead of `src`, move those runtime libs to optional `peerDependencies`, and add a `prepack` hook so `npm pack`/publish always builds first.
- **Ctrl+Enter never created a task.** Most terminals send bare CR for both Enter and Ctrl+Enter, so the modifier never arrives. Plain **Enter now submits** the create-task dialog from every field; **Ctrl+J** inserts a newline in the description.
- **Two intake/validator agents spawned per task (Ubuntu).** A duplicate plugin load in a task worktree gave each module copy its own in-memory guard, so concurrent `session.updated` events could both spawn a helper. Share `helperEntryClaims` and `sessionLocks` on `globalThis`, and claim the spawn (`{role}Outcome: "pending"`) inside the serialized metadata lock before creating the child. A failed spawn clears the claim so retries still work. Applied to both the intake and validator paths.

## Test plan
- [x] `bun run check` — prettier, oxlint, tsc, 641 tests pass, build, `package:check`
- [x] `dist/` is Solid-compiled (no raw JSX; `@opentui/*`/`solid-js` external), no bundled host deps in the packed tarball
- [ ] **Manual runtime smoke test:** `npm pack` → install under `node_modules/@kagan-sh/kagan` with host peers → open the board and confirm arrows/Tab/Enter work
- [ ] Create a task: Enter submits from the description; Ctrl+J inserts a newline
- [ ] New task on Ubuntu: exactly one intake agent spawns

## Notes / follow-ups
- `scripts/build.ts` imports OpenTUI's non-exported `scripts/solid-transform.js` — works today, brittle across OpenTUI upgrades.
- Dev pins are `@opentui 0.4.2` while the peer floor is `>=0.4.3`; `AGENTS.md` may still say "never pre-transform" — doc/version follow-ups.