### PR TITLE
feat: automatically prepare compatible updates

### DIFF
--- a/.claude/skills/opencode-plugin-idioms/SKILL.md
+++ b/.claude/skills/opencode-plugin-idioms/SKILL.md
@@ -2,10 +2,10 @@
 name: opencode-plugin-idioms
 description: Event hook payload shapes, session lifecycle timing, toast/TUI-route render boundaries, and child-session tagging conventions for OpenCode server (@opencode-ai/plugin) and TUI (@opencode-ai/plugin/tui) plugins, grounded in the vendored OpenCode source at references/opencode.
 type: prompt
-whenToUse: Load before modifying src/server.ts, src/tui.tsx, src/tui/board/board.tsx, src/tui/board/commands.tsx, src/tui/board/store.tsx, src/server/intake.ts, or src/server/validator/spawn.ts — or when debugging a missing toast, a session-creation race, a permission/gate ordering bug, or a plugin-spawned child session re-triggering its own handler.
+whenToUse: Load before modifying src/server.ts, src/tui.tsx, src/tui/board/board.tsx, src/tui/board/commands.tsx, src/tui/board/store.tsx, src/tui/updates.ts, src/tui/update-manager.ts, src/server/intake.ts, or src/server/validator/spawn.ts — or when debugging a missing toast, a session-creation race, a permission/gate ordering bug, or a plugin-spawned child session re-triggering its own handler.
 ---
 
-Version check: repo pins `@opencode-ai/plugin@1.17.13`; vendored copy at `references/opencode/packages/plugin/package.json` should match — verify there, never from memory.
+Version check: repo pins `@opencode-ai/plugin@1.17.18`; vendored copy at `references/opencode/packages/plugin/package.json` should match — verify there, never from memory.
 
 ## 1. Event hook: what fires, exact payload, and ordering guarantees
 
@@ -139,6 +139,10 @@ The shared `App()` render tree switches on route type and renders a plugin's cus
 ```
 
 When `route.data.type === "plugin"` (this repo's `api.route.navigate(ROUTE)` in `src/tui.tsx:29`), neither `<Switch>` `<Match>` fires, so `<Home/>`/`<Session/>` (and their embedded `<Toast/>`) don't mount. **A toast call made while the kagan board is the active route is not dropped by a race or clobbered visually — there is simply no `<Toast/>` component mounted to render it.** It is silently swallowed until the user navigates back to `home` or a `session` route. Use the board's own notice overlay for board-route feedback.
+
+Automatic update status deliberately uses a separate dual surface: `api.ui.toast` once when the
+current route is `home` or `session`, and persistent footer state on the Kagan route. It never enters
+`store.notify`; operational task warnings retain the board Notice queue.
 
 ## 4. Spawning child/helper sessions without recursive triggering
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      opencode:
+        patterns:
+          - "@opencode-ai/plugin"
+          - "@opencode-ai/sdk"
+        update-types:
+          - minor
+          - patch

--- a/.specs/README.md
+++ b/.specs/README.md
@@ -6,7 +6,7 @@ plugin today.
 ## Files and authority order
 
 1. [`requirements.md`](./kagan-supervision-board/requirements.md) — what must be true. EARS-style
-   acceptance criteria with stable numbers (R1–R17); code and tests trace to these. When documents
+   acceptance criteria with stable numbers (R1–R18); code and tests trace to these. When documents
    disagree, this one wins.
 2. [`design.md`](./kagan-supervision-board/design.md) — how it's built: architecture constraints,
    the metadata model, and the key flows, each traced to the requirements it satisfies.

--- a/.specs/kagan-supervision-board/design.md
+++ b/.specs/kagan-supervision-board/design.md
@@ -1,7 +1,7 @@
 # Design — Kagan Supervision Board
 
 Technical design backing [requirements.md](./requirements.md). Traces each subsystem to the
-requirements it satisfies (R1–R17).
+requirements it satisfies (R1–R18).
 
 ## Overview
 
@@ -13,12 +13,13 @@ Kagan ships as two OpenCode plugin surfaces from one package:
   state of its own; everything authoritative lives in session metadata.
 - **TUI plugin** (`src/tui.tsx`, default export `{ id, tui }`) — renders the board route, the
   create-task dialog, and the triage/merge dialogs; owns user-initiated actions (create, move,
-  triage, approve, send-back) via a Solid store.
+  triage, approve, send-back) via a Solid store and owns automatic update checking, preparation,
+  promotion, and feedback.
 
 Both receive the plugin `options` object (OpenCode config). The option reference in
 [`docs/reference/configuration.md`](../../docs/reference/configuration.md) is canonical.
 
-## Architecture constraints (verified against @opencode-ai/{plugin,sdk} 1.17.13)
+## Architecture constraints (verified against @opencode-ai/{plugin,sdk} 1.17.18)
 
 These constraints shape the design and must hold for it to be correct:
 
@@ -38,8 +39,14 @@ These constraints shape the design and must hold for it to be correct:
   `info.id`); `session.idle` carries `properties.sessionID`.
 - **`promptAsync`** starts an agent turn and returns immediately; used for every agent-starting
   prompt (intake, validator, auto-start, send-back).
-- **Toasts are invisible while the board route is active**, so all board feedback uses the board's
-  own `Notice` overlay via the store, never `api.ui.toast`.
+- **Toasts are invisible while the board route is active**, so task and board-action feedback uses
+  the board's own `Notice` overlay. Automatic update feedback is the deliberate exception: one host
+  toast on home/session routes plus persistent board footer state, never the Notice queue (R3.8,
+  R18.5).
+- **Plugin activation ends at restart.** `api.plugins.add` can resolve, compatibility-check, import,
+  and validate an exact package during the current TUI process, but server hooks already loaded by
+  OpenCode cannot be replaced safely. Compatible npm updates therefore promote only during
+  `api.lifecycle.onDispose`; restart loads the promoted wrapper (R18).
 - **The host dialog stack already centers each dialog element** in a full-screen overlay, so the
   create-task dialog renders bare content and calls `dialog.setSize`, rather than wrapping itself in
   another overlay.
@@ -78,12 +85,14 @@ same-session writes so concurrent event handlers cannot clobber each other.
 | `server/intake.ts`                                | `spawnIntake` read-only child                                                                                                                                      | R4                                                   |
 | `server/validator/`                               | `spawnValidator` read-only child, diff+context prompt, validator model rotation                                                                                    | R9                                                   |
 | `checks/runner.ts`                                | Setup/check command runner with timeout, skipped/ran step evidence, and output tail                                                                                | R9.11–15, R17.2–3                                    |
+| `tui.tsx`                                         | TUI composition, routes, subscriptions, automatic-update orchestration, and route-aware update toast                                                               | R3, R18.3–5, R18.9                                   |
 | `tui/session/`, `tui/tasks/`                      | TUI data ops: list/create, serialized metadata patching, send-back, merge, triage, approval, retry                                                                 | R1, R3.2, R11, R12, R17.8                            |
 | `tui/dialogs/create-task.tsx`                     | Custom OpenTUI create dialog, including configured/custom task scope selection                                                                                     | R1.1–1.4, R1.9–10                                    |
-| `tui/board/store.tsx`                             | Solid board store: grouping, ordering, selection, move gating, refresh, notices                                                                                    | R3, R7, R17.4–5                                      |
+| `tui/board/store.tsx`                             | Solid board store: grouping, ordering, selection, move gating, refresh, notices, and update status                                                                 | R3, R7, R17.4–5, R18                                 |
 | `tui/board/commands.tsx`                          | Key bindings and dialog flows: create, move, triage, approve/merge, send-back, retry, task details view                                                            | R5.2, R10, R11, R12, R17.3, R17.7                    |
-| `tui/board/board.tsx` / `column.tsx` / `card.tsx` | Board layout, column headers with cap, cards with task number and badges; board footer shows version and update banner                                             | R3, R3.7–8, R7.4                                     |
-| `tui/updates.ts`                                  | npm dist-tag lookup with TTL cache; semver comparison for update banner                                                                                            | R3.8                                                 |
+| `tui/board/board.tsx` / `column.tsx` / `card.tsx` | Board layout, column headers with cap, cards with task number and badges; board footer shows version and persistent update status                                  | R3, R3.7–8, R7.4, R18                                |
+| `tui/updates.ts`                                  | one-hour npm latest/manifest cache and `engines.opencode` classification                                                                                           | R3.8, R18.1, R18.4, R18.6–7                          |
+| `tui/update-manager.ts`                           | exact-release preparation, hostile-path validation, disposal promotion/restore, and successful-load cleanup                                                        | R18.2–3, R18.6–9                                     |
 | `tui/format.ts`                                   | Card badges, age/diff/subtask formatting                                                                                                                           | R3.6                                                 |
 | `tui/dialogs/task-details.tsx`                    | Read-only task details view from live session metadata and diff stats                                                                                              | R17.7                                                |
 | `tui/dialogs/onboarding.tsx`                      | First-run board tour and opt-out persistence                                                                                                                       | R17.6                                                |
@@ -204,6 +213,19 @@ back-pointer even if role is absent. When both are true it throws, which OpenCod
 agent as a failed tool call carrying the thrown message; a generic OpenCode session (neither board
 task, role, nor parent back-pointer) is left untouched, and non-`bash` tool calls and non-push bash
 commands are ignored.
+
+**Automatic update (R18).** Only TUI instances loaded from bare `@kagan-sh/kagan` or explicit
+`@latest` resolve npm `latest`; exact pins and file installs return before network access. A newer
+clean release is classified only after its manifest supplies a valid `engines.opencode` range.
+Compatible latest is prepared exactly through `api.plugins.add`, which independently performs the
+host compatibility check and imports the package without activating a duplicate `kagan` plugin id.
+The manager proves that the current and prepared targets are non-symlinked
+`opencode/packages/@kagan-sh/kagan@…/node_modules/@kagan-sh/kagan` wrappers before writing one
+sibling marker. Its disposal callback renames current to one backup, promotes prepared to
+`kagan@latest`, and restores current if promotion fails. The next successful load of the marker's
+version removes only that validated backup and marker. Ready/blocked status is a dedicated store
+signal: home/session routes receive one host toast, while the board renders persistent footer text
+and never consumes Notice capacity.
 
 ## Configuration
 

--- a/.specs/kagan-supervision-board/requirements.md
+++ b/.specs/kagan-supervision-board/requirements.md
@@ -80,9 +80,8 @@ status cues, so that I can see at a glance what needs my attention.
 6. WHILE a Backlog task is intake-ready, its card SHALL display a distinct border color and an
    `intake ok` badge indicating it is eligible to move to In Progress.
 7. THE board footer SHALL display the plugin name and version.
-8. WHERE the published npm `latest` dist-tag is a newer clean release (`x.y.z`) than the
-   installed plugin version, the board footer SHALL append an update-available indicator naming
-   that version.
+8. WHERE automatic update status is ready or blocked, the board footer SHALL persist the prepared
+   version or the OpenCode compatibility requirement respectively (R18).
 9. WHILE a task is in Review and not yet approved, the board SHALL sort its card ahead of other
    cards in that column.
 10. WHILE a Backlog task's intake outcome is `failed`, the card SHALL display a distinct failed
@@ -460,3 +459,32 @@ so that failures, handoffs, and supervision evidence are visible instead of hidd
     child sessions instead of the session default.
 13. WHERE the plugin options set `validatorModels`, Kagan SHALL rotate reviewer models per the
     configuration reference when spawning validator sessions.
+
+---
+
+## Requirement 18 — Automatic npm updates
+
+**User Story:** As an npm user, I want Kagan to prepare compatible releases automatically and tell
+me when OpenCode blocks one, so that updating requires only a restart and no compatibility judgment.
+
+#### Acceptance Criteria
+
+1. WHERE Kagan was loaded from bare `@kagan-sh/kagan` or explicit `@latest`, Kagan SHALL check npm
+   `latest` no more than once per successful one-hour cache window.
+2. WHEN npm `latest` is newer and its `engines.opencode` range accepts the running OpenCode version,
+   Kagan SHALL prepare that exact release through the TUI plugin API without changing plugin config.
+3. WHEN a compatible release has been prepared THEN Kagan SHALL keep the running wrapper unchanged
+   until TUI disposal, promote the prepared wrapper during disposal, and require an OpenCode restart
+   to activate it.
+4. WHEN npm `latest` requires a different OpenCode version THEN Kagan SHALL leave the current
+   wrapper unchanged and SHALL persistently name the required OpenCode range on the board.
+5. WHERE automatic update status is ready or blocked on a home or session route, Kagan SHALL show
+   one host toast; update status SHALL NOT enter the board Notice queue.
+6. IF Kagan was loaded from an exact npm pin or a local/file source THEN Kagan SHALL NOT query npm,
+   prepare a release, or mutate its wrapper.
+7. IF a registry request, manifest validation, download, import, or cache-path validation fails THEN
+   Kagan SHALL remain quiet and SHALL leave the current wrapper unchanged.
+8. WHEN promotion of the prepared wrapper fails after the current wrapper was moved to backup THEN
+   Kagan SHALL restore the current wrapper immediately.
+9. WHEN the prepared version loads successfully after restart THEN Kagan SHALL remove its validated
+   backup and marker without deleting any broader OpenCode cache path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,12 @@ spec authority and read order. `src/domain/task/metadata.ts` is the authoritativ
   board that does not repaint. The architecture guard enforces this.
 - Use `TuiPluginApi` for renderer dimensions, keyboard input, and keymap layers; do not import
   OpenTUI/Solid context hooks for those surfaces.
+- Automatic updates are TUI-only. `src/tui/updates.ts` checks npm `latest` for bare/`@latest`
+  installs, prepares compatible exact releases through `api.plugins.add`, promotes only on
+  `api.lifecycle.onDispose`, and toasts only on home/session routes. Never add a server update hook
+  or touch exact pins and file installs. `src/tui/update-manager.ts` treats cache paths as hostile:
+  it accepts only non-symlinked `@kagan-sh/kagan` wrappers and removes only its own marker and single
+  backup; never broaden that deletion.
 
 ## External APIs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,9 @@ bun run plugin:install
 ```
 
 This installs your local build into OpenCode. Open a project in OpenCode and launch the board to
