### PR TITLE
test: run real-git tests in isolation and guard global-state leaks

### DIFF
--- a/test/fixtures/git.ts
+++ b/test/fixtures/git.ts
@@ -1,0 +1,26 @@
+import type { GitResult, GitRunner } from "../../src/git/runner"
+
+// Runs the real git binary with every GIT_* variable stripped and global/system config routed to
+// /dev/null, so a test's temp repos can neither read nor write the user's real repo or gitconfig.
+function hermeticGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !key.startsWith("GIT_")) env[key] = value
+  }
+  env.GIT_CONFIG_GLOBAL = "/dev/null"
+  env.GIT_CONFIG_SYSTEM = "/dev/null"
+  return env
+}
+
+export function hermeticGitRunner(): GitRunner {
+  const env = hermeticGitEnv()
+  return async (args, cwd): Promise<GitResult> => {
+    const proc = Bun.spawn(["git", ...args], { cwd, env, stdout: "pipe", stderr: "pipe", stdin: "ignore" })
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    return { code, stdout, stderr }
+  }
+}

--- a/test/fixtures/git.ts
+++ b/test/fixtures/git.ts
@@ -1,14 +1,15 @@
+import { devNull } from "node:os"
 import type { GitResult, GitRunner } from "../../src/git/runner"
 
 // Runs the real git binary with every GIT_* variable stripped and global/system config routed to
-// /dev/null, so a test's temp repos can neither read nor write the user's real repo or gitconfig.
+// the null device, so a test's temp repos can neither read nor write the user's real repo or gitconfig.
 function hermeticGitEnv(): Record<string, string> {
   const env: Record<string, string> = {}
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined && !key.startsWith("GIT_")) env[key] = value
   }
-  env.GIT_CONFIG_GLOBAL = "/dev/null"
-  env.GIT_CONFIG_SYSTEM = "/dev/null"
+  env.GIT_CONFIG_GLOBAL = devNull
+  env.GIT_CONFIG_SYSTEM = devNull
   return env
 }
 

--- a/test/git/runner.test.ts
+++ b/test/git/runner.test.ts
@@ -5,7 +5,6 @@ import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   baseBranchFreshness,
-  bunGitRunner,
   createTaskWorktree,
   ensureWorktreePluginConfig,
   type GitResult,
@@ -16,6 +15,7 @@ import {
 import { mergeTaskBranch } from "../../src/git/merge"
 import { orderDiffsByRisk, worktreeDiffs } from "../../src/git/diffs"
 import { newSideHunkRanges } from "../../src/domain/task/findings"
+import { hermeticGitRunner } from "../fixtures/git"
 
 function stubRunner(
   handler: (args: string[], cwd: string) => Partial<GitResult> | undefined,
@@ -336,7 +336,7 @@ describe("mergeTaskBranch", () => {
 })
 
 describe("mergeTaskBranch (real repo)", () => {
-  const run = bunGitRunner()
+  const run = hermeticGitRunner()
   const tempDirs: string[] = []
 
   afterEach(async () => {

--- a/test/guards/hermeticity.test.ts
+++ b/test/guards/hermeticity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join, relative } from "node:path"
+
+const testDir = new URL("../", import.meta.url).pathname
+const helper = "fixtures/git.ts"
+
+function testFiles(directory = testDir): string[] {
+  return readdirSync(directory).flatMap((name) => {
+    const path = join(directory, name)
+    if (statSync(path).isDirectory()) return testFiles(path)
+    return /\.tsx?$/.test(name) ? [path] : []
+  })
+}
+
+describe("git hermeticity", () => {
+  test("no test spawns real git except through the hermetic helper", () => {
+    const offenders = testFiles().filter((path) => {
+      if (relative(testDir, path) === helper) return false
+      const source = readFileSync(path, "utf8")
+      return /\bbunGitRunner\(/.test(source) || /Bun\.spawn\(\s*\[\s*["']git["']/.test(source)
+    })
+    expect(offenders.map((path) => relative(testDir, path))).toEqual([])
+  })
+
+  test("no test passes --global or --system to git", () => {
+    const offenders = testFiles().filter((path) => /["'](--global|--system)["']/.test(readFileSync(path, "utf8")))
+    expect(offenders.map((path) => relative(testDir, path))).toEqual([])
+  })
+})

--- a/test/tui/board/commands.test.ts
+++ b/test/tui/board/commands.test.ts
@@ -10,7 +10,7 @@ import { join } from "node:path"
 import type { BoardSession } from "../../../src/tui/types"
 import { SETTINGS_ROUTE } from "../../../src/tui/types"
 import type { BoardStore } from "../../../src/tui/board/commands"
-import { bunGitRunner } from "../../../src/git/runner"
+import { hermeticGitRunner } from "../../fixtures/git"
 import { attachRendererMockInput, mockSessionClient, mockTheme, mockTuiApi } from "../../fixtures/api"
 
 import { BOARD_BINDINGS, createBoardCommands, footerHints } from "../../../src/tui/board/commands"
@@ -1128,7 +1128,7 @@ describe("createBoardCommands", () => {
   }
 
   test("approving reaches promptAnotherBranch, which warns when the task's own branch is the only local branch", async () => {
-    const run = bunGitRunner()
+    const run = hermeticGitRunner()
     const repoDir = await mkdtemp(join(tmpdir(), "kagan-cmd-repo-"))
     tempDirs.push(repoDir)
     await run(["init", "-q", "-b", "main"], repoDir)


### PR DESCRIPTION
## What

Tests that spawn the real `git` binary now run through a sanitized runner (`test/fixtures/git.ts`): every `GIT_*` environment variable is stripped and `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` point at `/dev/null`, so fixture repos can neither read nor write the user's global git config, and a leaked `GIT_DIR` can never redirect them onto the real repository.

A new guard (`test/guards/hermeticity.test.ts`) fails the suite if any test spawns git outside the helper or passes `--global`/`--system`.

## Why

Running the suite inside this linked worktree's pre-commit hook exported `GIT_DIR`, which hijacked the fixture repos' `git init`/`config`/`worktree`/`merge` calls onto the real repository — it rewrote the repo-local user identity, flagged the repo bare, moved `main`, and registered six fixture worktrees/branches. The hook now unsets `GIT_*`, and this change makes the tests themselves safe in any invocation context.

## Verification

- `bun run verify` (verifyx all) green
- `bun run test`: 587 pass, 0 fail
- Teardown audited suite-wide: temp dirs, `.opencode` fixtures, and the hash-scoped `~/.kagan/worktrees` dir all clean up in `afterEach`, failure-safe