-see your changes. Run `bun run plugin:reset` to undo it.
+see your changes. Local/file installs, including `plugin:install:prod`, intentionally skip automatic
+update checks; only a published bare/`@latest` npm install exercises that path. Run
+`bun run plugin:reset` to undo the install.
 
 ## The one command that has to pass
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The agent never touches your checkout. It works on a `kagan/<slug>` branch in it
 
 ## Install
 
-You need [OpenCode](https://opencode.ai/) **1.17.13** or newer (below **1.18.0** — see `engines.opencode` in `package.json`).
+You need [OpenCode](https://opencode.ai/) **1.17.13** or newer (below **1.18.0** — see
+`engines.opencode` in `package.json`).
 
 From npm:
 
@@ -35,7 +36,11 @@ Or add a local clone to both OpenCode config files:
 
 Open the board with `/kagan` from the command palette, the `kagan` palette command, or `<leader>k` (the leader key defaults to `ctrl+x`).
 
-OpenCode caches the version it first installs and never re-checks, so the board footer flags when a newer release is out — see [Updating](https://docs.kagan.sh/quickstart/#updating) to move to it.
+For bare `@kagan-sh/kagan` and explicit `@latest` installs, Kagan prepares compatible `latest`
+releases automatically. Ready or blocked updates appear once as a host toast on home/session routes
+and persist in the board footer. Restart OpenCode when an update is ready; if `latest` needs a newer
+OpenCode, Kagan names the required range. Exact version pins and local installs remain unchanged. See
+[Updating](https://docs.kagan.sh/quickstart/#updating).
 
 Pass options by using the array-of-array form, or open `/kagan-settings` from the project — see the [configuration reference](https://docs.kagan.sh/reference/configuration/).
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,19 +5,21 @@
     "": {
       "name": "kagan",
       "dependencies": {
-        "@opencode-ai/plugin": "1.17.13",
+        "@opencode-ai/plugin": "1.17.18",
+        "semver": "7.8.5",
         "zod": "4.1.8",
       },
       "devDependencies": {
         "@babel/core": "7.28.0",
         "@babel/preset-typescript": "7.27.1",
         "@makerx/verify": "1.2.0",
-        "@opencode-ai/sdk": "1.17.13",
+        "@opencode-ai/sdk": "1.17.18",
         "@opentui/core": "0.4.3",
         "@opentui/keymap": "0.4.3",
         "@opentui/solid": "0.4.3",
         "@tsconfig/bun": "1.0.10",
         "@types/bun": "1.3.13",
+        "@types/semver": "7.7.1",
         "babel-plugin-module-resolver": "5.0.2",
         "babel-preset-solid": "1.9.12",
         "oxlint": "1.60.0",
@@ -248,9 +250,9 @@
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.17.13", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.3.4", "@opentui/keymap": ">=0.3.4", "@opentui/solid": ">=0.3.4" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-JjoIs6qTPl0IrXo+J1GTqX9lcb2h2dMoW6BWMR2IbTT3MY2FQ/lvBXDzkx0d3zVRaYN+NTmV4u8Nth396xq+sQ=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.17.18", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.17.18", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.3", "@opentui/keymap": ">=0.4.3", "@opentui/solid": ">=0.4.3" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-tqVBzhTHYUzO0laAmcQeBtT56tXYM5VGUk9V60O+cMx4kkSfac4qEfPVguCGUMJnfcU+u+EPvpME6xmHWoQE8w=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-VItOGjMzRQx3zypwmeFLNhCiIx32kxS7FqzIJvVZLfyNGCifs3rfGC9qzNKWcxQo4SjNvAw++v4gWWU6Inv+JQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.18", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-c/C9PhY8PrbcxDY+JIYtOZsrmMD0KzoVvxq+RGUrZ6LQp57SuVBbT4lfwA2G8Se5RNC1N5JtYjiuaXeECnF2SQ=="],
 
     "@opentui/core": ["@opentui/core@0.4.3", "", { "dependencies": { "bun-ffi-structs": "0.2.4", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.3", "@opentui/core-darwin-x64": "0.4.3", "@opentui/core-linux-arm64": "0.4.3", "@opentui/core-linux-arm64-musl": "0.4.3", "@opentui/core-linux-x64": "0.4.3", "@opentui/core-linux-x64-musl": "0.4.3", "@opentui/core-win32-arm64": "0.4.3", "@opentui/core-win32-x64": "0.4.3" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ=="],
 
@@ -423,6 +425,8 @@
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -960,7 +964,7 @@
 
     "semantic-release": ["semantic-release@25.0.5", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "semver-regex": ["semver-regex@4.0.5", "", {}, "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="],
 
@@ -1136,11 +1140,15 @@
 
     "@actions/http-client/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "@makerx/verify/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
-
-    "@semantic-release/npm/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
 
@@ -1155,8 +1163,6 @@
     "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
-    "conventional-changelog-writer/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "crypto-random-string/type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
@@ -1179,8 +1185,6 @@
     "make-asynchronous/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "marked-terminal/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
-
-    "normalize-package-data/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "npm/@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
 
@@ -1484,8 +1488,6 @@
 
     "semantic-release/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
-    "semantic-release/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
     "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "signale/figures": ["figures@2.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA=="],
@@ -1573,8 +1575,6 @@
     "signale/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
-
-    "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "cli-highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,5 +26,9 @@ Plain OpenCode chat sessions are untouched: no board card, no intake, no gating.
 Supervised task sessions cannot push to a remote — work leaves the sandbox only through the board's
 merge dialog.
 
+Bare `@kagan-sh/kagan` and explicit `@latest` installs also prepare compatible Kagan `latest`
+releases automatically; see [Updating](/quickstart#updating) for restart-to-apply and OpenCode
+compatibility behavior.
+
 Start with the [Quickstart](/quickstart). The lifecycle in full detail:
 [Task lifecycle](/concepts/task-lifecycle).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,26 +26,17 @@ entry shown in the [configuration reference](/reference/configuration).
 
 ## Updating
 
-When a newer version is published, the board footer shows `→ vX.Y.Z available` (the check hits npm at
-most once a day). OpenCode does **not** update plugins on its own: the
-first version it installs is cached and reused on every launch, and re-running `opencode plugin
-@kagan-sh/kagan` reuses that same cache. To move to a newer version, use one of these:
+Bare `@kagan-sh/kagan` and explicit `@latest` installs check npm at most once per successful
+one-hour window. When `latest` supports the running OpenCode, Kagan prepares it in the background
+and shows `vX.Y.Z ready — restart OpenCode`; restart once to apply it. Ready and blocked status
+appears once as a host toast on home/session routes and persists in the board footer.
 
-**Refresh the cached install** — remove Kagan's cached package, then restart OpenCode. It reinstalls
-the latest on the next launch.
+If `latest` requires another OpenCode version, Kagan keeps the current release and names the
+required OpenCode range. Update-check and preparation failures are silent and never disturb the
+working plugin; the ready message appears only after preparation succeeds.
 
-```bash
-rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/opencode/packages/@kagan-sh/kagan@latest"
-```
-
-**Pin a version and bump it** — set an explicit version in `opencode.json` and `tui.json`. OpenCode
-caches each exact version separately, so changing the number forces a clean install:
-
-```json
-{
-  "plugin": ["@kagan-sh/kagan@0.1.3"]
-}
-```
+Exact version pins and local/file installs are advanced-user choices. Kagan never checks or changes
+them automatically.
 
 ## Your first task
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,6 +36,14 @@ task back with instructions to rebase onto the current base.
 Supervised sessions cannot push to a remote. Use the board's approve/merge flow, or take over the
 worktree yourself if you need a different git flow.
 
+**The footer says an update is ready.**
+Kagan has prepared that release without changing the running plugin. Restart OpenCode once to
+apply it.
+
+**The footer says to update OpenCode for a Kagan release.**
+That Kagan release does not support the running OpenCode version. The footer names the required
+range; the current Kagan release remains active until OpenCode is compatible.
+
 **My existing sessions don't appear on the board.**
 By design — the board shows only tasks created through it. Chat sessions stay in OpenCode's
 native session list.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "printWidth": 120
   },
   "dependencies": {
-    "@opencode-ai/plugin": "1.17.13",
+    "@opencode-ai/plugin": "1.17.18",
+    "semver": "7.8.5",
     "zod": "4.1.8"
   },
   "peerDependencies": {
@@ -90,12 +91,13 @@
     "@babel/core": "7.28.0",
     "@babel/preset-typescript": "7.27.1",
     "@makerx/verify": "1.2.0",
-    "@opencode-ai/sdk": "1.17.13",
+    "@opencode-ai/sdk": "1.17.18",
     "@opentui/core": "0.4.3",
     "@opentui/keymap": "0.4.3",
     "@opentui/solid": "0.4.3",
     "@tsconfig/bun": "1.0.10",
     "@types/bun": "1.3.13",
+    "@types/semver": "7.7.1",
     "babel-plugin-module-resolver": "5.0.2",
     "babel-preset-solid": "1.9.12",
     "oxlint": "1.60.0",

--- a/scripts/package-check.ts
+++ b/scripts/package-check.ts
@@ -1,8 +1,16 @@
 import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import { minVersion } from "semver"
 
 const repoRoot = resolve(import.meta.dir, "..")
+const rootPackage = (await Bun.file(join(repoRoot, "package.json")).json()) as {
+  dependencies: Record<string, string>
+  engines: { opencode: string }
+}
+const engineFloor = minVersion(rootPackage.engines.opencode)?.version
+if (!engineFloor) throw new Error(`Invalid OpenCode engine range: ${rootPackage.engines.opencode}`)
+const openCodeVersions = [...new Set([rootPackage.dependencies["@opencode-ai/plugin"], engineFloor])]
 
 type PackedFile = { path: string }
 type PackResult = { filename: string; files: PackedFile[] }
@@ -79,46 +87,51 @@ assertSameFiles(
 const dir = await mkdtemp(join(tmpdir(), "kagan-package-"))
 try {
   const packed = parsePackJson(await run(["npm", "pack", "--json", "--pack-destination", dir]))
-  const consumer = join(dir, "consumer")
-  await mkdir(consumer)
-  await writeFile(
-    join(consumer, "package.json"),
-    JSON.stringify(
-      {
-        type: "module",
-        dependencies: {
-          "@kagan-sh/kagan": `file:${join(dir, packed.filename)}`,
-          "@opentui/core": "0.4.3",
-          "@opentui/keymap": "0.4.3",
-          "@opentui/solid": "0.4.3",
-          "solid-js": "1.9.12",
+  for (const openCodeVersion of openCodeVersions) {
+    const consumer = join(dir, `consumer-${openCodeVersion}`)
+    await mkdir(consumer)
+    await writeFile(
+      join(consumer, "package.json"),
+      JSON.stringify(
+        {
+          type: "module",
+          dependencies: {
+            "@kagan-sh/kagan": `file:${join(dir, packed.filename)}`,
+            "@opentui/core": "0.4.3",
+            "@opentui/keymap": "0.4.3",
+            "@opentui/solid": "0.4.3",
+            "solid-js": "1.9.12",
+          },
+          overrides: {
+            "@opencode-ai/plugin": openCodeVersion,
+            "@opencode-ai/sdk": openCodeVersion,
+          },
         },
-      },
-      null,
-      2,
-    ),
-  )
-  await run(["npm", "install", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"], consumer)
-  const pluginRoot = join(consumer, "node_modules", "@kagan-sh", "kagan")
-  await assertNoBundledHostDeps(pluginRoot)
-  await run(
-    [
-      "bun",
-      "--conditions",
-      "browser",
-      "-e",
-      `import { ensureRuntimePluginSupport } from "@opentui/solid/runtime-plugin-support/configure"
+        null,
+        2,
+      ),
+    )
+    await run(["npm", "install", "--ignore-scripts", "--omit=dev", "--no-audit", "--no-fund"], consumer)
+    const pluginRoot = join(consumer, "node_modules", "@kagan-sh", "kagan")
+    await assertNoBundledHostDeps(pluginRoot)
+    await run(
+      [
+        "bun",
+        "--conditions",
+        "browser",
+        "-e",
+        `import { ensureRuntimePluginSupport } from "@opentui/solid/runtime-plugin-support/configure"
 import { runtimeModules } from "@opentui/keymap/runtime-modules"
 ensureRuntimePluginSupport({ additional: runtimeModules })
 const server = await import("@kagan-sh/kagan/server")
 const tui = await import("@kagan-sh/kagan/tui")
 if (typeof server.default?.server !== "function") throw new Error("server export missing")
 if (typeof tui.default?.tui !== "function") throw new Error("tui export missing")`,
-    ],
-    consumer,
-  )
+      ],
+      consumer,
+    )
+    console.log(`package check passed with OpenCode ${openCodeVersion}`)
+  }
 } finally {
   await rm(dir, { recursive: true, force: true })
 }
-
-console.log("package check passed")

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -1,27 +1,53 @@
 /** @jsxImportSource @opentui/solid */
-import type { TuiPlugin, TuiPluginModule } from "@opencode-ai/plugin/tui"
+import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
 import { createRoot } from "solid-js"
 import { Board } from "./tui/board/board"
 import { Settings } from "./tui/routes/settings"
 import { showOnboarding } from "./tui/dialogs/onboarding"
 import { createBoardStore, createSessionEventSubscription, createSessionStatusSubscription } from "./tui/board/store"
-import { checkForUpdate } from "./tui/updates"
+import { checkForUpdate, type UpdateStatus } from "./tui/updates"
+import { cleanupPreparedUpdate, prepareUpdate } from "./tui/update-manager"
 import { ROUTE, SETTINGS_ROUTE } from "./tui/types"
 import { version } from "../package.json"
 
-const tui: TuiPlugin = async (api, options) => {
+export function showUpdateToast(api: TuiPluginApi, currentVersion: string, status: Exclude<UpdateStatus, undefined>) {
+  if (api.route.current.name !== "home" && api.route.current.name !== "session") return
+  api.ui.toast({
+    variant: status.kind === "ready" ? "success" : "warning",
+    title: "Kagan",
+    message:
+      status.kind === "ready"
+        ? `Kagan v${status.version} is ready. Restart OpenCode to apply.`
+        : `Kagan v${currentVersion} remains active. Kagan v${status.version} requires OpenCode ${status.requiredOpenCode}.`,
+  })
+}
+
+const tui: TuiPlugin = async (api, options, meta) => {
   const store = createRoot(() => createBoardStore(api, options))
   const disposeEvents = createSessionEventSubscription(api, () => store.refresh())
   const disposeStatusEvents = createSessionStatusSubscription(api, store.setSessionStatus)
   api.lifecycle.onDispose(() => disposeEvents())
   api.lifecycle.onDispose(() => disposeStatusEvents())
 
-  checkForUpdate({
-    kv: api.kv,
-    currentVersion: version,
-    now: Date.now(),
-    onUpdate: (latest) => store.setUpdateAvailable(latest),
-  }).catch(() => {})
+  cleanupPreparedUpdate(meta, version)
+    .catch(() => {})
+    .then(() =>
+      checkForUpdate({
+        kv: api.kv,
+        currentVersion: version,
+        openCodeVersion: api.app.version,
+        source: meta.source,
+        spec: meta.spec,
+        now: Date.now(),
+      }),
+    )
+    .then(async (status) => {
+      if (!status || api.lifecycle.signal.aborted) return
+      if (status.kind === "ready" && !(await prepareUpdate({ api, meta, currentVersion: version, status }))) return
+      store.setUpdateStatus(status)
+      showUpdateToast(api, version, status)
+    })
+    .catch(() => {})
 
   api.route.register([
     {

--- a/src/tui/board/board.tsx
+++ b/src/tui/board/board.tsx
@@ -8,6 +8,7 @@ import { BOARD_BINDINGS, createBoardCommands, footerHints, HelpOverlay, type Boa
 import { COLUMNS, type ColumnType } from "../../domain/task/types"
 import { version } from "../../../package.json"
 import { useRendererDimensions } from "../renderer"
+import type { UpdateStatus } from "../updates"
 
 // Light │ so the rule stays subordinate to the heavy ┃ state bars on cards.
 const COLUMN_RULE_CHARS: BorderCharacters = {
@@ -99,6 +100,12 @@ function Main(props: {
   )
 }
 
+function updateFooter(status: Exclude<UpdateStatus, undefined>) {
+  return status.kind === "ready"
+    ? ` · v${status.version} ready — restart OpenCode`
+    : ` · update OpenCode to ${status.requiredOpenCode} for Kagan v${status.version}`
+}
+
 function Footer(props: { api: TuiPluginApi; store: BoardStore; hints: () => { key: string; label: string }[] }) {
   const theme = () => props.api.theme.current
   const filter = () => props.store.filter()
@@ -107,8 +114,12 @@ function Footer(props: { api: TuiPluginApi; store: BoardStore; hints: () => { ke
     <box flexDirection="row" flexShrink={0} paddingLeft={2} paddingRight={2} justifyContent="space-between">
       <text wrapMode="none" truncate={true} fg={theme().textMuted}>
         kagan v{version}
-        <Show when={props.store.updateAvailable()}>
-          {(latest) => <span style={{ fg: theme().info }}>{` → v${latest()} available`}</span>}
+        <Show when={props.store.updateStatus()}>
+          {(status) => (
+            <span style={{ fg: status().kind === "ready" ? theme().info : theme().warning }}>
+              {updateFooter(status())}
+            </span>
+          )}
         </Show>
         <Show when={filter()}>{` · filter: ${filter()}`}</Show>
       </text>

--- a/src/tui/board/store.tsx
+++ b/src/tui/board/store.tsx
@@ -16,6 +16,7 @@ import { deleteSession } from "../tasks/delete"
 import { getFilter, getOrder, setFilter as persistFilter, setOrder } from "../session/preferences"
 import { COLUMNS, type ColumnType } from "../../domain/task/types"
 import { ROUTE, type BoardCard, type BoardSession } from "../types"
+import type { UpdateStatus } from "../updates"
 
 const TASK_NUMBER_QUERY = /^#(\d+)$/
 
@@ -263,7 +264,7 @@ export function createBoardStore(api: TuiPluginApi, options?: Record<string, unk
   const scopes = configuredScopes(options)
   const sendBackThreshold = sendBackStopThreshold(options)
   const [sessions, setSessions] = createSignal<BoardSession[]>([])
-  const [updateAvailable, setUpdateAvailable] = createSignal<string | undefined>()
+  const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>()
   const [selectedID, setSelectedID] = createSignal<string | undefined>()
   const [selectedColumn, setSelectedColumn] = createSignal<ColumnType>("backlog")
   const [filter, setFilterSignal] = createSignal(getFilter(api))
@@ -277,9 +278,8 @@ export function createBoardStore(api: TuiPluginApi, options?: Record<string, unk
   const filteredSessions = createMemo(() => filterSessions(sessions(), filter()))
   const columns = createMemo(() => groupCardsByColumn(filteredSessions(), orders()))
 
-  // Board feedback renders through the Notice overlay, not api.ui.toast: OpenCode mounts its
-  // <Toast/> per route (home, session) and plugin routes never get one, so a toast fired while
-  // the board is active updates state nothing renders.
+  // Task and board-action feedback renders through the Notice overlay: OpenCode mounts <Toast/>
+  // only on home/session routes. Update status is separate persistent footer state.
   const [notices, setNotices] = createSignal<BoardNotice[]>([])
   const noticeTimers = new Map<string, ReturnType<typeof setTimeout>>()
   let noticeSeq = 0
@@ -554,8 +554,8 @@ export function createBoardStore(api: TuiPluginApi, options?: Record<string, unk
     columns,
     notices,
     notify,
-    updateAvailable,
-    setUpdateAvailable,
+    updateStatus,
+    setUpdateStatus,
     select,
     selectNext,
     selectPrevious,

--- a/src/tui/update-manager.ts
+++ b/src/tui/update-manager.ts
@@ -1,0 +1,104 @@
+import type { TuiPluginApi, TuiPluginMeta } from "@opencode-ai/plugin/tui"
+import { join } from "node:path"
+import { isAutomaticUpdateInstall, KAGAN_PACKAGE, parseRelease, type UpdateStatus } from "./updates"
+import {
+  defaultFileSystem,
+  type FileSystem,
+  markerMatches,
+  stat,
+  type UpdateMarker,
+  type UpdatePaths,
+  updatePaths,
+  validateWrapper,
+  validMarkerFile,
+} from "./update-paths"
+
+export async function cleanupPreparedUpdate(
+  meta: TuiPluginMeta,
+  currentVersion: string,
+  fs: FileSystem = defaultFileSystem,
+): Promise<void> {
+  if (!isAutomaticUpdateInstall({ source: meta.source, spec: meta.spec, version: currentVersion })) return
+  const paths = updatePaths(meta.target, currentVersion)
+  const markerInfo = await stat(fs, paths.marker)
+  if (!markerInfo) return
+  if (!validMarkerFile(markerInfo)) throw new Error("Unsafe Kagan update marker")
+
+  const marker = JSON.parse(await fs.readFile(paths.marker, "utf8")) as UpdateMarker
+  if (!markerMatches(marker, paths, currentVersion)) return
+  await validateWrapper(fs, paths.current, meta.target, currentVersion)
+
+  const backupInfo = await stat(fs, paths.backup)
+  if (backupInfo) {
+    await validateWrapper(fs, paths.backup, join(paths.backup, "node_modules", "@kagan-sh", "kagan"))
+    await fs.rm(paths.backup, { recursive: true })
+  }
+  if (!validMarkerFile(await stat(fs, paths.marker))) throw new Error("Unsafe Kagan update marker")
+  await fs.rm(paths.marker)
+}
+
+async function promotePreparedUpdate(
+  paths: UpdatePaths,
+  currentVersion: string,
+  preparedVersion: string,
+  fs: FileSystem = defaultFileSystem,
+): Promise<void> {
+  await validateWrapper(fs, paths.current, join(paths.current, "node_modules", "@kagan-sh", "kagan"), currentVersion)
+  await validateWrapper(fs, paths.prepared, paths.preparedTarget, preparedVersion)
+  if (await stat(fs, paths.backup)) throw new Error("Kagan update backup already exists")
+  await fs.rename(paths.current, paths.backup)
+  try {
+    await fs.rename(paths.prepared, paths.current)
+  } catch (error) {
+    try {
+      await fs.rename(paths.backup, paths.current)
+    } catch (restoreError) {
+      throw new AggregateError([error, restoreError], "Kagan update promotion and restore failed")
+    }
+    throw error
+  }
+}
+
+export async function prepareUpdate(input: {
+  api: TuiPluginApi
+  meta: TuiPluginMeta
+  currentVersion: string
+  status: UpdateStatus
+  fs?: FileSystem
+}): Promise<boolean> {
+  const { api, meta, currentVersion, status } = input
+  if (
+    status?.kind !== "ready" ||
+    !isAutomaticUpdateInstall({ source: meta.source, spec: meta.spec, version: currentVersion }) ||
+    !parseRelease(status.version)
+  ) {
+    return false
+  }
+
+  const installed = await api.plugins.add(`${KAGAN_PACKAGE}@${status.version}`).catch(() => false)
+  if (!installed) return false
+
+  const fs = input.fs ?? defaultFileSystem
+  try {
+    const paths = updatePaths(meta.target, status.version)
+    await validateWrapper(fs, paths.current, meta.target, currentVersion)
+    await validateWrapper(fs, paths.prepared, paths.preparedTarget, status.version)
+    if (await stat(fs, paths.backup)) return false
+    const markerInfo = await stat(fs, paths.marker)
+    if (markerInfo && !validMarkerFile(markerInfo)) return false
+    if (api.lifecycle.signal.aborted) return false
+
+    const marker: UpdateMarker = {
+      version: status.version,
+      current: paths.current,
+      prepared: paths.prepared,
+      backup: paths.backup,
+    }
+    await fs.writeFile(paths.marker, JSON.stringify(marker))
+    if (api.lifecycle.signal.aborted) return false
+    api.lifecycle.onDispose(() => promotePreparedUpdate(paths, currentVersion, status.version, fs))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/tui/update-paths.ts
+++ b/src/tui/update-paths.ts
@@ -1,0 +1,111 @@
+import { lstat, readFile, realpath, rename, rm, writeFile } from "node:fs/promises"
+import { basename, dirname, isAbsolute, join, resolve } from "node:path"
+import { KAGAN_PACKAGE, parseRelease } from "./updates"
+
+export type UpdatePaths = {
+  current: string
+  prepared: string
+  preparedTarget: string
+  backup: string
+  marker: string
+}
+
+export type UpdateMarker = Pick<UpdatePaths, "current" | "prepared" | "backup"> & { version: string }
+
+export type FileSystem = {
+  lstat: typeof lstat
+  readFile: typeof readFile
+  realpath: typeof realpath
+  rename: typeof rename
+  rm: typeof rm
+  writeFile: typeof writeFile
+}
+
+export const defaultFileSystem: FileSystem = { lstat, readFile, realpath, rename, rm, writeFile }
+
+export function updatePaths(target: string, version: string): UpdatePaths {
+  if (!isAbsolute(target) || resolve(target) !== target || !parseRelease(version)) {
+    throw new Error("Invalid Kagan update path")
+  }
+
+  const packageDir = target
+  const packageScope = dirname(packageDir)
+  const nodeModules = dirname(packageScope)
+  const current = dirname(nodeModules)
+  const scopeCache = dirname(current)
+  const packagesCache = dirname(scopeCache)
+  const openCodeCache = dirname(packagesCache)
+  if (
+    basename(packageDir) !== "kagan" ||
+    basename(packageScope) !== "@kagan-sh" ||
+    basename(nodeModules) !== "node_modules" ||
+    basename(current) !== "kagan@latest" ||
+    basename(scopeCache) !== "@kagan-sh" ||
+    basename(packagesCache) !== "packages" ||
+    basename(openCodeCache) !== "opencode" ||
+    packageDir !== join(current, "node_modules", "@kagan-sh", "kagan")
+  ) {
+    throw new Error("Unexpected Kagan cache layout")
+  }
+
+  const prepared = join(scopeCache, `kagan@${version}`)
+  return {
+    current,
+    prepared,
+    preparedTarget: join(prepared, "node_modules", "@kagan-sh", "kagan"),
+    backup: join(scopeCache, "kagan@latest.kagan-backup"),
+    marker: join(scopeCache, "kagan@latest.kagan-update.json"),
+  }
+}
+
+export async function stat(fs: FileSystem, path: string) {
+  return fs.lstat(path).catch(() => undefined)
+}
+
+async function validateDirectory(fs: FileSystem, path: string) {
+  const info = await fs.lstat(path)
+  if (!info.isDirectory() || info.isSymbolicLink()) throw new Error(`Unsafe Kagan cache path: ${path}`)
+}
+
+export function validMarkerFile(info: Awaited<ReturnType<FileSystem["lstat"]>> | undefined) {
+  return info?.isFile() === true && !info.isSymbolicLink() && info.nlink === 1
+}
+
+export async function validateWrapper(fs: FileSystem, wrapper: string, target: string, expectedVersion?: string) {
+  const scopeCache = dirname(wrapper)
+  const packagesCache = dirname(scopeCache)
+  const openCodeCache = dirname(packagesCache)
+  for (const path of [
+    openCodeCache,
+    packagesCache,
+    scopeCache,
+    wrapper,
+    join(wrapper, "node_modules"),
+    join(wrapper, "node_modules", "@kagan-sh"),
+    target,
+  ]) {
+    await validateDirectory(fs, path)
+  }
+
+  const [wrapperReal, targetReal] = await Promise.all([fs.realpath(wrapper), fs.realpath(target)])
+  if (targetReal !== join(wrapperReal, "node_modules", "@kagan-sh", "kagan")) {
+    throw new Error("Kagan cache wrapper escapes its expected directory")
+  }
+
+  const manifestPath = join(target, "package.json")
+  const manifestInfo = await fs.lstat(manifestPath)
+  if (!manifestInfo.isFile() || manifestInfo.isSymbolicLink()) throw new Error("Unsafe Kagan package manifest")
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as { name?: unknown; version?: unknown }
+  if (manifest.name !== KAGAN_PACKAGE || (expectedVersion !== undefined && manifest.version !== expectedVersion)) {
+    throw new Error("Unexpected Kagan package in cache wrapper")
+  }
+}
+
+export function markerMatches(marker: UpdateMarker, paths: UpdatePaths, version: string) {
+  return (
+    marker.version === version &&
+    marker.current === paths.current &&
+    marker.prepared === paths.prepared &&
+    marker.backup === paths.backup
+  )
+}

--- a/src/tui/updates.ts
+++ b/src/tui/updates.ts
@@ -1,39 +1,50 @@
+import { clean, gt, satisfies, valid, validRange } from "semver"
+
 const REGISTRY_DIST_TAGS = "https://registry.npmjs.org/-/package/@kagan-sh/kagan/dist-tags"
-const CHECK_TTL_MS = 24 * 60 * 60 * 1000
+const REGISTRY_MANIFEST = "https://registry.npmjs.org/@kagan-sh%2Fkagan"
+const CHECK_TTL_MS = 60 * 60 * 1000
 const FETCH_TIMEOUT_MS = 3000
 const LAST_CHECK_KEY = "kagan:update:lastCheck"
-const LATEST_KEY = "kagan:update:latest"
+const MANIFEST_KEY = "kagan:update:manifest"
+export const KAGAN_PACKAGE = "@kagan-sh/kagan"
+
+export type UpdateStatus =
+  | { kind: "ready"; version: string }
+  | { kind: "blocked"; version: string; requiredOpenCode: string }
+  | undefined
 
 type UpdateKv = {
   get: <Value = unknown>(key: string, fallback?: Value) => Value
   set: (key: string, value: unknown) => void
 }
 
-function parseRelease(version: string): [number, number, number] | undefined {
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim())
-  if (!match) return undefined
-  return [Number(match[1]), Number(match[2]), Number(match[3])]
+// Automatic updates intentionally exclude development and prerelease builds from both sides.
+export function parseRelease(version: string): string | undefined {
+  const normalized = clean(version.trim())
+  return normalized === version.trim() && /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : undefined
 }
 
-function isNewerRelease(latest: string, current: string): boolean {
+function isAutomaticUpdateSpec(spec: string): boolean {
+  return spec === KAGAN_PACKAGE || spec === `${KAGAN_PACKAGE}@latest`
+}
+
+export function isAutomaticUpdateInstall(input: { source: string; spec: string; version: string }): boolean {
+  return input.source === "npm" && isAutomaticUpdateSpec(input.spec) && parseRelease(input.version) !== undefined
+}
+
+export function isNewerRelease(latest: string, current: string): boolean {
   const next = parseRelease(latest)
   const now = parseRelease(current)
-  if (!next || !now) return false
-  const [nextMajor, nextMinor, nextPatch] = next
-  const [nowMajor, nowMinor, nowPatch] = now
-  if (nextMajor !== nowMajor) return nextMajor > nowMajor
-  if (nextMinor !== nowMinor) return nextMinor > nowMinor
-  return nextPatch > nowPatch
+  return Boolean(next && now && gt(next, now))
 }
 
-async function fetchLatestVersion(fetchImpl: typeof fetch, timeoutMs: number): Promise<string | undefined> {
+async function fetchJson(fetchImpl: typeof fetch, url: string, timeoutMs: number): Promise<unknown> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    const response = await fetchImpl(REGISTRY_DIST_TAGS, { signal: controller.signal })
+    const response = await fetchImpl(url, { signal: controller.signal })
     if (!response.ok) return undefined
-    const data = (await response.json()) as { latest?: unknown }
-    return typeof data.latest === "string" ? data.latest : undefined
+    return await response.json()
   } catch {
     return undefined
   } finally {
@@ -41,35 +52,86 @@ async function fetchLatestVersion(fetchImpl: typeof fetch, timeoutMs: number): P
   }
 }
 
-async function resolveLatestVersion(
-  kv: UpdateKv,
-  now: number,
-  deps: { fetchImpl?: typeof fetch; ttlMs?: number } = {},
-): Promise<string | undefined> {
-  const ttl = deps.ttlMs ?? CHECK_TTL_MS
-  const cached = kv.get<string | undefined>(LATEST_KEY, undefined)
-  const lastCheck = kv.get<number>(LAST_CHECK_KEY, 0)
-  if (lastCheck <= now && now - lastCheck < ttl) return cached
+type LatestManifest = { version: string; requiredOpenCode?: string }
 
-  const latest = await fetchLatestVersion(deps.fetchImpl ?? fetch, FETCH_TIMEOUT_MS)
-  if (latest === undefined) return cached
-  kv.set(LATEST_KEY, latest)
-  kv.set(LAST_CHECK_KEY, now)
-  return latest
+function readCachedManifest(value: unknown): LatestManifest | undefined {
+  if (!value || typeof value !== "object") return
+  const candidate = value as Record<string, unknown>
+  if (typeof candidate.version !== "string" || !parseRelease(candidate.version)) return
+  if (candidate.requiredOpenCode !== undefined && typeof candidate.requiredOpenCode !== "string") return
+  if (typeof candidate.requiredOpenCode === "string" && !validRange(candidate.requiredOpenCode)) return
+  return { version: candidate.version, requiredOpenCode: candidate.requiredOpenCode }
 }
 
-export async function checkForUpdate(input: {
+export async function resolveLatestManifest(
+  kv: UpdateKv,
+  currentVersion: string,
+  now: number,
+  deps: { fetchImpl?: typeof fetch } = {},
+): Promise<LatestManifest | undefined> {
+  const cached = readCachedManifest(kv.get(MANIFEST_KEY))
+  const lastCheck = kv.get<number>(LAST_CHECK_KEY, 0)
+  if (lastCheck <= now && now - lastCheck < CHECK_TTL_MS) return cached
+
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const tags = (await fetchJson(fetchImpl, REGISTRY_DIST_TAGS, FETCH_TIMEOUT_MS)) as { latest?: unknown } | undefined
+  const latest = typeof tags?.latest === "string" ? parseRelease(tags.latest) : undefined
+  if (!latest) return
+
+  let manifest: LatestManifest = { version: latest }
+  if (latest !== currentVersion) {
+    const data = (await fetchJson(fetchImpl, `${REGISTRY_MANIFEST}/${latest}`, FETCH_TIMEOUT_MS)) as
+      | { engines?: { opencode?: unknown } }
+      | undefined
+    const requiredOpenCode = data?.engines?.opencode
+    if (typeof requiredOpenCode !== "string" || !validRange(requiredOpenCode)) return
+    manifest = { version: latest, requiredOpenCode: requiredOpenCode.trim() }
+  }
+
+  kv.set(MANIFEST_KEY, manifest)
+  kv.set(LAST_CHECK_KEY, now)
+  return manifest
+}
+
+type CheckInput = {
   kv: UpdateKv
   currentVersion: string
+  openCodeVersion: string
+  source: "file" | "npm" | "internal"
+  spec: string
   now: number
-  onUpdate: (latest: string) => void
   fetchImpl?: typeof fetch
-  ttlMs?: number
-}): Promise<void> {
-  if (!parseRelease(input.currentVersion)) return
-  const latest = await resolveLatestVersion(input.kv, input.now, {
+}
+
+async function runCheck(input: CheckInput): Promise<UpdateStatus> {
+  if (
+    !isAutomaticUpdateInstall({ source: input.source, spec: input.spec, version: input.currentVersion }) ||
+    !valid(input.openCodeVersion)
+  ) {
+    return
+  }
+
+  const manifest = await resolveLatestManifest(input.kv, input.currentVersion, input.now, {
     fetchImpl: input.fetchImpl,
-    ttlMs: input.ttlMs,
   })
-  if (latest && isNewerRelease(latest, input.currentVersion)) input.onUpdate(latest)
+  if (!manifest || !isNewerRelease(manifest.version, input.currentVersion) || !manifest.requiredOpenCode) return
+  if (satisfies(input.openCodeVersion, manifest.requiredOpenCode)) {
+    return { kind: "ready", version: manifest.version }
+  }
+  return { kind: "blocked", version: manifest.version, requiredOpenCode: manifest.requiredOpenCode }
+}
+
+const pendingChecks = new WeakMap<UpdateKv, Map<string, Promise<UpdateStatus>>>()
+
+export function checkForUpdate(input: CheckInput): Promise<UpdateStatus> {
+  const key = [input.source, input.spec, input.currentVersion, input.openCodeVersion].join("\0")
+  const checks = pendingChecks.get(input.kv) ?? new Map<string, Promise<UpdateStatus>>()
+  pendingChecks.set(input.kv, checks)
+  const existing = checks.get(key)
+  if (existing) return existing
+  const check = runCheck(input).finally(() => {
+    checks.delete(key)
+  })
+  checks.set(key, check)
+  return check
 }

--- a/test/guards/pins.test.ts
+++ b/test/guards/pins.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, test } from "bun:test"
+import { satisfies, valid } from "semver"
 
 describe("dependency pins", () => {
+  test("OpenCode plugin and SDK pins are exact, synchronized, and inside the supported engine range", async () => {
+    const root = await Bun.file(new URL("../../package.json", import.meta.url)).json()
+    const plugin = root.dependencies["@opencode-ai/plugin"]
+    const sdk = root.devDependencies["@opencode-ai/sdk"]
+    expect(valid(plugin)).toBe(plugin)
+    expect(valid(sdk)).toBe(sdk)
+    expect(plugin).toBe(sdk)
+    expect(satisfies(plugin, root.engines.opencode)).toBe(true)
+  })
+
   // .opencode/ is gitignored local config, so the pin can only be enforced where it exists.
   test("the .opencode plugin package matches the root plugin pin", async () => {
     const opencodeFile = Bun.file(new URL("../../.opencode/package.json", import.meta.url))
     if (!(await opencodeFile.exists())) return
     const root = await Bun.file(new URL("../../package.json", import.meta.url)).json()
     const opencode = await opencodeFile.json()
-    expect(opencode.dependencies["@opencode-ai/plugin"]).toBe(root.devDependencies["@opencode-ai/plugin"])
+    expect(opencode.dependencies["@opencode-ai/plugin"]).toBe(root.dependencies["@opencode-ai/plugin"])
   })
 })

--- a/test/tui/board/board.test.tsx
+++ b/test/tui/board/board.test.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "solid-js"
 import type { TuiToast } from "@opencode-ai/plugin/tui"
 import { Board } from "../../../src/tui/board/board"
 import { createBoardStore } from "../../../src/tui/board/store"
+import { showUpdateToast } from "../../../src/tui"
 import { ROUTE, type BoardSession } from "../../../src/tui/types"
 import type { ColumnType } from "../../../src/domain/task/types"
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
@@ -138,17 +139,39 @@ describe("Board", () => {
     expect(frame).not.toContain("d delete")
   })
 
-  test("shows the update indicator in the footer once a newer version is available", async () => {
+  test("shows prepared and blocked update states in the footer", async () => {
     const api = mockBoardApi()
     const store = createRoot(() => createBoardStore(api))
     await store.refresh()
-    renderSetup = await testRender(() => <Board api={api} store={store} />, { width: 120, height: 20 })
+    renderSetup = await testRender(() => <Board api={api} store={store} />, { width: 180, height: 20 })
     await renderSetup.flush()
-    expect(renderSetup.captureCharFrame()).not.toContain("available")
+    expect(renderSetup.captureCharFrame()).not.toContain("restart OpenCode")
 
-    store.setUpdateAvailable("9.9.9")
+    store.setUpdateStatus({ kind: "ready", version: "9.9.9" })
     await renderSetup.flush()
-    expect(renderSetup.captureCharFrame()).toContain("v9.9.9 available")
+    expect(renderSetup.captureCharFrame()).toContain("v9.9.9 ready — restart OpenCode")
+
+    store.setUpdateStatus({ kind: "blocked", version: "10.0.0", requiredOpenCode: ">=2.0.0" })
+    await renderSetup.flush()
+    expect(renderSetup.captureCharFrame()).toContain("update OpenCode to >=2.0.0 for Kagan v10.0.0")
+  })
+
+  test("uses host toasts only off the board", () => {
+    const home = mockBoardApi({ routeName: "home" })
+    showUpdateToast(home, "0.1.0", { kind: "ready", version: "0.2.0" })
+    expect(home.toasts[0]?.message).toBe("Kagan v0.2.0 is ready. Restart OpenCode to apply.")
+
+    const sessionApi = mockBoardApi({ routeName: "session" })
+    showUpdateToast(sessionApi, "0.1.0", {
+      kind: "blocked",
+      version: "0.2.0",
+      requiredOpenCode: ">=1.18.0",
+    })
+    expect(sessionApi.toasts[0]?.message).toContain("requires OpenCode >=1.18.0")
+
+    const board = mockBoardApi()
+    showUpdateToast(board, "0.1.0", { kind: "ready", version: "0.2.0" })
+    expect(board.toasts).toHaveLength(0)
   })
 
   test("keeps the footer trimmed once a card is selected", async () => {

--- a/test/tui/update-manager.test.ts
+++ b/test/tui/update-manager.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { link, lstat, mkdir, mkdtemp, readFile, realpath, rename, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { TuiPluginApi, TuiPluginMeta } from "@opencode-ai/plugin/tui"
+import { cleanupPreparedUpdate, prepareUpdate } from "../../src/tui/update-manager"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "kagan-update-"))
+  roots.push(root)
+  const scope = join(root, "opencode", "packages", "@kagan-sh")
+  const current = join(scope, "kagan@latest")
+  const target = join(current, "node_modules", "@kagan-sh", "kagan")
+  await writePackage(target, "0.1.0")
+  return { root, scope, current, target }
+}
+
+async function writePackage(target: string, version: string) {
+  await mkdir(target, { recursive: true })
+  await writeFile(join(target, "package.json"), JSON.stringify({ name: "@kagan-sh/kagan", version }))
+}
+
+function meta(target: string, overrides: Partial<TuiPluginMeta> = {}): TuiPluginMeta {
+  return {
+    id: "kagan",
+    source: "npm",
+    spec: "@kagan-sh/kagan",
+    target,
+    state: "same",
+    first_time: 0,
+    last_time: 0,
+    time_changed: 0,
+    load_count: 1,
+    fingerprint: "test",
+    ...overrides,
+  }
+}
+
+function api(add: () => Promise<boolean>) {
+  const disposers: Array<() => void | Promise<void>> = []
+  return {
+    value: {
+      plugins: { add },
+      lifecycle: {
+        signal: new AbortController().signal,
+        onDispose: (dispose: () => void | Promise<void>) => {
+          disposers.push(dispose)
+          return () => {}
+        },
+      },
+    } as unknown as TuiPluginApi,
+    disposers,
+  }
+}
+
+const nodeFs = { lstat, readFile, realpath, rename, rm, writeFile }
+
+describe("prepareUpdate", () => {
+  test("rejects a non-release status before calling the host installer", async () => {
+    const layout = await fixture()
+    let called = false
+    const mock = api(async () => {
+      called = true
+      return true
+    })
+    expect(
+      await prepareUpdate({
+        api: mock.value,
+        meta: meta(layout.target),
+        currentVersion: "0.1.0",
+        status: { kind: "ready", version: "latest" },
+      }),
+    ).toBe(false)
+    expect(called).toBe(false)
+  })
+
+  test("failed download or import leaves the current wrapper untouched", async () => {
+    const layout = await fixture()
+    const mock = api(async () => false)
+    expect(
+      await prepareUpdate({
+        api: mock.value,
+        meta: meta(layout.target),
+        currentVersion: "0.1.0",
+        status: { kind: "ready", version: "0.2.0" },
+      }),
+    ).toBe(false)
+    expect(JSON.parse(await readFile(join(layout.target, "package.json"), "utf8")).version).toBe("0.1.0")
+    expect(mock.disposers).toHaveLength(0)
+  })
+
+  test("prepares exact latest without touching current before disposal", async () => {
+    const layout = await fixture()
+    const preparedTarget = join(layout.scope, "kagan@0.2.0", "node_modules", "@kagan-sh", "kagan")
+    const mock = api(async () => {
+      await writePackage(preparedTarget, "0.2.0")
+      return true
+    })
+
+    expect(
+      await prepareUpdate({
+        api: mock.value,
+        meta: meta(layout.target),
+        currentVersion: "0.1.0",
+        status: { kind: "ready", version: "0.2.0" },
+      }),
+    ).toBe(true)
+    expect(JSON.parse(await readFile(join(layout.target, "package.json"), "utf8")).version).toBe("0.1.0")
+    expect(await lstat(join(layout.scope, "kagan@latest.kagan-update.json"))).toBeTruthy()
+    expect(mock.disposers).toHaveLength(1)
+  })
+
+  test("rejects a symlinked cache wrapper", async () => {
+    const layout = await fixture()
+    const realPrepared = join(layout.root, "prepared")
+    await writePackage(join(realPrepared, "node_modules", "@kagan-sh", "kagan"), "0.2.0")
+    await symlink(realPrepared, join(layout.scope, "kagan@0.2.0"))
+    const mock = api(async () => true)
+
+    expect(
+      await prepareUpdate({
+        api: mock.value,
+        meta: meta(layout.target),
+        currentVersion: "0.1.0",
+        status: { kind: "ready", version: "0.2.0" },
+      }),
+    ).toBe(false)
+    expect(mock.disposers).toHaveLength(0)
+  })
+
+  test("rejects a hardlinked marker without modifying its source", async () => {
+    const layout = await fixture()
+    const preparedTarget = join(layout.scope, "kagan@0.2.0", "node_modules", "@kagan-sh", "kagan")
+    const victim = join(layout.root, "victim.json")
+    await writeFile(victim, "do not replace")
+    await link(victim, join(layout.scope, "kagan@latest.kagan-update.json"))
+    const mock = api(async () => {
+      await writePackage(preparedTarget, "0.2.0")
+      return true
+    })
+
+    expect(
+      await prepareUpdate({
+        api: mock.value,
+        meta: meta(layout.target),
+        currentVersion: "0.1.0",
+        status: { kind: "ready", version: "0.2.0" },
+      }),
+    ).toBe(false)
+    expect(await readFile(victim, "utf8")).toBe("do not replace")
+    expect(mock.disposers).toHaveLength(0)
+  })
+
+  test("revalidates wrappers at disposal before touching current", async () => {
+    const layout = await fixture()
+    const prepared = join(layout.scope, "kagan@0.2.0")
+    const preparedTarget = join(prepared, "node_modules", "@kagan-sh", "kagan")
+    const mock = api(async () => {
+      await writePackage(preparedTarget, "0.2.0")
+      return true
+    })
+    await prepareUpdate({
+      api: mock.value,
+      meta: meta(layout.target),
+      currentVersion: "0.1.0",
+      status: { kind: "ready", version: "0.2.0" },
+    })
+
+    await rm(prepared, { recursive: true })
+    const replacement = join(layout.root, "replacement")
+    await writePackage(join(replacement, "node_modules", "@kagan-sh", "kagan"), "0.2.0")
+    await symlink(replacement, prepared)
+
+    await expect(mock.disposers[0]!()).rejects.toThrow("Unsafe Kagan cache path")
+    expect(JSON.parse(await readFile(join(layout.target, "package.json"), "utf8")).version).toBe("0.1.0")
+  })
+
+  test("failed second rename restores the current wrapper", async () => {
+    const layout = await fixture()
+    const preparedTarget = join(layout.scope, "kagan@0.2.0", "node_modules", "@kagan-sh", "kagan")
+    const mock = api(async () => {
+      await writePackage(preparedTarget, "0.2.0")
+      return true
+    })
+    let renames = 0
+    const fs = {
+      ...nodeFs,
+      rename: async (from: Parameters<typeof rename>[0], to: Parameters<typeof rename>[1]) => {
+        renames++
+        if (renames === 2) throw new Error("second rename failed")
+        await rename(from, to)
+      },
+    }
+
+    expect(
+      await prepareUpdate({
+        api: mock.value,
+        meta: meta(layout.target),
+        currentVersion: "0.1.0",
+        status: { kind: "ready", version: "0.2.0" },
+        fs,
+      }),
+    ).toBe(true)
+    await expect(mock.disposers[0]!()).rejects.toThrow("second rename failed")
+    expect(JSON.parse(await readFile(join(layout.target, "package.json"), "utf8")).version).toBe("0.1.0")
+    expect(renames).toBe(3)
+  })
+
+  test("successful next startup removes the marker and backup", async () => {
+    const layout = await fixture()
+    const preparedTarget = join(layout.scope, "kagan@0.2.0", "node_modules", "@kagan-sh", "kagan")
+    const mock = api(async () => {
+      await writePackage(preparedTarget, "0.2.0")
+      return true
+    })
+    await prepareUpdate({
+      api: mock.value,
+      meta: meta(layout.target),
+      currentVersion: "0.1.0",
+      status: { kind: "ready", version: "0.2.0" },
+    })
+    await mock.disposers[0]!()
+    await cleanupPreparedUpdate(meta(layout.target), "0.2.0")
+
+    expect(JSON.parse(await readFile(join(layout.target, "package.json"), "utf8")).version).toBe("0.2.0")
+    expect(await lstat(join(layout.scope, "kagan@latest.kagan-backup")).catch(() => undefined)).toBeUndefined()
+    expect(await lstat(join(layout.scope, "kagan@latest.kagan-update.json")).catch(() => undefined)).toBeUndefined()
+  })
+})
+
+describe("cleanupPreparedUpdate", () => {
+  test("does nothing for exact pins", async () => {
+    const layout = await fixture()
+    const marker = join(layout.scope, "kagan@latest.kagan-update.json")
+    await writeFile(marker, "{}")
+    await cleanupPreparedUpdate(meta(layout.target, { spec: "@kagan-sh/kagan@0.1.0" }), "0.1.0")
+    expect(await lstat(marker)).toBeTruthy()
+  })
+
+  test("keeps a marker whose paths do not match the validated layout", async () => {
+    const layout = await fixture()
+    const marker = join(layout.scope, "kagan@latest.kagan-update.json")
+    await writeFile(marker, JSON.stringify({ version: "0.1.0", current: "/tmp/other", prepared: "", backup: "" }))
+    await cleanupPreparedUpdate(meta(layout.target), "0.1.0")
+    expect(await lstat(marker)).toBeTruthy()
+  })
+
+  test("rejects a hardlinked marker before cleanup", async () => {
+    const layout = await fixture()
+    const victim = join(layout.root, "victim.json")
+    await writeFile(victim, "{}")
+    await link(victim, join(layout.scope, "kagan@latest.kagan-update.json"))
+    await expect(cleanupPreparedUpdate(meta(layout.target), "0.1.0")).rejects.toThrow("Unsafe Kagan update marker")
+    expect(await readFile(victim, "utf8")).toBe("{}")
+  })
+})

--- a/test/tui/updates.test.ts
+++ b/test/tui/updates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { checkForUpdate } from "../../src/tui/updates"
+import { checkForUpdate, isNewerRelease, parseRelease, resolveLatestManifest } from "../../src/tui/updates"
 
 function mockKv(initial: Record<string, unknown> = {}) {
   const store: Record<string, unknown> = { ...initial }
@@ -12,161 +12,199 @@ function mockKv(initial: Record<string, unknown> = {}) {
   }
 }
 
-function fetchReturning(latest: unknown, ok = true): typeof fetch {
-  return (async () => ({
-    ok,
-    json: async () => ({ latest }),
-  })) as unknown as typeof fetch
+function registryFetch(input: {
+  latest?: unknown
+  engine?: unknown
+  failTags?: boolean
+  failManifest?: boolean
+  calls?: string[]
+}): typeof fetch {
+  return (async (url: string | URL | Request) => {
+    const value = String(url)
+    input.calls?.push(value)
+    const manifest = !value.endsWith("/dist-tags")
+    if ((!manifest && input.failTags) || (manifest && input.failManifest)) throw new Error("network down")
+    return {
+      ok: true,
+      json: async () => (manifest ? { engines: { opencode: input.engine } } : { latest: input.latest ?? "0.2.0" }),
+    }
+  }) as unknown as typeof fetch
 }
 
-const fetchThatThrows: typeof fetch = (async () => {
-  throw new Error("network down")
-}) as unknown as typeof fetch
-
 const HOUR = 60 * 60 * 1000
-const DAY = 24 * HOUR
+
+describe("release parsing", () => {
+  test("accepts only clean numeric releases", () => {
+    expect(parseRelease("0.1.3")).toBe("0.1.3")
+    for (const raw of ["0.0.0-development", "0.3.0-beta.1", "1.2", "v1.2.3", "latest", ""]) {
+      expect(parseRelease(raw)).toBeUndefined()
+    }
+  })
+
+  test("compares segments numerically", () => {
+    expect(isNewerRelease("0.1.10", "0.1.3")).toBe(true)
+    expect(isNewerRelease("0.2.0", "0.1.99")).toBe(true)
+    expect(isNewerRelease("1.0.0", "0.9.9")).toBe(true)
+    expect(isNewerRelease("0.1.3", "0.1.3")).toBe(false)
+    expect(isNewerRelease("0.1.2", "0.1.3")).toBe(false)
+    expect(isNewerRelease("latest", "0.1.3")).toBe(false)
+  })
+})
+
+describe("resolveLatestManifest", () => {
+  test("fetches latest and its engine range, then caches for one hour", async () => {
+    const kv = mockKv()
+    const calls: string[] = []
+    const fetchImpl = registryFetch({ latest: "0.2.0", engine: ">=1.17.13 <1.18.0", calls })
+    expect(await resolveLatestManifest(kv, "0.1.0", HOUR + 1, { fetchImpl })).toEqual({
+      version: "0.2.0",
+      requiredOpenCode: ">=1.17.13 <1.18.0",
+    })
+    expect(calls).toHaveLength(2)
+
+    expect(await resolveLatestManifest(kv, "0.1.0", HOUR * 2, { fetchImpl })).toEqual({
+      version: "0.2.0",
+      requiredOpenCode: ">=1.17.13 <1.18.0",
+    })
+    expect(calls).toHaveLength(2)
+  })
+
+  test("does not fetch a manifest when latest equals current", async () => {
+    const calls: string[] = []
+    const result = await resolveLatestManifest(mockKv(), "0.2.0", HOUR + 1, {
+      fetchImpl: registryFetch({ latest: "0.2.0", calls }),
+    })
+    expect(result).toEqual({ version: "0.2.0" })
+    expect(calls).toHaveLength(1)
+  })
+
+  test("refetches when the cached timestamp is in the future", async () => {
+    const kv = mockKv({
+      "kagan:update:manifest": { version: "0.1.0" },
+      "kagan:update:lastCheck": HOUR * 10,
+    })
+    const calls: string[] = []
+    expect(
+      await resolveLatestManifest(kv, "0.1.0", HOUR, {
+        fetchImpl: registryFetch({ latest: "0.2.0", engine: ">=1.17.13", calls }),
+      }),
+    ).toEqual({ version: "0.2.0", requiredOpenCode: ">=1.17.13" })
+    expect(calls).toHaveLength(2)
+    expect(kv.store["kagan:update:lastCheck"]).toBe(HOUR)
+  })
+
+  test("stays quiet and does not refresh the timestamp after registry or manifest failure", async () => {
+    for (const fetchImpl of [
+      registryFetch({ failTags: true }),
+      registryFetch({ latest: "0.2.0", failManifest: true }),
+    ]) {
+      const kv = mockKv({
+        "kagan:update:manifest": { version: "0.1.9", requiredOpenCode: ">=1.0.0" },
+        "kagan:update:lastCheck": 0,
+      })
+      expect(await resolveLatestManifest(kv, "0.1.0", HOUR + 1, { fetchImpl })).toBeUndefined()
+      expect(kv.store["kagan:update:lastCheck"]).toBe(0)
+    }
+  })
+})
 
 describe("checkForUpdate", () => {
-  test("notifies once when a newer release is published", async () => {
-    const kv = mockKv()
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "0.1.3",
-      now: DAY + 1,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: fetchReturning("0.1.10"),
-    })
-    expect(seen).toEqual(["0.1.10"])
+  const base = {
+    currentVersion: "0.1.0",
+    openCodeVersion: "1.17.18",
+    source: "npm" as const,
+    spec: "@kagan-sh/kagan",
+    now: HOUR + 1,
+  }
+
+  test("classifies compatible latest as ready for bare and explicit latest specs", async () => {
+    for (const spec of ["@kagan-sh/kagan", "@kagan-sh/kagan@latest"]) {
+      expect(
+        await checkForUpdate({
+          ...base,
+          spec,
+          kv: mockKv(),
+          fetchImpl: registryFetch({ latest: "0.2.0", engine: ">=1.17.13 <1.18.0" }),
+        }),
+      ).toEqual({ kind: "ready", version: "0.2.0" })
+    }
   })
 
-  test("stays silent when already on the latest release", async () => {
-    const kv = mockKv()
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "0.1.3",
-      now: DAY + 1,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: fetchReturning("0.1.3"),
-    })
-    expect(seen).toEqual([])
+  test("classifies incompatible latest with its required OpenCode range", async () => {
+    expect(
+      await checkForUpdate({
+        ...base,
+        kv: mockKv(),
+        fetchImpl: registryFetch({ latest: "0.2.0", engine: ">=1.18.0" }),
+      }),
+    ).toEqual({ kind: "blocked", version: "0.2.0", requiredOpenCode: ">=1.18.0" })
   })
 
-  test("notifies for a major-version bump", async () => {
-    const kv = mockKv()
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "1.9.9",
-      now: DAY + 1,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: fetchReturning("2.0.0"),
-    })
-    expect(seen).toEqual(["2.0.0"])
+  test("rejects a missing or invalid engine range", async () => {
+    for (const engine of [undefined, "not a range"]) {
+      expect(
+        await checkForUpdate({
+          ...base,
+          kv: mockKv(),
+          fetchImpl: registryFetch({ latest: "0.2.0", engine }),
+        }),
+      ).toBeUndefined()
+    }
   })
 
-  test("notifies for a minor-version bump", async () => {
-    const kv = mockKv()
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "1.1.9",
-      now: DAY + 1,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: fetchReturning("1.2.0"),
-    })
-    expect(seen).toEqual(["1.2.0"])
+  test("does not query npm for exact pins, file installs, or development builds", async () => {
+    for (const input of [
+      { ...base, spec: "@kagan-sh/kagan@0.1.0" },
+      { ...base, source: "file" as const, spec: "file:///tmp/kagan" },
+      { ...base, currentVersion: "0.0.0-development" },
+      { ...base, openCodeVersion: "development" },
+    ]) {
+      const calls: string[] = []
+      expect(await checkForUpdate({ ...input, kv: mockKv(), fetchImpl: registryFetch({ calls }) })).toBeUndefined()
+      expect(calls).toHaveLength(0)
+    }
   })
 
-  test("serves the cached latest without fetching inside the TTL window", async () => {
-    const kv = mockKv({ "kagan:update:latest": "2.0.0", "kagan:update:lastCheck": DAY })
-    let called = false
-    const spyFetch = (async () => {
-      called = true
-      return { ok: true, json: async () => ({ latest: "9.9.9" }) }
+  test("does not share an in-flight npm result with an exact-pin caller", async () => {
+    let releaseTags!: () => void
+    const tagsReady = new Promise<void>((resolve) => {
+      releaseTags = resolve
+    })
+    let calls = 0
+    const fetchImpl = (async () => {
+      calls++
+      if (calls === 1) await tagsReady
+      return {
+        ok: true,
+        json: async () => (calls === 1 ? { latest: "0.2.0" } : { engines: { opencode: ">=1.17.13" } }),
+      }
     }) as unknown as typeof fetch
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "1.0.0",
-      now: DAY + HOUR,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: spyFetch,
-    })
-    expect(called).toBe(false)
-    expect(seen).toEqual(["2.0.0"])
-  })
-
-  test("refetches when the stored lastCheck is in the future (clock moved backward)", async () => {
-    const kv = mockKv({ "kagan:update:latest": "1.0.0", "kagan:update:lastCheck": DAY * 3 })
-    let called = false
-    const spyFetch = (async () => {
-      called = true
-      return { ok: true, json: async () => ({ latest: "2.0.0" }) }
-    }) as unknown as typeof fetch
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "1.0.0",
-      now: DAY,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: spyFetch,
-    })
-    expect(called).toBe(true)
-    expect(seen).toEqual(["2.0.0"])
-    expect(kv.store["kagan:update:lastCheck"]).toBe(DAY)
-    expect(kv.store["kagan:update:latest"]).toBe("2.0.0")
-  })
-
-  test("keeps the cached latest and preserves lastCheck when the fetch fails, so the next call retries", async () => {
-    const kv = mockKv({ "kagan:update:latest": "2.0.0", "kagan:update:lastCheck": 0 })
-    let failingCalls = 0
-    const failing = (async () => {
-      failingCalls++
-      throw new Error("network down")
-    }) as unknown as typeof fetch
-    const seen: string[] = []
-    await checkForUpdate({
-      kv,
-      currentVersion: "1.0.0",
-      now: DAY * 2,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: failing,
-    })
-    expect(failingCalls).toBe(1)
-    expect(seen).toEqual(["2.0.0"])
-    expect(kv.store["kagan:update:lastCheck"]).toBe(0)
-
-    await checkForUpdate({
-      kv,
-      currentVersion: "1.0.0",
-      now: DAY * 2,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: fetchReturning("3.0.0"),
-    })
-    expect(failingCalls).toBe(1)
-    expect(seen).toEqual(["2.0.0", "3.0.0"])
-    expect(kv.store["kagan:update:latest"]).toBe("3.0.0")
-    expect(kv.store["kagan:update:lastCheck"]).toBe(DAY * 2)
-  })
-
-  test("never fetches for a dev/prerelease install", async () => {
     const kv = mockKv()
-    let called = false
-    const spyFetch = (async () => {
-      called = true
-      return { ok: true, json: async () => ({ latest: "9.9.9" }) }
-    }) as unknown as typeof fetch
-    const seen: string[] = []
-    await checkForUpdate({
+    const npmCheck = checkForUpdate({ ...base, kv, fetchImpl })
+    expect(
+      await checkForUpdate({
+        ...base,
+        kv,
+        spec: "@kagan-sh/kagan@0.1.0",
+        fetchImpl,
+      }),
+    ).toBeUndefined()
+    releaseTags()
+    expect(await npmCheck).toEqual({ kind: "ready", version: "0.2.0" })
+  })
+
+  test("deduplicates concurrent checks with the same inputs", async () => {
+    const calls: string[] = []
+    const kv = mockKv()
+    const input = {
+      ...base,
       kv,
-      currentVersion: "0.0.0-development",
-      now: DAY + 1,
-      onUpdate: (latest) => seen.push(latest),
-      fetchImpl: spyFetch,
-    })
-    expect(called).toBe(false)
-    expect(seen).toEqual([])
+      fetchImpl: registryFetch({ latest: "0.2.0", engine: ">=1.17.13", calls }),
+    }
+    expect(await Promise.all([checkForUpdate(input), checkForUpdate(input)])).toEqual([
+      { kind: "ready", version: "0.2.0" },
+      { kind: "ready", version: "0.2.0" },
+    ])
+    expect(calls).toHaveLength(2)
   })
 })


### PR DESCRIPTION
Prepares the latest npm release for the next restart when it is compatible with the running OpenCode, while leaving incompatible, pinned, and local installs untouched.

## What it does
- `src/tui/updates.ts` checks npm `latest` once per hour for bare/`@latest` installs, fetches the candidate's `engines.opencode`, and classifies it as `ready` (compatible) or `blocked` (needs a newer OpenCode).
- `src/tui/update-manager.ts` prepares a compatible exact release via `api.plugins.add`, writes a marker, and promotes it into place only on `api.lifecycle.onDispose` so the next restart loads it. Failed promotion restores the backup.
- `src/tui/update-paths.ts` holds the cache-path resolution and validation: only non-symlinked `@kagan-sh/kagan` wrappers are accepted, and cleanup removes only its own marker and single backup.
- The board footer shows persistent update status; a host toast appears only on home/session routes.

## Notes
- Exact pins, `file:` installs, and development builds are never touched.
- Rebased onto the `verifyx` reorg: source lives under `src/tui/`, and the update code passes the new complexity gate.

## Verification
`bun run verify` passes (all built-in verifyx checks, format, lint, types, 602 tests, package validation).